### PR TITLE
Update Multisignature LIP

### DIFF
--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -190,12 +190,12 @@ The asset property of a Multisignature Registration Transaction has to be serial
 ```
 serialize_asset_for_multisignature_registration(asset):
    let byteBuffer be an empty byte buffer
-   let lm be the length of the array asset.mandatoryKeys
-   append lm as an 8-bit unsigned integer to byteBuffer
+   let numMandatoryKeys be the length of the array asset.mandatoryKeys
+   append numMandatoryKeys as an 8-bit unsigned integer to byteBuffer
    for each key in asset.mandatoryKeys:
        append the big endian encoding of key to byteBuffer
-   let lo be the length of the array asset.optionalKeys
-   append lo as an 8-bit unsigned integer to byteBuffer
+   let numOptionalKeys be the length of the array asset.optionalKeys
+   append numOptionalKeys as an 8-bit unsigned integer to byteBuffer
    for each key in asset.optionalKeys:
        append the big endian encoding of key to byteBuffer
    append asset.numberOfSignatures as an 8-bit unsigned integer to byteBuffer
@@ -226,17 +226,17 @@ serialize_signatures(signatures):
 Existing multisignature accounts are converted in order to meet the specifications of multisignature accounts [proposed above](#multisignature-account-registration):
 
 *   The `lifetime` property is removed and ignored.
-*   The set of optional keys equals the set of keys previously listed in the `keysgroup` property.
+*   The set of optional keys equals the set of keys previously listed in the `keysgroup` property ordered lexicographically.
 *   If the account is NOT registered as a second signature account:
     *   The set of mandatory keys contains exactly one public key, namely the one that registered the multisignature account.
     *   The value of the `numberOfSignatures` property equals the value of the `min` property. The `min` property is removed and ignored.
 *   If the account is registered as a second signature account:
-    *   The set of mandatory keys contains two public keys: the one that registered the multisignature account and the second registered public key.
+    *   The set of mandatory keys contains two public keys: the one that registered the multisignature account and the second registered public key. This set is ordered lexicographically.
     *   The value of the `numberOfSignatures` property equals the value of the `min` property plus 1. The `min` property is removed and ignored.
 
 Second signature accounts that have not been converted by the above procedure are converted into multisignature accounts as follow:
 
-*   The set of mandatory keys contains two public keys: the one that registered the second signature account and the second registered public key.
+*   The set of mandatory keys contains two public keys: the one that registered the second signature account and the second registered public key. This set is ordered lexicographically.
 *   The set of optional keys is empty.
 *   The value of the `numberOfSignatures` property is set to 2.
 

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -81,11 +81,13 @@ A small upper bound on the number keys for a multisignature account is useful in
 3. The number of computational steps to verify a transaction is proportional to the number of signatures.
 
 In other words, if the fee for a transaction is proportional to the required computational and storage resources then there is no harm in allowing a high number of signatures. In practice, we cannot achieve exact proportionality, but linear dependencies which we consider to be sufficient.
+
 Point 1 is achieved by a dynamic fee system in which the fee depends linearly on the size of a transaction, e.g., the one [currently proposed](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md) for Lisk. Point 2 is already fulfilled in the current protocol.
+
 To achieve point 3 as well, we propose to take into account the order of the arrays of public keys used in the multisignature registration. The `signatures` property of transactions originating from multisignature accounts must be an array with elements being either signatures, or empty byte buffers.
 For position `i` in `signatures`, the signature at position `i` must be valid with respect to the public key at position `i` in the array of public keys, i.e. the array of mandatory keys concatenated with the optional keys. There must be a signature for every mandatory key and the total number of signatures must equal `numberOfSignatures`. This allows the verification of all signatures by iterating only once through the list of signatures.
-Note that users should not be required to create the `signatures` array themselves. This should be done by the tools used to create the transactions (either the wallet or
-[the tools used for collecting](#facilitate-the-collection-of-signatures) the signatures).
+
+Note that users should not be required to create the `signatures` array themselves. This should be done by the tools used to create the transactions (either the wallet or [the tools used for collecting](#facilitate-the-collection-of-signatures) the signatures).
 
 There are, however, still some limitations that disallow arbitrarily large numbers of keys. The block size limit proposed in [LIP 0002](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0002.md) is 15 kB. Hence, no transaction can be larger than 15 kB if LIP 0002 gets implemented. To keep a generous buffer for potential protocol changes in the future that introduce transactions with a very large payload, we propose a rather conservative limit of at most 64 keys per account. 64 signatures require 4.1 kB of size which leaves more than 10 kB for the maximum payload size of a transaction. Note that this upper limit can easily be increased in the future by simply changing a constant.
 
@@ -175,7 +177,6 @@ validity_from_multisignature_accounts(transaction):
 ```
 
 Therefore, for transactions outgoing from multisignature accounts, `signatures` must be of length `length(mandatoryKeys) + length(optionalKeys)`.
-
 
 ### Transaction Broadcasting
 

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -80,10 +80,10 @@ A small upper bound on the number keys for a multisignature account is useful in
 2. The storage required to store a transaction on a node is proportional to the number of signatures.
 3. The number of computational steps to verify a transaction is proportional to the number of signatures.
 
-In other words, if the fee for a transaction is proportional to the required computational and storage resources then there is no harm in allowing a high number of signatures. In practice, we cannot achieve exact proportionality, but linear dependencies which we consider to be sufficient. 
-Point 1 is achieved by a dynamic fee system in which the fee depends linearly on the size of a transaction, e.g., the one [currently proposed](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md) for Lisk. Point 2 is already fulfilled in the current protocol. 
-To achieve point 3 as well, we propose to take into account the order of the arrays of public keys used in the multisignature registration. The `signatures` property of transactions originating from multisignature accounts must be an array with elements being either signatures, or empty byte buffers. 
-For position `i` in `signatures`, the signature at position `i` must be valid with respect to the public key at position `i` in the array of public keys, i.e. the array of mandatory keys concatenated with the optional keys. There must be a signature for every mandatory key and the total number of signatures must equal `numberOfSignatures`. This allows the verification of all signatures by iterating only once through the list of signatures. 
+In other words, if the fee for a transaction is proportional to the required computational and storage resources then there is no harm in allowing a high number of signatures. In practice, we cannot achieve exact proportionality, but linear dependencies which we consider to be sufficient.
+Point 1 is achieved by a dynamic fee system in which the fee depends linearly on the size of a transaction, e.g., the one [currently proposed](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md) for Lisk. Point 2 is already fulfilled in the current protocol.
+To achieve point 3 as well, we propose to take into account the order of the arrays of public keys used in the multisignature registration. The `signatures` property of transactions originating from multisignature accounts must be an array with elements being either signatures, or empty byte buffers.
+For position `i` in `signatures`, the signature at position `i` must be valid with respect to the public key at position `i` in the array of public keys, i.e. the array of mandatory keys concatenated with the optional keys. There must be a signature for every mandatory key and the total number of signatures must equal `numberOfSignatures`. This allows the verification of all signatures by iterating only once through the list of signatures.
 Note that users should not be required to create the `signatures` array themselves. This should be done by the tools used to create the transactions (either the wallet or
 [the tools used for collecting](#facilitate-the-collection-of-signatures) the signatures).
 
@@ -107,11 +107,11 @@ In the current protocol, it is allowed to do a second public key registration an
 
 Note that those conversions do not change the access rules of accounts.
 
-## Specification 
+## Specification
 
 ### Multisignature Account Registration
 
-An account is converted into a multisignature account via a Multisignature Registration Transaction. This transaction has to be sent from the account that is supposed to be converted. An account can only be converted into a multisignature account once and Multisignature Registration Transactions from multisignature accounts are invalid. 
+An account is converted into a multisignature account via a Multisignature Registration Transaction. This transaction has to be sent from the account that is supposed to be converted. An account can only be converted into a multisignature account once and Multisignature Registration Transactions from multisignature accounts are invalid.
 
 Besides all mandatory properties of a transaction (`type`, `senderPublicKey`, etc.), the registration transaction needs the following:
 
@@ -148,7 +148,7 @@ For other transactions, `signatures` contains exactly one element.
 
 ##### Transaction from Multisignature Accounts
 
-Transactions outgoing from multisignature accounts are validly signed if the following logic returns true, 
+Transactions outgoing from multisignature accounts are validly signed if the following logic returns true,
 ```
 validity_from_multisignature_accounts(transaction):
    let signatures be transaction.signatures
@@ -217,7 +217,7 @@ serialize_signatures(signatures):
       if element is a signature
          append 0x01 to byteBuffer
          append element to byteBuffer
-   
+
    return byteBuffer
 ```
 

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -22,8 +22,8 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 The current multisignature system in Lisk has several shortcomings:
 
 1. It is possible to spam the network and the transaction pool of the nodes by sending transactions from multisignature accounts without all required signatures. Both sending the transactions and sending the signatures is free as long as the transaction does not receive the required amount of signatures. This is possible in the current protocol because:
-    - the transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures, and
-    - the signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
+    - The transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures.
+    - The signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
 
     The queue for transactions from multisignature accounts in a transaction pool could also be easily flooded without any malicious acting, because pending transactions from multisignature accounts can be very large and they can pend for up to 72 hours. Whenever the limit of the queue is reached due to too many pending transactions, all newly arriving transactions from multisignature accounts get rejected.
 

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -5,7 +5,7 @@ Author: Andreas Kendziorra <andreas.kendziorra@lightcurve.io>
 Discussions-To: https://research.lisk.io/t/make-multisignature-accounts-more-flexible-prevent-spamming-and-make-signature-sets-immutable/186
 Type: Standards Track
 Created: 2019-08-09
-Updated: 2019-09-09
+Updated: 2020-01-22
 Requires: 0015
 ```
 

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -22,16 +22,16 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 The current multisignature system in Lisk has several shortcomings:
 
 1. It is possible to spam the network and the transaction pool of the nodes by sending transactions from multisignature accounts without all required signatures. Both sending the transactions and sending the signatures is free as long as the transaction does not receive the required amount of signatures. This is possible in the current protocol because:
-   - the transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures, and
-   - the signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
+    - the transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures, and
+    - the signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
 
-   The queue for transactions from multisignature accounts in a transaction pool could also be easily flooded without any malicious acting, because pending transactions from multisignature accounts can be very large and they can pend for up to 72 hours. Whenever the limit of the queue is reached due to too many pending transactions, all newly arriving transactions from multisignature accounts get rejected.
+    The queue for transactions from multisignature accounts in a transaction pool could also be easily flooded without any malicious acting, because pending transactions from multisignature accounts can be very large and they can pend for up to 72 hours. Whenever the limit of the queue is reached due to too many pending transactions, all newly arriving transactions from multisignature accounts get rejected.
 
 2. There is little flexibility for the account rules. More precisely:
-   - A signature by the key pair that registered the multisignature account is always mandatory for a transaction.
-   - A signature by a specific key pair from the keys group cannot be made mandatory (unless it is mandatory for every key in the keys group).
+    - A signature by the key pair that registered the multisignature account is always mandatory for a transaction.
+    - A signature by a specific key pair from the keys group cannot be made mandatory (unless it is mandatory for every key in the keys group).
 
-   This prevents, for example, creating an account shared among several users in which everyone has equal rights. Also, it is not possible for a single user to create an account that requires signatures for two out of three (or more) public keys. This would increase the security of an account but permits to lose one key without losing access to the account.
+    This prevents, for example, creating an account shared among several users in which everyone has equal rights. Also, it is not possible for a single user to create an account that requires signatures for two out of three (or more) public keys. This would increase the security of an account but permits to lose one key without losing access to the account.
 
 3. Users that register a multisignature account need a second key pair/passphrase if they want to have a personal account as well. In other words, the account creators cannot use a single key pair for their personal account and for the multisignature accounts they create.
 4. The number of keys participating in the account is upper bounded by 16.
@@ -45,8 +45,8 @@ An easy solution to prevent spamming in the network and in the transaction pools
 
 Besides removing the risk of spamming, this approach has the following advantages:
 
-*   A transaction pool can treat a transaction from a multisignature account like any other transaction. Thus, there is no extra queue required anymore.
-*   Multisignature accounts do not require the `lifetime` property anymore. This simplifies the registration process of multisignature accounts and allows an unlimited time span between transaction creation and signing.
+* A transaction pool can treat a transaction from a multisignature account like any other transaction. Thus, there is no extra queue required anymore.
+* Multisignature accounts do not require the `lifetime` property anymore. This simplifies the registration process of multisignature accounts and allows an unlimited time span between transaction creation and signing.
 
 #### Facilitate the Collection of Signatures
 
@@ -119,9 +119,9 @@ Besides all mandatory properties of a transaction (`type`, `senderPublicKey`, et
 2. The `asset` property needs to contain the property `optionalKeys`. The value of this property is an array of pairwise distinct public keys. This array must be ordered lexicographically. Once the account is registered as a multisignature account, every outgoing transaction requires some signatures for some public keys in `optionalKeys` (the number of needed signatures depends on the `numberOfSignatures` property and may also be zero). The array may be empty.
 3. The sets of mandatory and optional keys, specified by `mandatoryKeys` and `optionalKeys,` must be disjoint; their union must have at least one element and at most 64 elements.
 4. The `asset` property needs to contain the `numberOfSignatures` property.
-   - The value must be an integer between 1 and the total number of public keys of the account (sum of optional and mandatory keys).
-   - The value must not be smaller than the length of the value of `mandatoryKeys`.
-   - The value specifies how many signatures are needed for every outgoing transaction from the registered multisignature account, where signatures for mandatory and optional keys are counted.
+    - The value must be an integer between 1 and the total number of public keys of the account (sum of optional and mandatory keys).
+    - The value must not be smaller than the length of the value of `mandatoryKeys`.
+    - The value specifies how many signatures are needed for every outgoing transaction from the registered multisignature account, where signatures for mandatory and optional keys are counted.
 5. The `signatures` property of the transaction object is appended with signatures corresponding to the public keys contained in `mandatoryKeys` and `optionalKeys`. All public keys must have a corresponding signature. The signatures corresponding to `mandatoryKeys` are appended first, followed by those corresponding to `optionalKeys`, where the order of signatures is the same as the order of public keys in the respective array.
 
 The properties `lifetime` and `keysgroup` are not required anymore.
@@ -151,27 +151,27 @@ For other transactions, `signatures` contains exactly one element.
 Transactions outgoing from multisignature accounts are validly signed if the following logic returns true,
 ```
 validity_from_multisignature_accounts(transaction):
-   let signatures be transaction.signatures
-   let message be the serialized transaction without signatures
-   let mandatoryKeys and optionalKeys be the arrays of public keys defined when registering the multisignature account
-   let numMandatoryKeys = length(mandatoryKeys)
-   let numOptionalKeys = length(optionalKeys)
+    let signatures be transaction.signatures
+    let message be the serialized transaction without signatures
+    let mandatoryKeys and optionalKeys be the arrays of public keys defined when registering the multisignature account
+    let numMandatoryKeys = length(mandatoryKeys)
+    let numOptionalKeys = length(optionalKeys)
 
-   for k from 0 to numMandatoryKeys-1
-       if signatures[k] is NOT a valid signature with respect to message and mandatoryKeys[k]
-           return false
+    for k from 0 to numMandatoryKeys-1
+        if signatures[k] is NOT a valid signature with respect to message and mandatoryKeys[k]
+            return false
 
-   validOptionalSig = 0
-   for k from 0 to numOptionalKeys-1
-       if signatures[numMandatoryKeys + k] is a valid signature with respect to message and optionalKeys[k]
-           validOptionalSig += 1
-       else if signatures[numMandatoryKeys + k].byteLength != 0
-           return false
+    validOptionalSig = 0
+    for k from 0 to numOptionalKeys-1
+        if signatures[numMandatoryKeys + k] is a valid signature with respect to message and optionalKeys[k]
+            validOptionalSig += 1
+        else if signatures[numMandatoryKeys + k].byteLength != 0
+            return false
 
-   if numMandatorKeys + validOptionalSig == numberOfSignatures
-       return true
-   else
-       return false
+    if numMandatorKeys + validOptionalSig == numberOfSignatures
+        return true
+    else
+        return false
 ```
 
 Therefore, for transactions outgoing from multisignature accounts, `signatures` must be of length `length(mandatoryKeys) + length(optionalKeys)`.
@@ -189,17 +189,17 @@ The asset property of a Multisignature Registration Transaction has to be serial
 
 ```
 serialize_asset_for_multisignature_registration(asset):
-   let byteBuffer be an empty byte buffer
-   let numMandatoryKeys be the length of the array asset.mandatoryKeys
-   append numMandatoryKeys as an 8-bit unsigned integer to byteBuffer
-   for each key in asset.mandatoryKeys:
-       append the big endian encoding of key to byteBuffer
-   let numOptionalKeys be the length of the array asset.optionalKeys
-   append numOptionalKeys as an 8-bit unsigned integer to byteBuffer
-   for each key in asset.optionalKeys:
-       append the big endian encoding of key to byteBuffer
-   append asset.numberOfSignatures as an 8-bit unsigned integer to byteBuffer
-   return byteBuffer
+    let byteBuffer be an empty byte buffer
+    let numMandatoryKeys be the length of the array asset.mandatoryKeys
+    append numMandatoryKeys as an 8-bit unsigned integer to byteBuffer
+    for each key in asset.mandatoryKeys:
+        append the big endian encoding of key to byteBuffer
+    let numOptionalKeys be the length of the array asset.optionalKeys
+    append numOptionalKeys as an 8-bit unsigned integer to byteBuffer
+    for each key in asset.optionalKeys:
+        append the big endian encoding of key to byteBuffer
+    append asset.numberOfSignatures as an 8-bit unsigned integer to byteBuffer
+    return byteBuffer
 ```
 
 Note that both `for each` loops in `serialize_asset_for_multisignature_registration` have to process the array elements in the order given in the JSON arrays.
@@ -210,35 +210,34 @@ The `signatures` property of a transaction has to be serialized as by the functi
 
 ```
 serialize_signatures(signatures):
-   let byteBuffer be an empty byte buffer
-   for each element in signatures
-      if element is an empty byte buffer
-         append 0x00 to byteBuffer
-      if element is a signature
-         append 0x01 to byteBuffer
-         append element to byteBuffer
-
-   return byteBuffer
+    let byteBuffer be an empty byte buffer
+    for each element in signatures
+        if element is an empty byte buffer
+            append 0x00 to byteBuffer
+        if element is a signature
+            append 0x01 to byteBuffer
+            append element to byteBuffer
+    return byteBuffer
 ```
 
 ### Converting Existing Accounts
 
 Existing multisignature accounts are converted in order to meet the specifications of multisignature accounts [proposed above](#multisignature-account-registration):
 
-*   The `lifetime` property is removed and ignored.
-*   The set of optional keys equals the set of keys previously listed in the `keysgroup` property ordered lexicographically.
-*   If the account is NOT registered as a second signature account:
-    *   The set of mandatory keys contains exactly one public key, namely the one that registered the multisignature account.
-    *   The value of the `numberOfSignatures` property equals the value of the `min` property. The `min` property is removed and ignored.
-*   If the account is registered as a second signature account:
-    *   The set of mandatory keys contains two public keys: the one that registered the multisignature account and the second registered public key. This set is ordered lexicographically.
-    *   The value of the `numberOfSignatures` property equals the value of the `min` property plus 1. The `min` property is removed and ignored.
+* The `lifetime` property is removed and ignored.
+* The set of optional keys equals the set of keys previously listed in the `keysgroup` property ordered lexicographically.
+* If the account is NOT registered as a second signature account:
+    * The set of mandatory keys contains exactly one public key, namely the one that registered the multisignature account.
+    * The value of the `numberOfSignatures` property equals the value of the `min` property. The `min` property is removed and ignored.
+* If the account is registered as a second signature account:
+    * The set of mandatory keys contains two public keys: the one that registered the multisignature account and the second registered public key. This set is ordered lexicographically.
+    * The value of the `numberOfSignatures` property equals the value of the `min` property plus 1. The `min` property is removed and ignored.
 
 Second signature accounts that have not been converted by the above procedure are converted into multisignature accounts as follow:
 
-*   The set of mandatory keys contains two public keys: the one that registered the second signature account and the second registered public key. This set is ordered lexicographically.
-*   The set of optional keys is empty.
-*   The value of the `numberOfSignatures` property is set to 2.
+* The set of mandatory keys contains two public keys: the one that registered the second signature account and the second registered public key. This set is ordered lexicographically.
+* The set of optional keys is empty.
+* The value of the `numberOfSignatures` property is set to 2.
 
 ### Delegate Accounts
 
@@ -252,8 +251,8 @@ The Second Signature Registration Transaction is disabled. No account is conside
 
 This proposal results in a hard fork because:
 
-*   Every outgoing transaction from a multisignature account according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
-*   Multisignature Registration Transactions according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
-*   The second signature registration transaction is disabled and will be rejected by nodes following the proposed protocol.
-*   Accounts that are second signature accounts in the current protocol will be converted to multisignature accounts in the proposed protocol. This introduces another incompatibility for transactions from such accounts.
+* Every outgoing transaction from a multisignature account according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
+* Multisignature Registration Transactions according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
+* The second signature registration transaction is disabled and will be rejected by nodes following the proposed protocol.
+* Accounts that are second signature accounts in the current protocol will be converted to multisignature accounts in the proposed protocol. This introduces another incompatibility for transactions from such accounts.
 * The `signature` and `signSignature` properties of transactions are removed. All transactions now have their signatures in the `signatures` property.

--- a/proposals/lip-0017.md
+++ b/proposals/lip-0017.md
@@ -11,7 +11,7 @@ Requires: 0015
 
 ## Abstract
 
-This LIP proposes some improvements for the multisignature system in Lisk. The first improvement is that only valid transactions from multisignature accounts, i.e. transactions with all required signatures, are accepted and allowed to be forwarded by nodes. This will prevent spamming of the network and the transaction pool. Next, the settings for the account rules become more flexible. This allows, for example, to create accounts that require signatures for _m_ arbitrary public keys from a set of _n_ public keys without making the signature for any public key mandatory. Moreover, the upper bound on the number of participating keys is increased to 64 and the set of signatures of a transaction included in a block becomes immutable. The rules for the existing multisignature accounts do not change with this proposal.
+This LIP proposes some improvements for the multisignature system in Lisk. The first improvement is that only valid transactions from multisignature accounts, i.e. transactions with all required signatures, are accepted and allowed to be forwarded by nodes. This will prevent spamming of the network and the transaction pool. Next, the settings for the account rules become more flexible. This allows, for example, to create accounts that require signatures for _m_ arbitrary public keys from a set of _n_ public keys without making the signature for any public key mandatory. Moreover, the upper bound on the number of participating keys is increased to 64 and the set of signatures of a transaction included in a block becomes immutable. Lastly, we remove the concept of second signature and convert all accounts with second signatures to multisignature accounts. The rules for existing multisignature accounts do not change with this proposal.
 
 ## Copyright
 
@@ -22,16 +22,16 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 The current multisignature system in Lisk has several shortcomings:
 
 1. It is possible to spam the network and the transaction pool of the nodes by sending transactions from multisignature accounts without all required signatures. Both sending the transactions and sending the signatures is free as long as the transaction does not receive the required amount of signatures. This is possible in the current protocol because:
-    - the transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures, and
-    - the signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
+   - the transactions from multisignature accounts are broadcast by nodes even if they do not contain the required signatures, and
+   - the signatures for a transaction from a multisignature account are collected by the nodes after the transaction was send to the network.
 
-    The queue for transactions from multisignature accounts in a transaction pool could also be easily flooded without any malicious acting, because pending transactions from multisignature accounts can be very large and they can pend for up to 72 hours. Whenever the limit of the queue is reached due to too many pending transactions, all newly arriving transactions from multisignature accounts get rejected.
+   The queue for transactions from multisignature accounts in a transaction pool could also be easily flooded without any malicious acting, because pending transactions from multisignature accounts can be very large and they can pend for up to 72 hours. Whenever the limit of the queue is reached due to too many pending transactions, all newly arriving transactions from multisignature accounts get rejected.
 
 2. There is little flexibility for the account rules. More precisely:
-    - A signature by the key pair that registered the multisignature account is always mandatory for a transaction.
-    - A signature by a specific key pair from the keys group cannot be made mandatory (unless it is mandatory for every key in the keys group).
+   - A signature by the key pair that registered the multisignature account is always mandatory for a transaction.
+   - A signature by a specific key pair from the keys group cannot be made mandatory (unless it is mandatory for every key in the keys group).
 
-    This prevents, for example, creating an account shared among several users in which everyone has equal rights. Also, it is not possible for a single user to create an account that requires signatures for two out of three (or more) public keys. This would increase the security of an account, similar to a second passphrase account, but permits to lose one key without losing access to the account.
+   This prevents, for example, creating an account shared among several users in which everyone has equal rights. Also, it is not possible for a single user to create an account that requires signatures for two out of three (or more) public keys. This would increase the security of an account but permits to lose one key without losing access to the account.
 
 3. Users that register a multisignature account need a second key pair/passphrase if they want to have a personal account as well. In other words, the account creators cannot use a single key pair for their personal account and for the multisignature accounts they create.
 4. The number of keys participating in the account is upper bounded by 16.
@@ -54,7 +54,7 @@ When signatures have to be collected from several users before sending a transac
 
 ### Increase Flexibility of Account Rules
 
-When increasing the flexibility for the account rules, it has to be ensured that the rules for the existing multisignature accounts do not change. Therefore, we propose that each multisignature account has a set of mandatory keys, a set of optional keys and a `numberOfSignatures` property which defines how many signatures a transaction from this account requires (the reason to not call it `min` property as in the current protocol is explained [below](#making-the-signatures-set-immutable)). For a transaction to be valid, one signature for each mandatory key and _k_ signatures for _k_ distinct optional keys are required, where _k_ equals the `numberOfSignatures` value of the account minus the number of mandatory keys. An account should be allowed to have only optional or only mandatory keys. For example, an _m_-out-of-_n_ multisignature account has _n_ optional keys, no mandatory keys and the `numberOfSignatures` value equals _m_. Existing multisignature accounts get converted to a multisignature account with exactly one mandatory key (the key that registered the account), some optional keys (all keys specified in `keysgroup`) and the `numberOfSignatures` value equals the `min` value. If an existing multisignature account is additionally registered as a second signature account, then it gets converted into a multisignature account with two mandatory keys (see [below](#existing-combinations) for more details).
+When increasing the flexibility for the account rules, it has to be ensured that the rules for the existing multisignature accounts do not change. Therefore, we propose that each multisignature account has a set of mandatory keys, a set of optional keys and a `numberOfSignatures` property which defines how many signatures a transaction from this account requires (the reason to not call it `min` property as in the current protocol is explained [below](#making-the-signatures-set-immutable)). For a transaction to be valid, one signature for each mandatory key and _k_ signatures for _k_ distinct optional keys are required, where _k_ equals the `numberOfSignatures` value of the account minus the number of mandatory keys. An account should be allowed to have only optional or only mandatory keys. For example, an _m_-out-of-_n_ multisignature account has _n_ optional keys, no mandatory keys and the `numberOfSignatures` value equals _m_. Existing multisignature accounts get converted to a multisignature account with exactly one mandatory key (the key that registered the account), some optional keys (all keys specified in `keysgroup`) and the `numberOfSignatures` value equals the `min` value. If an existing multisignature account is additionally registered as a second signature account, then it gets converted into a multisignature according to the rules [below](#accounts-with-second-passphrase).
 
 #### Adding Sender Address to Transaction Objects
 
@@ -80,7 +80,11 @@ A small upper bound on the number keys for a multisignature account is useful in
 2. The storage required to store a transaction on a node is proportional to the number of signatures.
 3. The number of computational steps to verify a transaction is proportional to the number of signatures.
 
-In other words, if the fee for a transaction is proportional to the required computational and storage resources then there is no harm in allowing a high number of signatures. In practice, we cannot achieve exact proportionality, but linear dependencies which we consider to be sufficient. Point 1 is achieved by a dynamic fee system in which the fee depends linearly on the size of a transaction, e.g., the one [currently proposed](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md) for Lisk. Point 2 is already fulfilled in the current protocol. To achieve point 3 as well, we propose to define an order on the set of public keys of a multisignature account such that each public key has a distinct index. Then, a transaction originating from a multisignature account does not contain a list of signatures, but a list of pairs where each pair contains a signature and the index of the corresponding public key (see [below](#indexes-of-public-keys) for details). This allows the verification of all signatures by iterating only once through the list of pairs. Note that users should not be required to manage the indexes by themselves. This should be done by the tools used to create the transactions (either the wallet or
+In other words, if the fee for a transaction is proportional to the required computational and storage resources then there is no harm in allowing a high number of signatures. In practice, we cannot achieve exact proportionality, but linear dependencies which we consider to be sufficient. 
+Point 1 is achieved by a dynamic fee system in which the fee depends linearly on the size of a transaction, e.g., the one [currently proposed](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md) for Lisk. Point 2 is already fulfilled in the current protocol. 
+To achieve point 3 as well, we propose to take into account the order of the arrays of public keys used in the multisignature registration. The `signatures` property of transactions originating from multisignature accounts must be an array with elements being either signatures, or empty byte buffers. 
+For position `i` in `signatures`, the signature at position `i` must be valid with respect to the public key at position `i` in the array of public keys, i.e. the array of mandatory keys concatenated with the optional keys. There must be a signature for every mandatory key and the total number of signatures must equal `numberOfSignatures`. This allows the verification of all signatures by iterating only once through the list of signatures. 
+Note that users should not be required to create the `signatures` array themselves. This should be done by the tools used to create the transactions (either the wallet or
 [the tools used for collecting](#facilitate-the-collection-of-signatures) the signatures).
 
 There are, however, still some limitations that disallow arbitrarily large numbers of keys. The block size limit proposed in [LIP 0002](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0002.md) is 15 kB. Hence, no transaction can be larger than 15 kB if LIP 0002 gets implemented. To keep a generous buffer for potential protocol changes in the future that introduce transactions with a very large payload, we propose a rather conservative limit of at most 64 keys per account. 64 signatures require 4.1 kB of size which leaves more than 10 kB for the maximum payload size of a transaction. Note that this upper limit can easily be increased in the future by simply changing a constant.
@@ -89,105 +93,133 @@ There are, however, still some limitations that disallow arbitrarily large numbe
 
 The byte array of a transaction used for computing the transactionID and used in the payload hash of a block is not containing the value of the `signatures` property in the current protocol. This makes the set of signatures for a transaction from a multisignature account mutable. To avoid any mutable data contained in transactions, we propose to add the signatures to the byte array.
 
-This has, however, the consequence that a transaction from a multisignature account can have several transactionsIDs. For example, if there is a transaction, `tx`, from a 2-out-of-3 multisignature account with 3 signatures, then 4 different transactionIDs are possible (3 transactionIDs for picking 2 out of 3 signatures and one for taking all signatures). To avoid that this can be exploited, we require that [LIP 0015](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0015.md) is implemented. LIP 0015 replaces the uniqueness requirement of transactionIDs by a uniqueness requirement for _nonces_. If LIP 0015 is not implemented, then it will be possible to replay a transaction. For example, the transaction `tx` could be replayed 3 times with the given signature set (in fact, a cosigner can replay `tx` almost arbitrarily often since signatures are not unique for a given key pair and message).
+This has, however, the consequence that a transaction from a multisignature account can have several transactionsIDs. For example, if there is a transaction, `tx`, from a 2-out-of-3 multisignature account with 3 signatures, then 4 different transactionIDs are possible (3 transactionIDs for picking 2 out of 3 signatures and one for taking all signatures). To avoid that this can be exploited, we require that [LIP 0015](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0015.md) is implemented. LIP 0015 adds a uniqueness requirement for _nonces_. If LIP 0015 is not implemented, then it will be possible to replay a transaction. For example, the transaction `tx` could be replayed 3 times with the given signature set (in fact, a cosigner can replay `tx` almost arbitrarily often since signatures are not unique for a given key pair and message).
 
 Moreover, transactionIDs are used to identify unconfirmed transactions (transaction that are not included in the blockchain) within the peer-to-peer network. Therefore, it is desirable to use a single transactionID for the same transaction. To mitigate the risk that the same transaction is broadcast with different sets of signatures in the network, and therefore different transactionIDs, we propose to reject a transaction that has more signatures than required. Otherwise, it could happen that some nodes modify the transaction object by reducing the signature set to a minimum and distributing the same transaction with a new transactionID in the network. Especially active delegates could be tempted to do so, since they have an incentive to reduce the number of signatures once a dynamic fee system is enabled (currently planned and proposed in [LIP 0013](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0013.md)). For this reason, we use the name `numberOfSignatures` instead of `min` in the proposed protocol.
 
-### Combinations with 2nd Passphrase Registrations
+### Accounts with Second Passphrase
 
-In the current protocol, it is allowed to do a second public key registration (transaction type 1) and a multisignature registration for the same account, and there are some accounts for which both registrations were done. With the proposed changes, it will not be required anymore to do both registrations separately to achieve these specific account rules. Therefore, and for the sake of simplicity, we propose to not allow:
+An account that has registered a second passphrase has the same access rules as a multisignature account with two mandatory keys and `numberOfSignatures`=2, i.e. two signatures are required to validate transactions from this account. Keeping a distinction between second signature accounts and multisignature accounts with two signatures only brings confusion without bringing additional security. Future maintenance of the Lisk code base is also made easier by removing the concept of second signature. For those reasons, the second signature registration transaction is disabled and all second signature accounts are converted to multisignature accounts with the same two keys.
 
-*   to perform a second public key registration for a multisignature account, and
-*   to perform multisignature registration for accounts with a registered 2nd public key.
+The Lisk UI interface currently makes it very easy to register a second passphrase for your account. This feature can be kept, but the application needs to send a multisignature registration instead of a second signature registration. This multisignature registration must contain two mandatory keys: the original public key of the account and the public key derived from the newly created passphrase.
 
-#### Existing Combinations
+In the current protocol, it is allowed to do a second public key registration and a multisignature registration for the same account, and there are some accounts for which both registrations were done. We propose to convert existing accounts for which both registrations were done into a multisignature account with two mandatory keys (the original public key of the account and the second registered public key) and all keys from the keygroup as optional keys. Moreover, the `numberOfSignatures` value equals `min`+1.
 
-The _second signature_ of a second signature account is the signature of a transaction object that includes the _first signature_. However, with this proposal, there exists no _first signature_ anymore for multisignature accounts. To avoid some extra logic for second signature accounts, we propose to convert existing accounts for which both registrations were done into a multisignature account with two mandatory keys (the original public key of the account and the second registered public key) and all keys from the keygroup as optional keys. Moreover, the `numberOfSignatures` value equals `min`+1. Such an account will not be considered anymore as a second signature account. Note that this conversion does not change the access rules of the account.
+Note that those conversions do not change the access rules of accounts.
 
-## Specification
+## Specification 
 
 ### Multisignature Account Registration
 
-A multisignature account is created by converting an existing account into a multisignature account. This is done via a transaction of type 4 (multisignature registration transaction). This transaction has to be sent from the account that is supposed to be converted. Besides all mandatory properties of a transaction (`type`, `senderPublicKey`, etc.), the registration transaction needs the following:
+An account is converted into a multisignature account via a Multisignature Registration Transaction. This transaction has to be sent from the account that is supposed to be converted. An account can only be converted into a multisignature account once and Multisignature Registration Transactions from multisignature accounts are invalid. 
 
-1. The `asset` property needs to contain the property `mandatoryKeys`. The value of this property is an array of pairwise distinct public keys. Once the account is registered as a multisignature account, every outgoing transaction requires for every public key in `mandatoryKeys` a signature. The array may be empty.
-2. The `asset` property needs to contain the property `optionalKeys`. The value of this property is an array of pairwise distinct public keys. Once the account is registered as a multisignature account, every outgoing transaction requires some signatures for some public keys in `optionalKeys` (the number of needed signatures depends on the `numberOfSignatures` property and may also be zero). The array may be empty.
-3. The sets of mandatory and optional keys, specified by `mandatoryKeys` and `optionalKeys,` must be disjoint and their union must have at least two elements. The total number of public keys is upper bounded by 64.
+Besides all mandatory properties of a transaction (`type`, `senderPublicKey`, etc.), the registration transaction needs the following:
+
+1. The `asset` property needs to contain the property `mandatoryKeys`. The value of this property is an array of pairwise distinct public keys. This array must be ordered lexicographically. Once the account is registered as a multisignature account, every outgoing transaction requires for every public key in `mandatoryKeys` a signature. The array may be empty.
+2. The `asset` property needs to contain the property `optionalKeys`. The value of this property is an array of pairwise distinct public keys. This array must be ordered lexicographically. Once the account is registered as a multisignature account, every outgoing transaction requires some signatures for some public keys in `optionalKeys` (the number of needed signatures depends on the `numberOfSignatures` property and may also be zero). The array may be empty.
+3. The sets of mandatory and optional keys, specified by `mandatoryKeys` and `optionalKeys,` must be disjoint; their union must have at least one element and at most 64 elements.
 4. The `asset` property needs to contain the `numberOfSignatures` property.
-    - The value must be an integer between 1 and the total number of public keys of the account (sum of optional and mandatory keys).
-    - The value must not be smaller than the length of the value of `mandatoryKeys`.
-    - The value specifies how many signatures are needed for every outgoing transaction from the registered multisignature account, where signatures for mandatory and optional keys are counted.
-5. The transaction object needs to contain the `signatures` property. The value of this property is an array where each entry is an object with the properties `index` and `signature`. The value of index must be an integer. Moreover:
-    - For every entry `e`, the signature `e.signature` must be a valid signature of the registration transaction for the public key of the account with index `e.index` (see [below](#indexes-of-public-keys) for the specification of _index_).
-    - For any two distinct entries `e1` and `e2`, the indexes `e1.index` and `e2.index` must be distinct.
-    - For every public key in `mandatoryKeys` or `optionalKeys,` there must be an entry with a valid signature and matching index.
-    - If the sender public key is also contained in one of the two arrays, then there must be a index-signature entry for this public key as well.
+   - The value must be an integer between 1 and the total number of public keys of the account (sum of optional and mandatory keys).
+   - The value must not be smaller than the length of the value of `mandatoryKeys`.
+   - The value specifies how many signatures are needed for every outgoing transaction from the registered multisignature account, where signatures for mandatory and optional keys are counted.
+5. The `signatures` property of the transaction object is appended with signatures corresponding to the public keys contained in `mandatoryKeys` and `optionalKeys`. All public keys must have a corresponding signature. The signatures corresponding to `mandatoryKeys` are appended first, followed by those corresponding to `optionalKeys`, where the order of signatures is the same as the order of public keys in the respective array.
 
-    The `signatures` property of the current protocol that holds an array of signatures is replaced by this one.
+The properties `lifetime` and `keysgroup` are not required anymore.
 
-The properties `lifetime` and `keysgroup` are not required anymore and will be ignored.
+The address of the multisignature account is the same as the one before the multisignature registration. That means, this address has to be used as the `recipientID` for balance transfers to this multisignature account.
 
-The address of the multisignature account is the same as the one before the multisignature registration (as in the current protocol). That means, this address has to be used as the `recipientID` for balance transfers to this multisignature account.
+### Adding Sender Public Key to Transaction Objects
 
-#### Indexes of Public Keys
+The `senderPublicKey` property has to be provided in all transactions. The value of this property is always the original public key of the account, i.e. the public key used for registering the multisignature account. This is the case even if this key does neither belong to the set of mandatory nor to the set of optional keys.
 
-Each public key of a multisignature account gets an index which is used for the outgoing transactions. For this, a relational operator is needed: For two public keys _pk<sub>1</sub>_ and _pk<sub>2</sub>_, we say that _pk<sub>1</sub>_ is larger than _pk<sub>2</sub>_, and write _pk<sub>1</sub> > pk<sub>2</sub>_, if and only if the 256-bit representation of _pk<sub>1</sub>_ interpreted as a big-endian encoded integer is larger than the one of _pk<sub>2</sub>_.
+### `signatures` Replaces `signature`
 
-Let _s_ be the number of mandatory keys and _t_ be the number of optional keys of a multisignature account. Furthermore, let {_k<sub>1</sub>_, _k<sub>2</sub>_, …, _k<sub>s+t</sub>_} be the set of all public keys of the account, i.e. all mandatory and all optional public keys, such that the sequence **K**=(_k<sub>1</sub>_, _k<sub>2</sub>_, …, _k<sub>s+t</sub>_) fulfills the following:
+Transactions currently have multiple properties which can hold signatures: `signature`, `signSignature` and `signatures`. We remove the `signature` and `signSignature` properties and only keep the `signatures` property. This property is used to hold the signatures necessary to validate transactions. The items of this array are byte buffers of length 64, or empty byte buffers.
 
-*   _k<sub>1</sub>_, …, _k<sub>s</sub>_ are mandatory public keys and _k<sub>1</sub>_ > _k<sub>2</sub>_ > … > _k<sub>s-1</sub>_ > _k<sub>s</sub>_.
-*   _k<sub>s+1</sub>_, …, _k<sub>t</sub>_ are optional public keys and _k<sub>s+1</sub>_ > _k<sub>s+2</sub>_ > … > _k<sub>t-1</sub>_ > _k<sub>t</sub>_.
+#### Transaction Creation and Verification
 
-The _index_ of a public key _k_ is then the position of _k_ in **K**, where the positions range from 1 to _s+t_, i.e., the index of _k<sub>i</sub>_ is _i_ for every _i=1_, ..., _s+t_.
+##### Transaction from Non-Multisignature Accounts
 
-### Transaction Creation and Verification
+Transactions outgoing from non-multisignature accounts are validly signed if: The first element of `signatures` is a valid signature with respect to the serialized transaction (without `signatures`) and the public key value of `senderPublicKey`.
 
-An outgoing transaction from a multisignature account needs to fulfill the following in order to be valid:
+As described [above](#multisignature-account-registration), for Multisignature Registration Transaction, `signatures` also contains signatures corresponding to the public keys participating in the multisignature account. Specifically, `signatures` is an array composed of a signature corresponding to the `senderPublicKey` followed by signatures for the public keys in `mandatoryKeys` and `optionalKeys`, where the order of signatures is the same as the order of public keys in the respective array.
 
-1. The `senderPublicKey` property of the transaction JSON contains the public key used for registering the multisignature account.
-2. The transaction JSON has the property `signatures.` The value of this property contains an array where each entry is an object with the properties `index` and `signature`. The value of index must be an integer. Moreover, the array must fulfill the following:
-    - For every entry `e`, the signature `e.signature` must be a valid signature of the transaction for the public key of the account with index `e.index`.
-    - For any two distinct entries `e1` and `e2`, the indexes `e1.index` and `e2.index` must be distinct.
-    - For every mandatory public key of the account, there must be an entry with a valid signature and matching index.
-    - There must be an entry with a valid signature and matching index for exactly _m_ distinct public keys specified for the account (mandatory and optional keys), where _m_ is the `numberOfSignatures` value specified for the account during the registration (in other words, there must be an entry with a valid signature and matching index for exactly _m-p_ distinct public keys specified in `optionalKeys` if the account has _p_ mandatory keys).
+For other transactions, `signatures` contains exactly one element.
 
-    The `signatures` property of the current protocol which holds an array of signatures is replaced by this one.
+##### Transaction from Multisignature Accounts
 
-Moreover, the `signature` property is ignored in the transaction verification.
+Transactions outgoing from multisignature accounts are validly signed if the following logic returns true, 
+```
+validity_from_multisignature_accounts(transaction):
+   let signatures be transaction.signatures
+   let message be the serialized transaction without signatures
+   let mandatoryKeys and optionalKeys be the arrays of public keys defined when registering the multisignature account
+   let numMandatoryKeys = length(mandatoryKeys)
+   let numOptionalKeys = length(optionalKeys)
+
+   for k from 0 to numMandatoryKeys-1
+       if signatures[k] is NOT a valid signature with respect to message and mandatoryKeys[k]
+           return false
+
+   validOptionalSig = 0
+   for k from 0 to numOptionalKeys-1
+       if signatures[numMandatoryKeys + k] is a valid signature with respect to message and optionalKeys[k]
+           validOptionalSig += 1
+       else if signatures[numMandatoryKeys + k].byteLength != 0
+           return false
+
+   if numMandatorKeys + validOptionalSig == numberOfSignatures
+       return true
+   else
+       return false
+```
+
+Therefore, for transactions outgoing from multisignature accounts, `signatures` must be of length `length(mandatoryKeys) + length(optionalKeys)`.
+
 
 ### Transaction Broadcasting
 
-When a node receives a transaction, it first has to verify the transaction before broadcasting. This includes the steps 1 and 2 from the [section above](#transaction-creation-and-verification) for transactions from multisignature accounts. In particular, a node is not allowed to broadcast a transaction that does not have the correct number of signatures (step 2).
+When a node receives a transaction, it first has to verify the transaction before broadcasting. This includes the steps from the [section above](#transaction-creation-and-verification) for transactions from multisignature accounts. In particular, a node is not allowed to broadcast a transaction that does not have the appropriate signatures.
 
 ### Transaction Serialization
 
 #### Asset Property Serialization for Multisignature Registration Transactions
 
-The asset property of a transaction of type 4 has to be serialized as by the function `serialize_asset_for_type_4` in the pseudocode below. This serialization is used to compute the byte array of a transaction for the signature computation, the transactionID computation and to include the transaction into the payload hash of a block.
+The asset property of a Multisignature Registration Transaction has to be serialized as by the function `serialize_asset_for_multisignature_registration` in the pseudocode below. This serialization is used to compute the byte array of a transaction for the signature computation, for the ID computation and to include the transaction into the payload hash of a block.
 
 ```
-serialize_asset_for_type_4(asset):
-    let byteBuffer be an empty byte buffer
-    let lm be the length of the array asset.mandatoryKeys
-    append lm as an 8-bit unsigned integer to byteBuffer
-    for each key in asset.mandatoryKeys:
-        append the big endian encoding of key to byteBuffer
-    let lo be the length of the array asset.optionalKeys
-    append lo as an 8-bit unsigned integer to byteBuffer
-    for each key in asset.optionalKeys:
-        append the big endian encoding of key to byteBuffer
-    append asset.numberOfSignatures as an 8-bit unsigned integer to byteBuffer
-    return byteBuffer
+serialize_asset_for_multisignature_registration(asset):
+   let byteBuffer be an empty byte buffer
+   let lm be the length of the array asset.mandatoryKeys
+   append lm as an 8-bit unsigned integer to byteBuffer
+   for each key in asset.mandatoryKeys:
+       append the big endian encoding of key to byteBuffer
+   let lo be the length of the array asset.optionalKeys
+   append lo as an 8-bit unsigned integer to byteBuffer
+   for each key in asset.optionalKeys:
+       append the big endian encoding of key to byteBuffer
+   append asset.numberOfSignatures as an 8-bit unsigned integer to byteBuffer
+   return byteBuffer
 ```
 
-Note that both `for each` loops in `serialize_asset_for_type_4` have to process the array elements in the order given in the JSON arrays.
+Note that both `for each` loops in `serialize_asset_for_multisignature_registration` have to process the array elements in the order given in the JSON arrays.
 
 #### Signatures Serialization
 
-Let `tx` be a transaction of type 4 or a transaction from a multisignature account and let `{e_1, ..., e_m}` be the set of entries in the `signatures` property such that `e_1.index < ... < e_m.index`. For i=1,...,m, let `BI_i` be the byte representing `e_i.index`, `BS_i` the big endian encoding of `e_i.signature` and `B_i = BI_i||BS_i` the concatenation of `BI_i` and  `BS_i`. Let `BA_SIGS = B_1||...||B_m` and let `BA` be the byte array of `tx` that is used for computing the transactionID of `tx` and for including `tx` into the payload hash of a block. Then, `BA_SIGS` has to be contained in `BA`:
+The `signatures` property of a transaction has to be serialized as by the function `serialize_signatures` in the pseudocode below. This serialization is used to compute the byte array of a signed transaction for the ID computation and to include the transaction into the payload hash of a block. This serialization is always inserted at the end of the transaction byte buffer, i.e. the result of the pseudocode below is appended to the buffer to obtain the serialized transaction.
 
-*   If `tx` is a transaction of type 4, `BA_SIGS` follows the bytes of the `signature` property.
-*   If `tx` is a transaction from a multisignature account, `BA_SIGS` follows the bytes of the `asset` property.
+```
+serialize_signatures(signatures):
+   let byteBuffer be an empty byte buffer
+   for each element in signatures
+      if element is an empty byte buffer
+         append 0x00 to byteBuffer
+      if element is a signature
+         append 0x01 to byteBuffer
+         append element to byteBuffer
+   
+   return byteBuffer
+```
 
 ### Converting Existing Accounts
 
@@ -199,22 +231,29 @@ Existing multisignature accounts are converted in order to meet the specificatio
     *   The set of mandatory keys contains exactly one public key, namely the one that registered the multisignature account.
     *   The value of the `numberOfSignatures` property equals the value of the `min` property. The `min` property is removed and ignored.
 *   If the account is registered as a second signature account:
-    *   The set of mandatory keys contains two public key: the one that registered the multisignature account and the second registered public key. Moreover, the converted account is not treated as a second signature account anymore.
+    *   The set of mandatory keys contains two public keys: the one that registered the multisignature account and the second registered public key.
     *   The value of the `numberOfSignatures` property equals the value of the `min` property plus 1. The `min` property is removed and ignored.
+
+Second signature accounts that have not been converted by the above procedure are converted into multisignature accounts as follow:
+
+*   The set of mandatory keys contains two public keys: the one that registered the second signature account and the second registered public key.
+*   The set of optional keys is empty.
+*   The value of the `numberOfSignatures` property is set to 2.
 
 ### Delegate Accounts
 
-It is allowed that an account is registered as a delegate account and as a multisignature account. Blocks forged by such an account must have a signature for the public key that was used for the multisignature account registration (i.e., the original public key of the account), even if this key does neither belong to the set of mandatory nor to the set of optional keys.
+It is allowed that accounts are registered as delegate accounts and as multisignature accounts (this includes current second signature accounts). Blocks forged by such accounts are signed by the original public key of the account, i.e. the public key that was used for the multisignature account registration (or the second signature registration). This is the case even if this key does neither belong to the set of mandatory nor to the set of optional keys.
 
 ### Second Signature Registrations
 
-*   A transaction of type 4 (multisignature registration transaction) is invalid if a transaction of type 1 (second signature registration) was already performed for the same account.
-*   A transaction of type 1 (second signature registration) is invalid if a transaction of type 4 (multisignature registration transaction) was already performed for the same account.
+The Second Signature Registration Transaction is disabled. No account is considered as a second signature account anymore.
 
 ## Backwards Compatibility
 
 This proposal results in a hard fork because:
 
 *   Every outgoing transaction from a multisignature account according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
-*   Transactions of type 4 according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
-*   Accounts that are multisignature accounts and second signature accounts in the current protocol will not be second signature accounts in the proposed protocol. This introduces another incompatibility for transactions from such accounts.
+*   Multisignature Registration Transactions according to the proposed change will be rejected by nodes following the current protocol, and vice versa.
+*   The second signature registration transaction is disabled and will be rejected by nodes following the proposed protocol.
+*   Accounts that are second signature accounts in the current protocol will be converted to multisignature accounts in the proposed protocol. This introduces another incompatibility for transactions from such accounts.
+* The `signature` and `signSignature` properties of transactions are removed. All transactions now have their signatures in the `signatures` property.


### PR DESCRIPTION
Update to multisignature concept:
- the concept of "second sig accounts" is removed from the Lisk protocol. The same security can be obtained by making the converting the account to a multisignature account with 2 required keys. Therefore, we will disable the "second signature registration" transaction.
- the way `signatures` is stored and verified is improved.
- a multisignature account can now register just 1 public key (previous minimum was 2).

