### PR TITLE
Add appendix regarding forger data migration

### DIFF
--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -576,3 +576,61 @@ Below you find an illustration of the setting. After 67 blocks are added on top 
 *   In the numerator we consider all permutations ending with a delegate not in `M`.
 
 ![Expected Time for Finality](lip-0014/expected_time_for_finality.png)
+
+### Safely Activating Forging
+
+Recall that for delegates to correctly follow the protocol, any two blocks `B_1` and  `B_2` forged by the same delegate, where `B_1` is forged before `B_2`, must satisfy both of the following properties:
+
+(i) `max{ B_1.height, B_1.maxHeightPreviouslyForged} ≤ B_2.maxHeightPreviouslyForged`
+
+(ii) `(B_1.heightPrevoted < B_2.heightPrevoted) || (B_1.heightPrevoted == B_2.heightPrevoted &&  B_1.height < B_2.height)`
+
+Condition (i) is ensured by updating the value `maxHeightPreviouslyForged` and storing it persistently. Condition (ii) is ensured by the fork choice rule as well as Blocks Synchronization Mechanism and Fast Chain Switching Mechanism.
+
+We assume that delegates always persists the following properties of the last block `A` they forge:
+
+* `A.height`
+* `A.heightPrevoted`
+* `A.maxHeightPreviouslyForged`
+
+
+#### Migrating to a New Forging Node with Data
+
+Before activating forging on a node, the node operator has to be absolutely sure that forging for the same delegate is not activated on any other node. Moreover, the node operator has to have the correct properties of the last block `A` previously forged (mistakenly using a different block can lead to banning of the delegate).
+
+Then the node proceeds as follows:
+
+1. Synchronize with the blockchain until the tip of the chain `B` satisfies:
+```
+(A.heightPrevoted<B.heightPrevoted ) || ( A.heightPrevoted==B.heightPrevoted &&  A.height< B.height)
+```
+Only afterwards, forging is activated.
+
+2. The first block forged by the delegate uses the value `max{A.height, A.maxHeightPreviouslyForged}` in the `maxHeightPreviouslyForged` property.
+
+Step 1 ensures that property (ii) is satisfied while step 2 ensures that property (i) is satisfied.
+
+#### Migrating to a New Forging Node without Data
+
+Assume that a delegate `D` crashes and loses the data about the last forged block. In this section, we describe how to safely restart forging while ensuring that the delegate does not violate the protocol by accident.
+
+Assume that `T` is the time that the delegate `D` crashed, i.e., we are sure that the delegate did not forge any block after time `T` (it is best to use some safety margin as `T` can be any time after the node crashed and we just need to be sure that the delegate did not forge after time `T`).
+
+1. The node operator synchronizes with the blockchain until there is a block `C` with a timestamp > `T` that is finalized. Only afterwards forging is activated.
+
+2. Let `C_0` be the block at height `C.height-260000` and `X` be the total number of missed block slots between `C_0` and `C`, i.e., `X=ceil((C.timestamp-C0.timestamp)/10)-(C.height - C0.height)`. The first forged block uses the value `C.height+X` for its `maxHeightPreviouslyForged` property.
+
+**Claim.** Assume there is an unchanged set of 68 honest delegates (not containing `D`). Further, assume that any block `B` forged by delegate `D` before crashing satisfies the following properties:
+
+* `B` is forged before time `T` and `B.maxHeightPreviouslyForged` is the maximum height of all the blocks previously forged by `D`.
+* `B` either is a descendant of `C_0` or `B.height ≤ C.height+X`.
+
+Then `D` does not violate the protocol when using the initialization above.
+
+**Proof.**
+By the definition of `X`, any block that is a descendant of `C_0` and forged before time `T` has height at most `C.height+X`. Therefore, all blocks forged by delegate `D` before time `T` have height at most `C.height+X` by assumption.
+
+Let now `B_1` be the last block forged by `D` before crashing and `B_2` be the first block forged after performing the initialization above. By the above argument, we have  `B_1.height ≤ C.height+X`. Furthermore, as all blocks forged before time `T` have height at most `C.height+X`, we additionally obtain that  `B_1.maxHeightPreviouslyForged ≤ C.height+X`. Thus, if we set `B_2.maxHeightPreviouslyForged = C.height+X`, then property (i) is satisfied.
+
+The block at height `B_1.heightPrevoted` must receive a prevote by at least 35 of the honest delegates. Afterwards, these delegates will only prevote for blocks at heights larger than `B_1.heightPrevotes`. As at least one of these 35 delegates prevotes for `C`  (otherwise `C` can obtain at most 101 - 35 = 66 prevotes), we must have `B_1.heightPrevoted < C.height` because `C` is forged after `B_1`. Hence, we have
+`B_1.heightPrevoted < C.height ≤ B_2.heightPrevoted`.

--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/introduce-bft-consensus-protocol
 Status: Draft
 Type: Standards Track
 Created: 2019-03-28
-Updated: 2019-11-04
+Updated: 2019-01-22
 Requires: 0004
 ```
 

--- a/proposals/lip-0014.md
+++ b/proposals/lip-0014.md
@@ -583,7 +583,7 @@ Recall that for delegates to correctly follow the protocol, any two blocks `B_1`
 
 (i) `max{ B_1.height, B_1.maxHeightPreviouslyForged} ≤ B_2.maxHeightPreviouslyForged`
 
-(ii) `(B_1.heightPrevoted < B_2.heightPrevoted) || (B_1.heightPrevoted == B_2.heightPrevoted &&  B_1.height < B_2.height)`
+(ii) `(B_1.heightPrevoted < B_2.heightPrevoted) || (B_1.heightPrevoted == B_2.heightPrevoted && B_1.height < B_2.height)`
 
 Condition (i) is ensured by updating the value `maxHeightPreviouslyForged` and storing it persistently. Condition (ii) is ensured by the fork choice rule as well as Blocks Synchronization Mechanism and Fast Chain Switching Mechanism.
 
@@ -593,7 +593,6 @@ We assume that delegates always persists the following properties of the last bl
 * `A.heightPrevoted`
 * `A.maxHeightPreviouslyForged`
 
-
 #### Migrating to a New Forging Node with Data
 
 Before activating forging on a node, the node operator has to be absolutely sure that forging for the same delegate is not activated on any other node. Moreover, the node operator has to have the correct properties of the last block `A` previously forged (mistakenly using a different block can lead to banning of the delegate).
@@ -601,9 +600,11 @@ Before activating forging on a node, the node operator has to be absolutely sure
 Then the node proceeds as follows:
 
 1. Synchronize with the blockchain until the tip of the chain `B` satisfies:
+
 ```
-(A.heightPrevoted<B.heightPrevoted ) || ( A.heightPrevoted==B.heightPrevoted &&  A.height< B.height)
+(A.heightPrevoted < B.heightPrevoted ) || ( A.heightPrevoted == B.heightPrevoted && A.height < B.height)
 ```
+
 Only afterwards, forging is activated.
 
 2. The first block forged by the delegate uses the value `max{A.height, A.maxHeightPreviouslyForged}` in the `maxHeightPreviouslyForged` property.
@@ -618,7 +619,7 @@ Assume that `T` is the time that the delegate `D` crashed, i.e., we are sure tha
 
 1. The node operator synchronizes with the blockchain until there is a block `C` with a timestamp > `T` that is finalized. Only afterwards forging is activated.
 
-2. Let `C_0` be the block at height `C.height-260000` and `X` be the total number of missed block slots between `C_0` and `C`, i.e., `X=ceil((C.timestamp-C0.timestamp)/10)-(C.height - C0.height)`. The first forged block uses the value `C.height+X` for its `maxHeightPreviouslyForged` property.
+2. Let `C_0` be the block at height `C.height - 260000` and `X` be the total number of missed block slots between `C_0` and `C`, i.e., `X = ceil((C.timestamp - C0.timestamp) / 10) - (C.height - C0.height)`. The first forged block uses the value `C.height + X` for its `maxHeightPreviouslyForged` property.
 
 **Claim.** Assume there is an unchanged set of 68 honest delegates (not containing `D`). Further, assume that any block `B` forged by delegate `D` before crashing satisfies the following properties:
 
@@ -627,10 +628,8 @@ Assume that `T` is the time that the delegate `D` crashed, i.e., we are sure tha
 
 Then `D` does not violate the protocol when using the initialization above.
 
-**Proof.**
-By the definition of `X`, any block that is a descendant of `C_0` and forged before time `T` has height at most `C.height+X`. Therefore, all blocks forged by delegate `D` before time `T` have height at most `C.height+X` by assumption.
+**Proof.** By the definition of `X`, any block that is a descendant of `C_0` and forged before time `T` has height at most `C.height + X`. Therefore, all blocks forged by delegate `D` before time `T` have height at most `C.height + X` by assumption.
 
-Let now `B_1` be the last block forged by `D` before crashing and `B_2` be the first block forged after performing the initialization above. By the above argument, we have  `B_1.height ≤ C.height+X`. Furthermore, as all blocks forged before time `T` have height at most `C.height+X`, we additionally obtain that  `B_1.maxHeightPreviouslyForged ≤ C.height+X`. Thus, if we set `B_2.maxHeightPreviouslyForged = C.height+X`, then property (i) is satisfied.
+Let now `B_1` be the last block forged by `D` before crashing and `B_2` be the first block forged after performing the initialization above. By the above argument, we have  `B_1.height ≤ C.height + X`. Furthermore, as all blocks forged before time `T` have height at most `C.height + X`, we additionally obtain that  `B_1.maxHeightPreviouslyForged ≤ C.height + X`. Thus, if we set `B_2.maxHeightPreviouslyForged = C.height + X`, then property (i) is satisfied.
 
-The block at height `B_1.heightPrevoted` must receive a prevote by at least 35 of the honest delegates. Afterwards, these delegates will only prevote for blocks at heights larger than `B_1.heightPrevotes`. As at least one of these 35 delegates prevotes for `C`  (otherwise `C` can obtain at most 101 - 35 = 66 prevotes), we must have `B_1.heightPrevoted < C.height` because `C` is forged after `B_1`. Hence, we have
-`B_1.heightPrevoted < C.height ≤ B_2.heightPrevoted`.
+The block at height `B_1.heightPrevoted` must receive a prevote by at least 35 of the honest delegates. Afterwards, these delegates will only prevote for blocks at heights larger than `B_1.heightPrevotes`. As at least one of these 35 delegates prevotes for `C`  (otherwise `C` can obtain at most 101 - 35 = 66 prevotes), we must have `B_1.heightPrevoted < C.height` because `C` is forged after `B_1`. Hence, we have `B_1.heightPrevoted < C.height ≤ B_2.heightPrevoted`.


### PR DESCRIPTION
This PR add an additional section to the appendix of the "Introduce BFT consensus protocol" LIP. This section describes how delegates can migrate the consensus related data from one node to another node. This allows to stop forging on one node and start forging on another node without the risk of violating the BFT consensus protocol.