### PR TITLE
Change LIP licenses from GPL3 to CC0

### DIFF
--- a/proposals/lip-0001.md
+++ b/proposals/lip-0001.md
@@ -18,7 +18,7 @@ Because the LIPs are maintained as text files in a versioned repository, their r
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3][gpl-3].
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal][cc0].
 
 ## LIP Work Flow
 
@@ -86,7 +86,7 @@ Each LIP should have the following parts:
 
 * Abstract—A short (~200 word) description of the technical issue being addressed.
 
-* Copyright—Each LIP must be licensed under the [GNU General Public License, version 3][gpl-3].
+* Copyright—Each LIP must be licensed under the [Creative Commons Zero 1.0 Universal][cc0].
 
 * Specification—The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Lisk platforms. In the special case where the choice of a library is critical (e.g. security), a recommendation about libraries and reasoning should be included.
 
@@ -259,7 +259,7 @@ This document was derived heavily from Bitcoin's [BIP-0001][bip-0001] and [BIP-0
 
 [bip-0001]:         https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki  "BIP-0001"
 [bip-0002]:         https://github.com/bitcoin/bips/blob/master/bip-0002.mediawiki  "BIP-0002"
-[gpl-3]:            http://www.gnu.org/licenses/gpl-3.0.html                        "GNU General Public License, version 3"
+[cc0]:              https://creativecommons.org/publicdomain/zero/1.0/              "Creative Commons Zero 1.0 Universal"
 [lips-email]:       mailto:lips@lisk.io                                             "lips@lisk.io"
 [lips-process-img]: lip-0001/lip-0001-1.png                                         "LIP Process"
 [lips-repo]:        https://github.com/LiskHQ/lips                                  "LIPs git repository"

--- a/proposals/lip-0001.md
+++ b/proposals/lip-0001.md
@@ -16,10 +16,6 @@ We intend LIPs to be the primary mechanisms for proposing new features, for coll
 
 Because the LIPs are maintained as text files in a versioned repository, their revision history is the historical record of the feature proposal.
 
-## Copyright
-
-This LIP is licensed under the [Creative Commons Zero 1.0 Universal][cc0].
-
 ## LIP Work Flow
 
 The LIP process begins with a new idea for Lisk. Each potential LIP must have a champion—someone who writes the LIP using the style and format described below, shepherds the discussions in the appropriate forums, and attempts to build community consensus around the idea. The LIP champion (a.k.a. Author) should first attempt to ascertain whether the idea is LIP-able.
@@ -253,7 +249,20 @@ Will LIP comments be censored or limited to particular participants/"experts"?
 
 ## History
 
-This document was derived heavily from Bitcoin's [BIP-0001][bip-0001] and [BIP-0002][bip-0002]. In many places text was simply copied and modified to fit the purposes of the Lisk project.
+This document was derived heavily from Bitcoin's [BIP-0001][bip-0001] and [BIP-0002][bip-0002]. In many places text was simply copied and modified to fit the purposes of the Lisk project.<sup>[1]</sup>
+
+[1] BIP-0002 is licensed under BSD-2-Clause and OPL. In this respect, the BIP-0002 states the following: “...anyone may modify and redistribute the text provided they comply with the terms of *either* license. In other words, the license list is an "OR choice", not an "AND also" requirement.” Even though we assume that it is not necessary for our LIP-0001 to state, we would like to present the BSD-2-Clause-License used for BIP-0002 in accordance with https://opensource.org/licenses/BSD-2-Clause as followed:  
+
+Copyright, Title: BIP process, revised, Author: Luke Dashjr <luke+bip@dashjr.org>, Comments-URI: https://github.com/bitcoin/bips/wiki/Comments:BIP-0002, Created: 2016-02-03, License: BSD-2-Clause and OPL
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 <!-- Links -->
 

--- a/proposals/lip-0002.md
+++ b/proposals/lip-0002.md
@@ -17,7 +17,7 @@ This LIP proposes to replace the literal 25 transactions per block size limit wi
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0003.md
+++ b/proposals/lip-0003.md
@@ -16,7 +16,7 @@ This LIP addresses two issues affecting delegate list uniformity found within th
 
 ## Copyright
 
-This LIP is licensed under the  [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0004.md
+++ b/proposals/lip-0004.md
@@ -16,7 +16,7 @@ This LIP proposes a new implementation of the P2P layer of Lisk introducing a ro
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0005.md
+++ b/proposals/lip-0005.md
@@ -21,7 +21,7 @@ This LIP proposes a new application architecture for Lisk Core, that is of a fle
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html).
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0006.md
+++ b/proposals/lip-0006.md
@@ -14,6 +14,10 @@ Updated: 2018-11-21
 
 This LIP proposes to improve the processing of transactions by optimizing the verification of transactions, applying transactions in memory, and consolidating database queries. Additionally, it suggests improvements for managing transactions in the transaction pool.
 
+## Copyright
+
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
+
 ## Motivation
 
 In the current implementation, transactions are processed by performing application logic and database queries alternately. Furthermore, for transactions which are yet to be included in the blockchain, the database keeps track of the accounts state that would result if all these transactions were applied. This accounts state is called *unconfirmed state*. The *unconfirmed state* is calculated to ensure that transactions do not conflict with each other and it is calculated in the transaction pool and during block processing.

--- a/proposals/lip-0007.md
+++ b/proposals/lip-0007.md
@@ -20,7 +20,7 @@ The changes to the Lisk blockchain protocol are additionally reflected using a 2
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0008.md
+++ b/proposals/lip-0008.md
@@ -16,7 +16,7 @@ This LIP proposes to remove the hash-then-sign paradigm for block and transactio
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0009.md
+++ b/proposals/lip-0009.md
@@ -17,7 +17,7 @@ This LIP proposes to mitigate transaction replay on different chains by introduc
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 

--- a/proposals/lip-0010.md
+++ b/proposals/lip-0010.md
@@ -16,7 +16,7 @@ This LIP proposes to take the SHA3-256 hash of the block header as the blockID o
 
 ## Copyright
 
-This LIP is licensed under the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl-3.0.html "GNU General Public License, version 3").
+This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## Motivation
 


### PR DESCRIPTION
- Change the license of every existing LIP that has a copyright section from GPL3 to CC0
- Add a copyright section to LIP-0006 with CC0 license
- Change copyright guidelines in LIP-0001

