### PR TITLE
Fix specification for signatures in LIP 0012

### DIFF
--- a/proposals/lip-0012.md
+++ b/proposals/lip-0012.md
@@ -130,7 +130,7 @@ Transactions need to fulfill the following schema rules to be valid:
 
 A received transaction needs to be rejected if it violates any of the rules above, with the following exception:
 
-* Transactions of type 4 and transactions from multisignature accounts may or may not have the `signatures` property. If they have this property, the value needs to be an array of valid signatures with at most one signature per public key of the keys group. The array may have any length and may also be empty.
+* Transactions of type 4 and transactions from multisignature accounts may or may not have the `signatures` property.
 
 ### Signing Process
 

--- a/proposals/lip-0012.md
+++ b/proposals/lip-0012.md
@@ -120,13 +120,17 @@ For all other transaction types (not of type 0), the requirements for the `asset
 
 ### Transaction schema validation
 
-Received transaction JSON objects have to be rejected if they do not fulfill the following rules:
+Transactions need to fulfill the following schema rules to be valid:
 
 * The properties `asset`, `senderPublicKey`, `signature`, `timestamp`, `type` are required for every transaction.
 * The `signatures` property is required for transactions originating from multisignature accounts.
 * The `signSignature` property is required for transactions originating from a second passphrase account.
 * For balance transfer transactions, the asset property must have the `amount` and the `recipientId` property. The `data` property is optional.
 * For all other transaction types (not of type 0), the requirements for the `asset` property stay as in the current protocol.
+
+A received transaction needs to be rejected if it violates any of the rules above, with the following exception:
+
+* Transactions of type 4 and transactions from multisignature accounts may or may not have the `signatures` property. If they have this property, the value needs to be an array of valid signatures with at most one signature per public key of the keys group. The array may have any length and may also be empty.
 
 ### Signing Process
 


### PR DESCRIPTION
The specification for the `signatures` property is changed to be inline with the current implementation:

A received transaction of type 4 or a transaction from a multisignature account should not be rejected because the `signatures` property is missing. This is because the signatures may be collected after receiving the transaction.