### PR TITLE
Amend LIP-0007 to be less strict about the error codes

### DIFF
--- a/proposals/lip-0007.md
+++ b/proposals/lip-0007.md
@@ -27,7 +27,7 @@ The versioning scheme currently in place (semver) reliably communicates Lisk sof
 
 - Changes to the public API endpoints, requests and responses
 - Changes to the configuration schema and format
-- Changes to the logging system, levels and events
+- Changes to the logging system
 
 However, by using this versioning scheme alone, there is no logical capacity provided for communicating changes to the Lisk blockchain protocol except insofar as they result in changes to the implementation. That is, there is no separation of concerns between protocol changes and implementation changes in the current versioning scheme. Examples of protocol-level changes include:
 
@@ -86,28 +86,7 @@ For example, changes to:
 
 Are communicated according to Semver rules.
 
-Changes to the Lisk Core logging system and its levels are communicated as breaking (**MAJOR**) only when affecting logs on levels `warning`, `error` or `fatal`. How a particular change to the logs affect the release notation should be clarified by the examples below:
-
-- Any change to the logs error level is considered as **MAJOR**
-
-```js
-- logger.error(`Blockchain failed at height: ${err.block.height}`);
-+ logger.error(`Blockchain failed on round: ${err.round}`);
-```
-
-- Any change to the logs debug level is considered as **MINOR**
-
-```js
-- logger.debug('Processing block', block.id);
-+ logger.debug('Processing block of id', block.id);
-```
-
-- Any logs patching change is considered as **PATCH**
-
-```js
-- logger.error(`Blockchain failed at height: ${err.nonExistantKey.height}`);
-+ logger.error(`Blockchain failed at height: ${err.block.height}`);
-```
+Changes to the Lisk Core logging system and its levels are communicated as breaking (**MAJOR**) only when affecting the overall logs structure or format for all of the levels (`fatal`, `error`, `warn`, `info`, `debug`, `trace`) at the same time.
 
 ### Implementation
 

--- a/proposals/lip-0007.md
+++ b/proposals/lip-0007.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/use-a-consistent-and-informative-vers
 Status: Active
 Type: Informational
 Created: 2018-09-14
-Updated: 2019-05-10
+Updated: 2019-11-04
 ```
 
 ## Abstract


### PR DESCRIPTION
### Expected behavior
The rules of communicating logging breaking changes should be less strict and break the compatibility only if the overall log structure changes for all of the levels.

### Actual behavior
Changes to the Lisk Core logging system and its levels are communicated as breaking (MAJOR) only when affecting logs on levels warning, error or fatal. 