### PR TITLE
Remove the specification that the blockID has to be validated

### DIFF
--- a/proposals/lip-0020.md
+++ b/proposals/lip-0020.md
@@ -47,7 +47,7 @@ Although the success probability is very low, we want to increase the resistance
 
 ## Backwards Compatibility
 
-The change introduces a hard fork, because of the following: Blocks forged by nodes following the proposed protocol get rejected by nodes following the current protocol and vice versa since the format of the `id` and the `previousBlock` property change.
+The change introduces a hard fork, because of the following: Blocks forged by nodes following the proposed protocol get rejected by nodes following the current protocol and vice versa since the format of the `previousBlock` property changes.
 
 ## Reference Implementation
 

--- a/proposals/lip-0020.md
+++ b/proposals/lip-0020.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/use-full-sha-256-hash-of-block-header
 Status: Draft
 Type: Standards Track
 Created: 2019-09-06
-Updated: 2019-09-24
+Updated: 2020-01-30
 ```
 
 ## Abstract

--- a/proposals/lip-0020.md
+++ b/proposals/lip-0020.md
@@ -35,7 +35,7 @@ If `H` is the height from which on the proposed protocol is used, then the block
 
 ### BlockIDs in JSON Objects
 
-In a JSON object representing a block, all properties that contain a blockID have to be represented as a hexadecimal string. The properties of a block that contain a blockID are the `previousBlock` and the `id` property, whereby only the `previousBlock` property is required.
+In a JSON object representing a block, the property `previousBlock`, containing a blockID, has to be represented as a hexadecimal string.
 
 ## Rationale
 

--- a/proposals/lip-0020.md
+++ b/proposals/lip-0020.md
@@ -35,11 +35,7 @@ If `H` is the height from which on the proposed protocol is used, then the block
 
 ### BlockIDs in JSON Objects
 
-In a JSON object representing a block, all properties that contain a blockID have to be represented as a hexadecimal string. The properties of a block that contain a blockID are the `previousBlock` and the `id` property.
-
-### BlockID Verification
-
-During the verification of a block, the blockID must be verified as correct. If the blockID verification fails, the block has to be rejected. If `H` is the height from which on the proposed protocol is used, then a block `B` with `B.height < H` must have a valid blockID according to the current format (such a verification may happen, for example, during synchronisation).
+In a JSON object representing a block, all properties that contain a blockID have to be represented as a hexadecimal string. The properties of a block that contain a blockID are the `previousBlock` and the `id` property, whereby only the `previousBlock` property is required.
 
 ## Rationale
 

--- a/proposals/lip-0020.md
+++ b/proposals/lip-0020.md
@@ -23,7 +23,7 @@ In the current Lisk protocol, a blockID consists of 8 bytes of the SHA-256 diges
 
 ## Specification
 
-Let `blockBytesForId` denote the function that maps every block to the byte array that is used as the input for computing the blockID. In Lisk SDK 2.0.0, for instance, this function is implemented in [Block.getBytes](https://github.com/LiskHQ/lisk-sdk/blob/a8ad19b67677aa4abcfdcd28638319d7ca838644/framework/src/modules/chain/logic/block.js#L393). In the proposed protocol, the blockID of a transaction `B` is computed as follows:
+Let `blockBytesForId` denote the function that maps every block to the byte array that is used as the input for computing the blockID. In Lisk SDK 2.0.0, for instance, this function is implemented in [Block.getBytes](https://github.com/LiskHQ/lisk-sdk/blob/a8ad19b67677aa4abcfdcd28638319d7ca838644/framework/src/modules/chain/logic/block.js#L393). In the proposed protocol, the blockID of a block `B` is computed as follows:
 
 ```
 blockID = SHA-256(blockBytesForId(B)).


### PR DESCRIPTION
The `id` property is a non-required property. Therefore, it should not be validated during block validation. Instead, the blockID should be computed (and overridden if already existing) during block validation, as it is currently done.

