### PR TITLE
Update LIP0018 specifications of reclaim transaction

### DIFF
--- a/proposals/lip-0018.md
+++ b/proposals/lip-0018.md
@@ -190,7 +190,7 @@ The type of the reclaim transaction is the lowest positive integer that is not u
 
 ###### Schema
 
-The `asset` property of a reclaim transaction needs to contain the `amount` property which is of type _uint64_. The value of `asset.amount` must represent a number and this number must be equal to the balance associated to the address of the current format in Beddows.
+The `asset` property of a reclaim transaction needs to contain the `amount` property which is of type _uint64_. The value of `asset.amount` must be equal to the balance associated to the address of the current format in Beddows.
 
 A reclaim transaction is of the following form:
 

--- a/proposals/lip-0018.md
+++ b/proposals/lip-0018.md
@@ -190,7 +190,7 @@ The type of the reclaim transaction is the lowest positive integer that is not u
 
 ###### Schema
 
-The `asset` property of a reclaim transaction needs to contain the `amount` property which is of type _string_. The value of `asset.amount` must represent a decimal number and this number must be equal to the balance associated to the address of the current format in Beddows.
+The `asset` property of a reclaim transaction needs to contain the `amount` property which is of type _uint64_. The value of `asset.amount` must represent a number and this number must be equal to the balance associated to the address of the current format in Beddows.
 
 A reclaim transaction is of the following form:
 
@@ -209,18 +209,17 @@ A reclaim transaction is of the following form:
 
 A reclaim transaction, `tx`, must fulfil the following points to be valid:
 
-- Let `old_addr` be the address according to the old format for `tx.senderPublicKey`. Then, `old_addr` must be contained in `unregisteredAddresses`.
+- Let `old_addr` be the address according to the old format for `tx.senderPublicKey`. `old_addr` must be contained in `unregisteredAddresses`.
 - Let `old_balance` be the sum of all funds send to `old_addr` in Beddows. Then `tx.asset` must contain the property `amount`, and the number represented by `tx.asset.amount` must be equal to `old_balance`.
-- Let `new_addr` be the address of the new format for `tx.senderPublicKey` and let `new_balance` be the balance of `new_addr`. If there exists no account for `new_addr`, then `new_balance` is 0. Then `tx.fee` must be smaller or equal than `old_balance + new_balance`.
+
+Notice that the base properties of the transaction also have to be valid. In particular, this implies that the transaction fee is paid by the account corresponding to `tx.senderPublicKey`. In some cases, users might need to credit accounts specifically to reclaim the balance sent to "unregistered" addresses.
 
 ###### State Changes
 
 We use the same notation as in the [Validity](#validity) section. If the transaction `tx` is included in the blockchain, the following state changes apply:
 
 - `old_addr` is removed from `unregisteredAddresses`.
-- If no account for `new_addr` exists, the account is created.
-- If no public key is associated to `new_addr`, the public key `tx.senderPublicKey` is associated  to `new_addr`.
-- The balance for `new_addr` is set to `old_balance + new_balance - tx.fee`.
+- `tx.asset.amount` is added to the balance of the account corresponding to `tx.senderPublicKey`.
 
 ###### Serialization
 
@@ -314,10 +313,7 @@ The usage of a reclaim transaction for accessing funds send to  "unregistered" a
 
 #### Amount Property in Reclaim Transactions
 
-One may argue that the amount property of a reclaim transaction is not required to process the transaction. This is true. However, the undo step in case of reverting a block would be very expensive because one could not easily distinguish between the following two cases:
-
-1. The account received balance transfers only to the old address.
-2. The account received balance transfers to the old and the new address.
+One may argue that the amount property of a reclaim transaction is not required to process the transaction. This is true. However, we think that the state of a given account should be easily computed with the incoming and outgoing transaction from that account. In that regard, the reclaim transaction must indicate how many tokens were added to the account balance.
 
 ## Backwards Compatibility
 

--- a/proposals/lip-0018.md
+++ b/proposals/lip-0018.md
@@ -210,7 +210,7 @@ A reclaim transaction is of the following form:
 A reclaim transaction, `tx`, must fulfil the following points to be valid:
 
 - Let `old_addr` be the address according to the old format for `tx.senderPublicKey`. `old_addr` must be contained in `unregisteredAddresses`.
-- Let `old_balance` be the sum of all funds send to `old_addr` in Beddows. Then `tx.asset` must contain the property `amount`, and the number represented by `tx.asset.amount` must be equal to `old_balance`.
+- Let `old_balance` be the sum of all funds send to `old_addr` in Beddows. Then `tx.asset` must contain the property `amount`, and `tx.asset.amount` must be equal to `old_balance`.
 
 Notice that the base properties of the transaction also have to be valid. In particular, this implies that the transaction fee is paid by the account corresponding to `tx.senderPublicKey`. In some cases, users might need to credit accounts specifically to reclaim the balance sent to "unregistered" addresses.
 

--- a/proposals/lip-0018.md
+++ b/proposals/lip-0018.md
@@ -5,7 +5,7 @@ Author: Andrea Kendziorra <andreas.kendziorra@lightcurve.io>
 Discussions-To: https://research.lisk.io/t/use-base32-encoding-of-long-hash-of-public-key-plus-checksum-for-address/
 Type: Standards Track
 Created: 2019-03-08
-Updated: 2020-07-21
+Updated: 2020-08-17
 ```
 
 ## Abstract

--- a/proposals/lip-0018.md
+++ b/proposals/lip-0018.md
@@ -212,7 +212,7 @@ A reclaim transaction, `tx`, must fulfil the following points to be valid:
 - Let `old_addr` be the address according to the old format for `tx.senderPublicKey`. `old_addr` must be contained in `unregisteredAddresses`.
 - Let `old_balance` be the sum of all funds send to `old_addr` in Beddows. Then `tx.asset` must contain the property `amount`, and `tx.asset.amount` must be equal to `old_balance`.
 
-Notice that the base properties of the transaction also have to be valid. In particular, this implies that the transaction fee is paid by the account corresponding to `tx.senderPublicKey`. In some cases, users might need to credit accounts specifically to reclaim the balance sent to "unregistered" addresses.
+Notice that the base properties of the transaction also have to be valid. In particular, this implies that the transaction fee is paid by the account corresponding to `tx.senderPublicKey`. Hence this account needs to exist beforehand and have enough balance to pay for the fee.
 
 ###### State Changes
 
@@ -223,7 +223,7 @@ We use the same notation as in the [Validity](#validity) section. If the transac
 
 ###### Serialization
 
-The asset property of a reclaim transaction `tx` needs to be serialized to an array of 8 bytes containing the big endian encoding of `tx.asset.amount` interpreted as a 64-bit signed integer.
+The asset property of a reclaim transaction `tx` needs to be serialized to an array of 8 bytes containing the big endian encoding of `tx.asset.amount`, a 64-bit unsigned integer.
 
 ## Rationale
 


### PR DESCRIPTION
Updated the reclaim transaction in a way that can be extended from the base transaction, i.e., the fee is always paid by the account sending the transaction, and cannot be deduced from the reclaimed amount anymore.
The rationale for including `amount` in the reclaim transaction was also updated.

