### PR TITLE
Add clarification to LIP and sample code

### DIFF
--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -104,7 +104,7 @@ The Lisk-BFT protocol is formally defined and analyzed in [8]. It defines that b
 The whole section is organized as follows:
 
 *   The section "Additional Block Header Properties" defines the new properties `heightPrevious` and `heightPrevoted` for the block headers and the section "Validating Additional Block Header Properties" describes how these are validated.
-*   The section "Detecting Conflicting Block Headers" describes the conditions for when block headers are conflicting and the corresponding delegate violated the protocol.
+*   The section "Detecting Contradicting Block Headers" describes the conditions for when block headers are contradicting and the corresponding delegate violated the protocol.
 *   The section "Computing Prevotes and Precommits" describes how the `prevotes` and `precommits` implied by a block header can be computed.
 *   The formal specification of the different cases in the diagram above is given in the section "Applying Blocks According to Fork Choice Rule".
 *   The section "Timing of Block Forging" describes how the timing of block forging needs to be adjusted to be in line with the fork choice rule.
@@ -135,9 +135,9 @@ For a new child block `B`, which is supposed to be added to the current chain co
 
 In a separate LIP, we further propose a Proof-of-Misbehaviour transaction that can contain such an invalid block header as evidence for a violation of the protocol rules. This would allow to punish a delegate for providing incorrect information.
 
-### Detecting Conflicting Block Headers
+### Detecting Contradicting Block Headers
 
-In order to enforce the Lisk-BFT protocol rules, we also need to detect if a set of valid block headers by the same delegate violate the protocol rules. The properties that the valid block headers by one delegate need to satisfy are outlined in [8, Lemma 4.2]. We now present a function that checks these properties. We assume that every block header contains the following properties:
+In order to ensure that the implied `prevotes` and `precommits` satisfy the consensus framework [8, Definition 3.1], we also need to detect if a set of valid block headers by the same delegate are contradicting. The properties that the valid block headers by one delegate need to satisfy are outlined in [8, Lemma 4.2]. We now present a function that checks these properties. We assume that every block header contains the following properties:
 
 *   `height`: the height associated with the block
 *   `heightPrevious`: largest height of any block previously forged, as described above
@@ -149,7 +149,7 @@ The following code checks whether there is a conflict between two block headers,
 a violation of the Lisk-BFT protocol, by using the properties shown in [8, Lemma 4.2]:
 
 ```js
-checkHeadersConflicting(blockHeader1,blockHeader2) {
+checkHeadersContradicting(blockHeader1,blockHeader2) {
    // Order the two block headers such that b1 must be forged first
    let b1=blockHeader1;
    let b2=blockHeader2;
@@ -162,10 +162,10 @@ checkHeadersConflicting(blockHeader1,blockHeader2) {
 
    // The order of cases is essential here
    if(b1.delegatePubKey!=b2.delegatePubKey) {
-      // Blocks by different delegates are never conflicting
+      // Blocks by different delegates are never contradicting
       return false;
    } else if(b1.blockID==b2.blockID) {
-      // No conflict, as block headers are the same
+      // No contradiction, as block headers are the same
       return false;
    } else if (b1.heightPrevoted==b2.heightPrevoted &&  b1.height>=b2.height) {
       // Violation of the fork choice rule as delegate moved to different chain
@@ -179,13 +179,13 @@ checkHeadersConflicting(blockHeader1,blockHeader2) {
       // Violates that delegate chooses branch with largest heightPrevoted
       return true;
    } else {
-      // No conflicts between block headers
+      // No contradiction between block headers
       return false;
    }
 }
 ```
 
-Two conflicting block headers can be used as evidence for a violation of the protocol rules. As mentioned above, this proof can be used in a Proof-of-Misbehaviour transaction (proposed in a separate LIP), which includes this evidence in the blockchain and leads to a punishment of the misbehaving delegate.
+Two contradicting block headers can be used as evidence for a violation of the protocol rules. As mentioned above, this proof can be used in a Proof-of-Misbehaviour transaction (proposed in a separate LIP), which includes this evidence in the blockchain and leads to a punishment of the misbehaving delegate.
 
 ### Computing Prevotes and Precommits
 
@@ -347,6 +347,7 @@ We assume that the delegate forging a block adjusts the reward property in the b
 ### Change of Delegates
 
 We propose to let a change of delegates not take into effect immediately at the end of the round, but with a delay of 2 rounds. More specifically, we assume that at the beginning of a round `r`, we compute the top 101 delegates by delegate weight taking into account all vote transactions up to the end of the previous round. This information is then stored persistently for round `r`. For the set of active delegates of round `r`, we then take this information from round `r-2` to achieve the delay of 2 rounds.
+Note that for a new blockchain, this delay of 2 rounds can be achieved by letting the active delegates of the first three rounds be the delegates defined in the genesis block.
 
 ### Processing Blocks
 
@@ -364,7 +365,7 @@ If any of the validations fail, we discard the block. We further ban the peer se
 **2. Step Perform Lisk-BFT related validations and verifications**
 
 *   Check if the `B.heightPrevoted` value in the block header is correct. This is outlined in the section "Validating Additional Block Header Properties" above.
-*   Check if there is any conflict between the block header and any block by the same delegate in the current chain. For performance reasons, for a block `B` that is supposed to be added to the tip of the chain, we only check the blocks at heights `B.height-303` up to `B.height-1`. This verification step is formally defined in the section "Detecting Conflicting  Block Headers" above.
+*   Check if there is any contradiction between the block header and any block by the same delegate in the current chain. For performance reasons, for a block `B` that is supposed to be added to the tip of the chain, we only check the blocks at heights `B.height-303` up to `B.height-1`. This verification step is formally defined in the section "Detecting Contradicting Block Headers" above.
 *   Check whether the `reward` property of the block has the correct value as described in the section "Incentivizing Lisk-BFT Protocol Participation".
 
 If any of the validations fail, we discard the block. We further ban the peer sending the block as it should not forwarded a block that fails these validations.
@@ -446,6 +447,11 @@ Assume that block `A` is the block at the current tip of the chain of the node a
 (A.heightPrevoted<B.heightPrevoted) || (A.height<B.height && A.heightPrevoted==B.heightPrevoted)
 ```
 
+The process described in the following steps must guarantee that either the node changes to the chain with tip `B` or it restores the current chain with tip `A`, even in the case of node crashes.
+
+It is further essential that a node does not forge any blocks while performing the following steps for switching to a different chain. Otherwise, the node may forge a block contradicting the fork choice rule. This means that forging must be deactivated before starting the following steps.
+After exiting the "Fast Chain Switching Mechanism" (because it is aborted or successfully completed) either block `A` or block `B` is at the tip of the chain and forging can be activated again.
+
 A node proceeds along the following steps:
 
 **1. Step: Query blocks**
@@ -470,6 +476,9 @@ Assume the mechanism described in this section is triggered according to the con
 (A.heightPrevoted<B.heightPrevoted) ||
 (A.height<B.height && A.heightPrevoted==B.heightPrevoted)
 ```
+
+It is again essential that a node does not forge any blocks while performing the following steps for switching to a different chain. Otherwise, the node may forge a block contradicting the fork choice rule. This means that forging must be deactivated before starting the following steps.
+After exiting the "Block Synchronization Mechanism" (because it is aborted or successfully completed) the block at the tip of the chain satisfies the condition above and forging can be activated again.
 
 A node proceeds along the following steps:
 

--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -137,7 +137,7 @@ In a separate LIP, we further propose a Proof-of-Misbehaviour transaction that c
 
 ### Detecting Contradicting Block Headers
 
-In order to ensure that the implied `prevotes` and `precommits` satisfy the consensus framework [8, Definition 3.1], we also need to detect if a set of valid block headers by the same delegate are contradicting. The properties that the valid block headers by one delegate need to satisfy are outlined in [8, Lemma 4.2]. We now present a function that checks these properties. We assume that every block header contains the following properties:
+In order to ensure that the implied `prevotes` and `precommits` satisfy the consensus framework [8, Definition 3.1] and the respective delegate follows the fork choice rule, we also need to detect if a set of valid block headers by the same delegate are contradicting. The properties that the valid block headers by one delegate need to satisfy are outlined in [8, Lemma 4.2]. We now present a function that checks these properties. We assume that every block header contains the following properties:
 
 *   `height`: the height associated with the block
 *   `heightPrevious`: largest height of any block previously forged, as described above
@@ -145,7 +145,7 @@ In order to ensure that the implied `prevotes` and `precommits` satisfy the cons
 *   `blockID`: the hash of the block header
 *   `delegatePubKey`: public key of delegate forging the block
 
-The following code checks whether there is a conflict between two block headers, i.e.,
+The following code checks whether there is a contradiction between two block headers, i.e.,
 a violation of the Lisk-BFT protocol, by using the properties shown in [8, Lemma 4.2]:
 
 ```js
@@ -366,6 +366,8 @@ If any of the validations fail, we discard the block. We further ban the peer se
 
 *   Check if the `B.heightPrevoted` value in the block header is correct. This is outlined in the section "Validating Additional Block Header Properties" above.
 *   Check if there is any contradiction between the block header and any block by the same delegate in the current chain. For performance reasons, for a block `B` that is supposed to be added to the tip of the chain, we only check the blocks at heights `B.height-303` up to `B.height-1`. This verification step is formally defined in the section "Detecting Contradicting Block Headers" above.
+Note that if there is no block by the same delegate at heights `B.height-303` up to `B.height-1`, there is no contradiction.
+Otherwise, it is sufficient to only check whether `B` and the last block by the same delegate are contradicting (see Lemma 4.3. in [8]).
 *   Check whether the `reward` property of the block has the correct value as described in the section "Incentivizing Lisk-BFT Protocol Participation".
 
 If any of the validations fail, we discard the block. We further ban the peer sending the block as it should not forwarded a block that fails these validations.

--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/introduce-bft-consensus-protocol
 Status: Draft
 Type: Standards Track
 Created: 2019-03-28
-Updated: 2019-05-10
+Updated: 2019-06-14
 Requires: 0004
 ```
 

--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -366,7 +366,7 @@ If any of the validations fail, we discard the block. We further ban the peer se
 
 *   Check if the `B.heightPrevoted` value in the block header is correct. This is outlined in the section "Validating Additional Block Header Properties" above.
 *   Check if there is any contradiction between the block header and any block by the same delegate in the current chain. For performance reasons, for a block `B` that is supposed to be added to the tip of the chain, we only check the blocks at heights `B.height-303` up to `B.height-1`. This verification step is formally defined in the section "Detecting Contradicting Block Headers" above.
-Note that if there is no block by the same delegate at heights `B.height-303` up to `B.height-1`, there is no contradiction.
+Note that if there is no block by the same delegate at heights `B.height-303` up to `B.height-1`, there is no contradiction with any block at these heights.
 Otherwise, it is sufficient to only check whether `B` and the last block by the same delegate are contradicting (see Lemma 4.3. in [8]).
 *   Check whether the `reward` property of the block has the correct value as described in the section "Incentivizing Lisk-BFT Protocol Participation".
 

--- a/proposals/lip-0014/LiskBFT.js
+++ b/proposals/lip-0014/LiskBFT.js
@@ -178,6 +178,8 @@ class LiskBFT {
 
   /**
    * Check whether blockheader b is contradicting any block at height [maxHeightStored-heightOffset, maxHeightStored].
+	 * Note that only the last block by the same delegate has to be checked to ensure this property and therefore the
+	 * for-loop is exited after the first block by the same delegate.
    * If maxHeightStored-heightOffset<minHeightStored, only the blocks at heights [minHeightStored,maxHeightStored] are checked.
    *
    * @param  b  instance of BlockHeader

--- a/proposals/lip-0014/LiskBFT.js
+++ b/proposals/lip-0014/LiskBFT.js
@@ -6,7 +6,7 @@ const BlockHeader = require("./BlockHeader.js");
  * - Update the Prevote and Precommit counts for these blocks according to the Lisk-BFT consensus
  * - Update up to which height all blocks are finalized
  * - Update the current value of heightPrevoted in order to check this value for new blocks
- * - Check if a blockheader is conflicting with one of the last blockheaders
+ * - Check if a blockheader is contradicting one of the last blockheaders
  */
 class LiskBFT {
   constructor() {
@@ -177,14 +177,14 @@ class LiskBFT {
   }
 
   /**
-   * Check whether blockheader b is conflicting with any block at height [maxHeightStored-heightOffset, maxHeightStored].
+   * Check whether blockheader b is contradicting any block at height [maxHeightStored-heightOffset, maxHeightStored].
    * If maxHeightStored-heightOffset<minHeightStored, only the blocks at heights [minHeightStored,maxHeightStored] are checked.
    *
    * @param  b  instance of BlockHeader
    * @param  heightOffset (optional) gives the height up to which to check the headers, default value HEIGHT_OFFSET_PREVOTES_PRECOMMITS
-   * @return true if and only if b is conflicting with any header at the specified heights
+   * @return true if and only if b is contradicting any header at the specified heights
    */
-  checkHeaderConflictingChain(
+  checkHeaderContradictingChain(
     b,
     heightOffset = this.HEIGHT_OFFSET_PREVOTES_PRECOMMITS
   ) {
@@ -193,24 +193,26 @@ class LiskBFT {
       this.maxHeightStored - heightOffset
     );
     const maxHeightCheck = this.maxHeightStored;
-    for (let i = minHeightCheck; i <= maxHeightCheck; i++) {
+    for (let i = maxHeightCheck; i >= minHeightCheck; i--) {
       if (this.blockheaders.get(i).delegatePubKey == b.delegatePubKey) {
-        if (this.checkHeadersConflicting(this.blockheaders.get(i), b)) {
+        if (this.checkHeadersContradicting(this.blockheaders.get(i), b)) {
           return true;
-        }
+        } else {
+					return false;
+				}
       }
     }
     return false;
   }
 
   /**
-   * Check whether blockheader1 and blockheader2 are conflicting according to the Lisk-BFT consensus rules.
+   * Check whether blockheader1 and blockheader2 are contradicting according to the Lisk-BFT consensus rules.
    *
    * @param  blockheader1  instance of BlockHeader
    * @param  blockheader2  instance of BlockHeader
-   * @return true if and only if blockheader1 and blockheader2 are conflicting
+   * @return true if and only if blockheader1 and blockheader2 are contradicting
    */
-  checkHeadersConflicting(blockheader1, blockheader2) {
+  checkHeadersContradicting(blockheader1, blockheader2) {
     // Order the two blockheaders such that b1 must be forged first
     let b1 = blockheader1;
     let b2 = blockheader2;
@@ -227,10 +229,10 @@ class LiskBFT {
     }
     // Order of cases is essential here
     if (b1.delegatePubKey != b2.delegatePubKey) {
-      // Blocks by different delegates are never conflicting
+      // Blocks by different delegates are never contradicting
       return false;
     } else if (b1.blockID == b2.blockID) {
-      // No conflict, as blockheaders are the same
+      // No contradiction, as blockheaders are the same
       return false;
     } else if (
       b1.heightPrevoted == b2.heightPrevoted &&
@@ -247,7 +249,7 @@ class LiskBFT {
       // Violates that delegate chooses branch with largest heightPrevoted
       return true;
     } else {
-      // No conflicts between blockheaders
+      // No contradiction between blockheaders
       return false;
     }
   }
@@ -330,12 +332,12 @@ class LiskBFT {
         // Only if we have this.HEIGHT_OFFSET_PREVOTES_PRECOMMITS headers stored, we can guarantee that heightPrevoted is computed correctly
         throw new Error("Error: Wrong heightPrevoted in blockheader.");
       } else if (
-        this.checkHeaderConflictingChain(
+        this.checkHeaderContradictingChain(
           newBlockheader,
           this.HEIGHT_OFFSET_PREVOTES_PRECOMMITS
         )
       ) {
-        throw new Error("Error: Conflicting heightPrevious in blockheader.");
+        throw new Error("Error: Contradicting heightPrevious in blockheader.");
       }
       this.maxHeightStored += 1;
 

--- a/proposals/lip-0014/Test.js
+++ b/proposals/lip-0014/Test.js
@@ -5,7 +5,7 @@ const LiskBFT = require('./LiskBFT.js')
 
 function runAllTests() {
   const t1 = test1_basic();
-  const t2 = test2_headersConflicting();
+  const t2 = test2_headersContradicting();
   const t3 = test3_exampleEos();
   const t4 = test4_addBlockheader();
   const t5 = test5_removeBlockheader();
@@ -150,7 +150,7 @@ function test1_basic() {
   return test1Passed;
 }
 
-function test2_headersConflicting() {
+function test2_headersContradicting() {
   let test2Passed = true;
   let b1 = new BlockHeader(1, 1, 0, 3, 0, 1);
   let b2 = new BlockHeader(1, 1, 0, 3, 0, 1);
@@ -158,8 +158,8 @@ function test2_headersConflicting() {
   b1.blockID = 42;
   b2.blockID = 42;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.1 failed: same blockheaders so are not confliciting");
     test2Passed = false;
@@ -169,11 +169,11 @@ function test2_headersConflicting() {
   b2.delegatePubKey = 2;
   b2.blockID = 2;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log(
-      "Test 2.2 failed: blocks by different delegats are never conflicting"
+      "Test 2.2 failed: blocks by different delegats are never contradicting"
     );
     test2Passed = false;
   }
@@ -188,11 +188,11 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 0;
   b2.heightPrevious = 0;
   if (
-    !bft.checkHeadersConflicting(b1, b2) ||
-    !bft.checkHeadersConflicting(b2, b1)
+    !bft.checkHeadersContradicting(b1, b2) ||
+    !bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log(
-      "Test 2.3 failed: two different blocks by the same delegate at the same height and heightPrevoted are conflicting"
+      "Test 2.3 failed: two different blocks by the same delegate at the same height and heightPrevoted are contradicting"
     );
     test2Passed = false;
   }
@@ -207,11 +207,11 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 0;
   b2.heightPrevious = 0;
   if (
-    !bft.checkHeadersConflicting(b1, b2) ||
-    !bft.checkHeadersConflicting(b2, b1)
+    !bft.checkHeadersContradicting(b1, b2) ||
+    !bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log(
-      "Test 2.4 failed: blocks are conflicting due to wrong heightPrevious"
+      "Test 2.4 failed: blocks are contradicting due to wrong heightPrevious"
     );
     test2Passed = false;
   }
@@ -226,11 +226,11 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 1;
   b2.heightPrevious = 5;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log(
-      "Test 2.5 failed: blocks not conflicting as heightPrevoted increased"
+      "Test 2.5 failed: blocks not contradicting as heightPrevoted increased"
     );
     test2Passed = false;
   }
@@ -245,8 +245,8 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 0;
   b2.heightPrevious = 50;
   if (
-    !bft.checkHeadersConflicting(b1, b2) ||
-    !bft.checkHeadersConflicting(b2, b1)
+    !bft.checkHeadersContradicting(b1, b2) ||
+    !bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.6 failed: block contains wrong heightPrevious");
     test2Passed = false;
@@ -262,8 +262,8 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 33;
   b2.heightPrevious = 75;
   if (
-    !bft.checkHeadersConflicting(b1, b2) ||
-    !bft.checkHeadersConflicting(b2, b1)
+    !bft.checkHeadersContradicting(b1, b2) ||
+    !bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.7 failed: blocks show violation of fork choice rule");
     test2Passed = false;
@@ -279,8 +279,8 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 34;
   b2.heightPrevious = 75;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.8 failed: no conflict between blockheaders");
     test2Passed = false;
@@ -296,8 +296,8 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 34;
   b2.heightPrevious = 75;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.9: no conflict between blockheaders");
     test2Passed = false;
@@ -313,8 +313,8 @@ function test2_headersConflicting() {
   b2.heightPrevoted = 34;
   b2.heightPrevious = 80;
   if (
-    bft.checkHeadersConflicting(b1, b2) ||
-    bft.checkHeadersConflicting(b2, b1)
+    bft.checkHeadersContradicting(b1, b2) ||
+    bft.checkHeadersContradicting(b2, b1)
   ) {
     console.log("Test 2.10: no conflict between blockheaders");
     test2Passed = false;


### PR DESCRIPTION
- Clarify the definition of the active set of delegates in the first 2 rounds.
- Add clarification that forging nodes must not forge while changing to a different chain.
- Change of terminology from "conflicting blockheaders" to "contradicting blockheaders" to avoid confusion with the term "conflicting blocks".
