### PR TITLE
Move 'Discussion-To' links to Lisk Research

### DIFF
--- a/proposals/lip-0002.md
+++ b/proposals/lip-0002.md
@@ -3,7 +3,7 @@ LIP: 0002
 Title: Change to byte based block size limit
 Authors: Iker Alustiza <iker@lightcurve.io>
          Nazar Hussain <nazar@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000006.html
+Discussions-To: https://research.lisk.io/t/change-to-byte-based-block-size-limit/
 Status: Draft
 Type: Standards Track
 Module: Blocks

--- a/proposals/lip-0003.md
+++ b/proposals/lip-0003.md
@@ -2,7 +2,7 @@
 LIP: 0003
 Title: Uniform ordering of delegates list
 Authors: Iker Alustiza <iker@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000005.html
+Discussions-To: https://research.lisk.io/t/uniform-ordering-of-delegates-list/
 Status: Draft
 Type: Standards Track
 Module: Delegates

--- a/proposals/lip-0004.md
+++ b/proposals/lip-0004.md
@@ -2,7 +2,7 @@
 LIP: 0004
 Title: Introduce robust peer selection and banning mechanism
 Author: Jan Hackfeld <jan.hackfeld@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000004.html
+Discussions-To: https://research.lisk.io/t/introduce-robust-peer-selection-and-banning-mechanism/
 Status: Draft
 Type: Standards Track
 Module: Peers

--- a/proposals/lip-0005.md
+++ b/proposals/lip-0005.md
@@ -2,7 +2,7 @@
 LIP: 0005
 Title: Introduce new flexible, resilient and modular architecture for Lisk Core
 Author: Nazar Hussain <nazar@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000003.html
+Discussions-To: https://research.lisk.io/t/introduce-new-flexible-resilient-and-modular-architecture-for-lisk-core/
 Status: Draft
 Type: Informational
 Module: All

--- a/proposals/lip-0006.md
+++ b/proposals/lip-0006.md
@@ -2,7 +2,7 @@
 LIP: 0006
 Title: Improve transaction processing efficiency
 Author: Usman Khan <usman@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000001.html
+Discussions-To: https://research.lisk.io/t/improve-transaction-processing-efficiency/
 Status: Draft
 Type: Informational
 Module: Transactions, Transactions Pool

--- a/proposals/lip-0007.md
+++ b/proposals/lip-0007.md
@@ -2,7 +2,7 @@
 LIP: 0007
 Title: Use a consistent and informative versioning scheme
 Authors: Maciej Baj <maciej@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000000.html
+Discussions-To: https://research.lisk.io/t/use-a-consistent-and-informative-versioning-scheme/
 Status: Draft
 Type: Informational
 Module: -

--- a/proposals/lip-0008.md
+++ b/proposals/lip-0008.md
@@ -2,7 +2,7 @@
 LIP: 0008
 Title: Remove pre-hashing for block and transaction signatures
 Author: Andreas Kendziorra <andreas.kendziorra@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000007.html
+Discussions-To: https://research.lisk.io/t/remove-pre-hashing-for-block-and-transaction-signatures/
 Status: Draft
 Type: Standards Track
 Module: Blocks, Transactions

--- a/proposals/lip-0009.md
+++ b/proposals/lip-0009.md
@@ -3,7 +3,7 @@ LIP: 0009
 Title: Mitigate transaction replay on different chains
 Author: Manu Nelamane Siddalingegowda <manu@lightcurve.io>
         Iker Alustiza <iker@lightcurve.io>
-Discussions-To: https://lists.lisk.io/pipermail/lips_lists.lisk.io/2018-November/000002.html
+Discussions-To: https://research.lisk.io/t/mitigate-transaction-replay-on-different-chains/
 Status: Draft
 Type: Standards Track
 Module: Block, Transactions


### PR DESCRIPTION
Move the 'Discussion-To' link of the every existing LIP to the corresponding thread on Lisk Research.