### PR TITLE
Use ordered nonces instead of unordered nonces in LIP0015

### DIFF
--- a/proposals/lip-0015.md
+++ b/proposals/lip-0015.md
@@ -11,7 +11,7 @@ Requires: 0009
 
 ## Abstract
 
-This LIP proposes to replace timestamps by nonces in transaction objects. No constraints on the order of nonces shall be used. Moreover, the requirement that the combination of address, nonce and network identifier has to be unique is added. This will allow to invalidate pending transactions by reusing the nonce.
+This LIP proposes to replace timestamps by ordered nonces in transaction objects. This will allow to invalidate pending transactions by reusing the nonce.
 
 ## Copyright
 
@@ -45,43 +45,32 @@ As concluded in the previous subsection, restrictions on the value of the timest
 
 ### Enabling Invalidation of Transactions
 
-As mentioned in the motivation, there is currently no way to invalidate pending transactions. Therefore, we propose to enforce the uniqueness of nonces used for an account. More precisely, the combination of address, nonce and network identifier (see LIP [0009](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md)) has to be unique. This allows to invalidate pending transactions by reusing the nonce. This can be used, for example, in the case of pending low-fee transactions as mentioned above: Issuing the original transaction again with the same input, including the same nonce, but with a higher fee can replace the first transaction.
+As mentioned in the motivation, there is currently no way to invalidate pending transactions. Therefore, we propose to enforce the uniqueness of nonces used for an account. More precisely, the combination of account and nonce has to be unique. This allows to invalidate pending transactions by reusing the nonce. This can be used, for example, in the case of pending low-fee transactions as mentioned above: Issuing the original transaction again with the same input, including the same nonce, but with a higher fee can replace the first transaction.
 
 To invalidate a transaction without replacing it by a meaningful one, the sender could, for example, create a balance transfer transaction to his or herself  where the nonce of the transaction that is supposed to be invalidated, is used. Once this new transaction has been included, it is guaranteed that the first transaction would not be included anymore. Of course, the original transaction may be included before the second one. In this case, the user has certainty about the original transaction (included in the blockchain) and it is guaranteed that the second one does not get included.
 
-One may argue that enforcing uniqueness solely to the nonce value is sufficient too. That means, each nonce value would be allowed to be included in the blockchain only once. This is also allows transaction invalidation, but increases the probability of rejected transactions due to already used nonces. This is especially the case when many users/clients tend to choose nonces not uniformly at random, for example, by choosing the operating system time as the nonce. Moreover, it allows users to invalidate pending transactions of other users.
-
-Alternatively, one could also enforce the uniqueness of the combination of address and nonce. But this does not allow to delete the used combinations every time the network identifier changes. When enforcing the uniqueness of the combination of address, nonce and network identifier, all used combinations can be deleted when the network identifier changes. This is because transactions using the old network identifier are invalid and there is no need to check if the combination of address, nonce and network identifier was already used. See also the section [Impact on Storage and Performance](#Impact-on-Storage-and-Performance) for more reasoning why this is advantageous.
-
 ### Ordered vs. Unordered Nonces
 
-Ordered nonces (i.e., to require that the nonce of a transaction has to be equal to the incremented nonce of the previously included transaction of the same sender) have one obvious advantage over unordered nonces: One has to store only a single nonce per account. This requires less storage, enables faster verification and keeps the protocol and implementation simple (see also the discussion [below](#Impact-on-Storage-and-Performance)).
+Both ordered nonces (i.e., to require that the nonce of a transaction has to be equal to the incremented nonce of the previously included transaction of the same sender) and unordered nonces (not enforcing any order) have their advantages and disadvantages and there is no perfect solution. Ordered nonces have more drawbacks regarding the user experience. For example:
+- Each transaction in the transaction pool depends on the previous transaction. If several transactions originating from the same account are pending, and one of these transactions is pending for a long time due to a low fee, all following transactions are pending too, even if they have a very high fee. Moreover, it might be possible that one of the transactions is invalid. Consequently, the nonce of the invalid transaction has to be used again for a new (and valid) transaction before all following transactions get accepted.
+- Keeping track of the used nonces may become difficult too when some transactions are pending and especially when several devices are used for a single account (this issue has been partially discussed for [Ethereum](https://github.com/ethereum/go-ethereum/issues/2880) for quite some time already). The same holds for generating transactions while having no connection to the network (offline transactions).
 
-There are however significant disadvantages for ordered nonces: Each transaction in the transaction pool depends on the previous transaction. If several transactions originating from the same account are pending, and one of these transactions is pending for a long time due to a low fee, all following transactions are pending too, even if they have a very high fee. Moreover, it might be possible that one of the transactions is invalid. Consequently, the nonce of the invalid transaction has to be used again for a new (and valid) transaction before all following transactions get accepted. Keeping track of the used nonces may become difficult too when some transactions are pending and especially when several devices are used for a single account (this issue has been partially discussed for [Ethereum](https://github.com/ethereum/go-ethereum/issues/2880) for quite some time already). The same holds for generating transactions while having no connection to the network (offline transactions).
+For these reasons, even a previous version of this LIP proposed to use unordered nonces.
 
-Due to the mentioned disadvantages for the user experience, we propose to use unordered nonces. That means, there are no restrictions on the order of nonces.
+However, unordered nonces have significant drawbacks regarding storage, performance and simplicity. Further considerations led to the decision that these drawbacks are too large and that ordered nonces should be preferred over unordered nonces. The main drawbacks are:
+- The accounts state grows linearly with the number of transactions. Assuming a year of full blocks (~3.8*10<sup>8</sup> transactions), the unordered nonces would add ~3 GB to the accounts state. This impacts, for example, the accounts fetching performance for snapshooting mechanisms as desired by the [roadmap](https://lisk.io/roadmap) objective "Introduce decentralized re-genesis". More generally, it lowers the performance, storage-wise and syncing-wise, of nodes that are not interested in the complete transaction history but only in transactions from a certain block height on and the corresponding accounts state.
+- The account state of a single account can become very large. Hence, large data packages have to be transmitted when a client requests an account state from a node. This also reduces the possibility to develop light clients that are able to verify a single account state efficiently in the future.
+- The global state becomes very large. To enable an efficient lookup for an existing (address, nonce)-pair, it seems to be unavoidable that an implementation requires to store these pair in an extra table. Assuming [20-byte addresses](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0018.md), the table would grow by at least 28 bytes per transaction. Assuming again a year of full blocks (~3.8*10<sup>8</sup> transactions), this sums up to ~10 GB extra. This results in a 20% larger blockchain growth as intended in [LIP 0002](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0002.md#rationale).
+
+Moreover, ordered nonces are widely used within the industry, whereas no project is known to us that uses non-ordered nonces without any further techniques, such as timeouts.
 
 ### Format of Nonces
 
 We propose to use unsigned integers for nonces. Using 32 bits to represent a nonce could theoretically result in an exhausted set of nonces in reasonable time: An account issuing permanently 10 transactions per second (which is possible with the [intended changes for the block size](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0002.md)) has an exhausted set of nonces after 13.6 years. Therefore, we propose to use 64 bits to represent a nonce, which requires more than 10<sup>10</sup> years to exhaust the set of nonces with the mentioned frequency.
 
-### Choosing a Nonce
-
-As discussed before, an arbitrary 64-bit unsigned integer has to be used for the nonce, with the restriction that the combination of sender address, nonce and network identifier has to be unique. Two obvious ways exist to choose a nonce during transaction creation: using a pseudo random number generator or the system time. For the latter option, care has to be taken when creating multiple transactions at the same time. Of course, any other way to choose a 64-bit unsigned integer that fulfills the mentioned uniqueness requirement is valid too.
-
-### Impact on Storage and Performance
-
-To be able to quickly verify if a certain combination of sender address, nonce and network identifier was already used, it may be necessary to store these combinations in separate database tables for efficient querying. For example, there could be a table with two columns (one for the address and one for the nonce) for the current network identifier. Alternatively, one could use a table with a single column for the concatenation of address and nonce. This way, the single column coincides with the primary key which could speed up queries. Every time the network identifier changes, the table for the old network identifier can be deleted. One more alternative is to specify that the combination of address, nonce and network identifier is unique in the transaction table. That way, one does not need to create extra tables, but it also disallows to delete the combinations for network identifiers that are not valid anymore.
-
-The currently used address format uses 64 bits. However, the address system is [intended to be changed](https://lisk.io/roadmap) in the near future. For the following computations, we assume an address length of 192 bits. With this size, storing a combination of address and nonce requires 256 bits. Assuming the block size limit proposed in LIP [0002](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0002.md), approximately 120 transactions fit into one block. This can result in up to ~3.8*10<sup>8</sup> transactions per year. Hence, the required storage for the combinations of address and nonce could grow by up to ~12 GB per year.
-
-An average PC should be able to perform a few thousand queries per second for combinations of address and nonce in a table of the size of 12 GB. Once the size of the table results in too large query times, the table could be split.
-
-The impact on storage and performance will not be drastic in the near future because several hard forks are planned which every time results in a change of the network identifier. Hence, the previously used combinations can always be deleted. Once there is a long period without a hard fork, the impact on storage and performance could have a significant impact. In the [appendix](#Possibilities-to-Mitigate-the-Impact-on-Storage-and-Performance), some possibilities that could mitigate the impact are mentioned. This is, however, no complete research and no solution shall be specified in this LIP. If mitigation solutions are desired in the future, the solution shall be implemented in a separate step.
-
 ### Uniqueness of transactionIDs
 
-One purpose of the uniqueness requirement for transactionIDs in the current protocol is the prevention of transaction replay attacks. Due to the uniqueness requirement for the combination of address, nonce and network identifier added in this proposal, one could drop the uniqueness requirement for transactionIDs without adding any risk for transaction replay attacks. However, transactionIDs are also used to uniquely identify transactions, for instance, in RPCs, the API of Lisk Core and frontend tools like Lisk Hub. Therefore, we keep the uniqueness requirement.
+One purpose of the uniqueness requirement for transactionIDs in the current protocol is the prevention of transaction replay attacks. Due to the uniqueness requirement for the combination of address and nonce added in this proposal, one could drop the uniqueness requirement for transactionIDs without adding any risk for transaction replay attacks. However, transactionIDs are also used to uniquely identify transactions, for instance, in RPCs, the API of Lisk Core and frontend tools like Lisk Hub. Therefore, we keep the uniqueness requirement.
 
 ### Discarded Alternatives
 
@@ -91,7 +80,7 @@ Unspent transaction outputs (UTXOs) as used in Bitcoin make it very easy to inva
 
 #### Invalidation Transaction
 
-Another possibility to invalidate transactions is to create a new transaction type in which one can specify a transactionID that shall be considered as invalid. Once the invalidation transaction is included in the blockchain, a transaction with the specified Id that originates from the same account as the invalidation transaction is considered to be invalid. This solution is however less convenient. Invalidating a transaction is easy, but replacing a transaction (e.g. by another transaction that has the same input but a higher fee) requires to first invalidate the original transaction and to issue another updated transaction. Hence, two transactions are needed and for each some fees have to paid. For the proposed mechanism, invalidating and replacing can be done with only one transaction. Therefore, the proposed mechanism of using unordered nonces is preferred.
+Another possibility to invalidate transactions is to create a new transaction type in which one can specify a transactionID that shall be considered as invalid. Once the invalidation transaction is included in the blockchain, a transaction with the specified Id that originates from the same account as the invalidation transaction is considered to be invalid. This solution is however less convenient. Invalidating a transaction is easy, but replacing a transaction (e.g. by another transaction that has the same input but a higher fee) requires to first invalidate the original transaction and to issue another updated transaction. Hence, two transactions are needed and for each some fees have to paid. For the proposed mechanism, invalidating and replacing can be done with only one transaction. Therefore, the proposed mechanism of using ordered nonces is preferred.
 
 #### Timeout
 
@@ -99,21 +88,25 @@ Allowing to specify when a transaction becomes invalid provides little flexibili
 
 ## Specification
 
-### Transaction Objects
+### Nonces in Account States
 
-#### Timestamp
+Each account has the property `nonce`. The value of this property is a 64-bit unsigned integer. When an account is initialized, the value is set to 0.
 
-The `timestamp` property gets removed from transaction objects. Any transaction object having this property is considered to be invalid.
+### Nonces in Transactions
 
-#### Nonce
+Each transaction needs the `nonce` property. The value must be a 64-bit unsigned integer.
 
-Every transaction object needs a `nonce` property. The value of this property has to be a 64-bit unsigned integer. During the verification of a transaction, it has to be ensured that the combination of
+When a transaction, `tx`, is included in a block, it must fufill
+```
+senderAccount.nonce == tx.nonce
+```
+where `senderAccount` is the account associated with `tx.senderPublicKey`. Otherwise, the transaction is invalid.
 
-*   sender address
-*   nonce
-*   network identifier (see LIP [0009](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md))
+When `tx` is applied, then `senderAccount.nonce` is incremented by one.
 
-was not used for any other transaction included in the blockchain before. If this combination was already used, the transaction has to be rejected. Note that the network identifier is not part of the transaction JSON object. It is only part of the input message of the transaction signature, and a signature is rejected if the message did not contain the correct network identifier (see LIP [0009](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md) for more details).
+### Timestamp
+
+The `timestamp` property gets removed from transaction objects.
 
 ### Serialization for Signature and TransactionID Generation
 
@@ -133,19 +126,3 @@ This LIP introduces a hard fork. This is because:
 Due to the [change in the serialization process](#Serialization-for-Signature-and-TransactionID-Generation) for the byte array that serves as the input for the transaction signature, there is the possibility that the byte array `BA` of a transaction `tx` already included in the blockchain could represent a valid transaction according to the proposed protocol. If this were the case, the signature of `tx` would also be valid for the new transaction. In this case, an adversary could send this new valid transaction into the network without knowing the private key belonging to the signature.
 
 This is however only possible if the network identifier does not change because the network identifier determines the first 256 bits of the byte array. Since the proposed change is causing a hard fork, the network identifier will change and it is guaranteed that `BA` does represent a valid transaction after the hard fork. Thus, the signature of `tx` cannot be valid for any transaction after the hard fork.
-
-## Appendix
-
-### Possibilities to Mitigate the Impact on Storage and Performance
-
-Two ideas to mitigate the impact on storage and performance shall be mentioned in this section. Note that this does not pose a complete study, and more research may be required to find a good solution.
-
-#### Incentivise Expiration Times
-
-An optional transaction property that specifies an expiration time of a transaction could be added to the protocol. If a transaction contains an expiration time, then the combination of address and nonce could be allowed to be reused after the expiration time, because replaying the transaction after the expiration time is impossible (assuming that the expiration time is included in the input message of the transaction signature). Therefore, the combination of address and nonce does not need to be stored after the expiration time.
-
-The usage of a low expiration time could be incentivized by enforcing a higher transaction fee for transaction without a low expiration time. This is very simple for static fees. In a dynamic fee system in which the fee is proportional to the transaction size (as, for instance, in [this proposal](https://research.lisk.io/t/replace-static-fee-system-by-dynamic-fee-system/31?u=andreas.kendziorra)), the size of a transaction could artificially be increased by adding some redundant data. For example, a hash value of some known data could be added to the transaction object. This way, the transaction object becomes larger without the need that nodes store this redundant data, because it is alway easily reproducible. If a transaction without a low expiration time does not contain the redundant data, it is rejected.
-
-#### Artificially Change the Network Identifier
-
-The network identifier could be changed, for example, by incrementing the [version](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md#specification). This allows to delete all previously stored combinations, but introduces a hard fork.

--- a/proposals/lip-0015.md
+++ b/proposals/lip-0015.md
@@ -5,7 +5,7 @@ Author: Andreas Kendziorra <andreas.kendziorra@lightcurve.io>
 Discussions-To: https://research.lisk.io/t/enable-transaction-invalidation-by-using-nonces/
 Type: Standards Track
 Created: 2019-01-29
-Updated: 2019-09-06
+Updated: 2020-02-26
 Requires: 0009
 ```
 


### PR DESCRIPTION
Change from unordered nonces to ordered nonces because unordered nonces imply:
- that the accounts state grows linearly with the number of transaction
- a single account state can become very large
- the overall storage required for the blockchain may increase by up to ~10 GB extra per year.

Besides the storage requirement for a node, these points may impact the following functionalities (and may prevent them):
- snap-shooting mechanism where only the accounts state is fetched without the complete transaction history
- querying a single account state efficiently => light clients that can validate a single account state efficiently may not be possible