### PR TITLE
Fix serialization LIPs examples and formatting

### DIFF
--- a/proposals/lip-0027.md
+++ b/proposals/lip-0027.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.io/t/a-generic-serialization-method/208
 Status: Draft
 Type: Informational
 Created: 2020-02-18
-Updated: 2020-07-21
+Updated: 2021-02-08
 ```
 
 ## Abstract

--- a/proposals/lip-0027.md
+++ b/proposals/lip-0027.md
@@ -170,13 +170,9 @@ A Lisk JSON schema is a [JSON schema](https://json-schema.org/) according to [dr
 1. The [root schema](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-4.3.3) must be of type _object_.
 2. Every schema of type _object_ must have the `properties` keyword.
 3. Every property of a schema of type _object_ must follow:
-  1. Exactly one of the keywords `dataType` or `type` must be included. It must have a value from the [encoding table](#encoding-summary-table). As a consequence, the value of `type` cannot be "null", "number", "integer", "string", "boolean" or an array of values.
-  2. The keyword <code>fieldNumber</code> must be included. All values used for <code>fieldNumber</code> in a given object have to be different; nested objects can reuse the same values for <code>fieldNumber</code>.
-
-  This value is used to generate the key in the binary message. Values for <code>fieldNumber</code> have to be integers greater or equal than 1 and strictly smaller than 19000. As a consequence, every object must have less than 19000 properties.
-4. We restrict properties of type _array_ to [list validation](https://json-schema.org/understanding-json-schema/reference/array.html#list-validation) where each item matches the same schema.
-
-A property of type _array_ must have the <code>items</code> keyword and its value is a schema specifying the repeated schema. The value of items must include exactly one of the keywords <code>dataType</code> or <code>type</code>. This keyword must have a value from the [encoding table](#encoding-summary-table), but it is not allowed to be "array".
+    1. Exactly one of the keywords `dataType` or `type` must be included. It must have a value from the [encoding table](#encoding-summary-table). As a consequence, the value of `type` cannot be "null", "number", "integer", "string", "boolean" or an array of values.
+    2. The keyword <code>fieldNumber</code> must be included. All values used for <code>fieldNumber</code> in a given object have to be different; nested objects can reuse the same values for <code>fieldNumber</code>. This value is used to generate the key in the binary message. Values for <code>fieldNumber</code> have to be integers greater or equal than 1 and strictly smaller than 19000. As a consequence, every object must have less than 19000 properties.
+4. We restrict properties of type _array_ to [list validation](https://json-schema.org/understanding-json-schema/reference/array.html#list-validation) where each item matches the same schema. A property of type _array_ must have the <code>items</code> keyword and its value is a schema specifying the repeated schema. The value of items must include exactly one of the keywords <code>dataType</code> or <code>type</code>. This keyword must have a value from the [encoding table](#encoding-summary-table), but it is not allowed to be "array".
 5. Keywords other than `type`, `dataType`, `properties`, `items` and `fieldNumber` will be ignored by the serialization process.
 
 #### DataType Keyword
@@ -494,7 +490,7 @@ A binary message is valid, with respect to the corresponding data and schema, if
 
   1. Empty _Arrays_ do not appear in the binary message.
   2. [Non-packed arrays](#array-of-string-object-and-bytes) may contain multiple values.
-  3. Non-required properties for which no value was provided do not appear in the binary message.
+  3. Non-required properties for which no value was provided do not appear in the binary message. In particular, the key is also NOT contained in the binary message.
 
 4. The binary message does not contain properties not present in the schema.
 

--- a/proposals/lip-0028.md
+++ b/proposals/lip-0028.md
@@ -60,20 +60,21 @@ Consider a binary message `trsMsg` to be deserialized. The deserialization proce
 
 ### Transaction signature calculation
 
-Consider a data structure `unsignedTrsData` representing a valid transaction object in which the `signatures` array is initialized to the default value (an empty array). The signature of the object is calculated as follows:
+Consider a data structure `unsignedTrsData` representing a valid transaction object in which the `signatures` array is initialized to the default value (an empty array). A signature of the object on a certain chain is calculated as follows:
 
 1. `unsignedTrsData` is serialized using the method explained above. In particular, the empty `signatures` array is not part of the serialized data (see [below](#transactionSchema-schema)).
-2. The transaction signature is calculated by signing the binary message from step 1.
-3. The signature bytes from step 2 are inserted into the corresponding element of the `unsignedTrsData.signatures` array.
+2. The network identifier of the chain is prepended to the binary message from step 1. This is to [protect against transaction replay](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md).
+3. The transaction signature is calculated by signing the binary message from step 2.
+4. The signature bytes from step 3 are inserted into the corresponding element of the `unsignedTrsData.signatures` array.
 
 ### Transaction signature validation
 
-Consider a binary message `trsMsg` representing a serialized transaction object. The signature of the object is validated as follows:
+Consider a binary message `trsMsg` representing a serialized transaction object on a certain chain. The signature of the object is validated as follows:
 
 1. `trsMsg` is deserialized to an object, `trsData`, as explained above in [Deserialization](#deserialization).
 2. The signatures in `trsData.signatures` are removed from `trsData`, but kept for signature verification purposes. The array `trsData.signatures` is set to its default value.
 3. The transaction object, `trsData`, from step 2 is serialized using the method explained above.
-4. The signatures saved in step 2 are verified against the binary message from step 3 and the associated public keys.
+4. The signatures saved in step 2 are verified against the binary message from step 3 prepended by the chain's network identifier and the associated public keys.
 
 ### Transaction ID
 
@@ -374,6 +375,9 @@ This proposal introduces a hard fork in the network. Since the transaction seria
 
 ## Appendix: Serialization Example of Balance Transfer Transaction
 
+In this section, we present a serialization example for a transfer transaction. To calculate the signature, we use the network identifier:
+`networkID = 9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee`.
+
 #### **Transaction object to serialize:**
 
 ```js
@@ -385,12 +389,12 @@ myTrs = {
   senderPublicKey: '6689d38d0d89e072b5339d24b4bff1bd6ef99eb26d8e02697819aecc8851fd55',
   asset: {
     amount: 123986407700n,
-   recipientID: '2ca4b4e9924547c48c04300b320be84e8cd81e4a',
-   data: 'Odi et amo. Quare id faciam, fortasse requiris.'
+    recipientID: '2ca4b4e9924547c48c04300b320be84e8cd81e4a',
+    data: 'Odi et amo. Quare id faciam, fortasse requiris.'
   },
   signatures: [
-    '0898af68bd57e17a51fc5caa06a4acbea3a3c5d70e917632e3cd27498d64b701eab0269065ee48701546eceaedcbd849912c7413f8d321979931686c7b9f0c01',
-    'f616daae47cca08630a8a17d478c478ec8ef895393c650a01e2f754d4812041d196c813e2876eddfc0415d6cbdbf35f1d56b816bfbe0b198446d17842a7df20e'
+    '0e1540cdbdc23d4eab54ac3a6cd22c114a458f86c4f27b57fd999703b7193ab32c4f04eddd493111e641147235806b796f76c185cc9b2cac63d54825e946c209',
+    'a258f73cd99d68834f047ab18555457cdabfc060297433f3a708236c9fd9ec72009ecd6ca6b7d6428383d7af3c50baf66955d51fbe4c012cfa56612046bafb02'
   ]
 }
 ```
@@ -398,19 +402,24 @@ myTrs = {
 #### **Binary message (258 bytes):**
 
 ```
-0x080210001805209883fdc3042a206689d38d0d89e072b5339d24b4bff1bd6ef99eb26d8e02697819aecc8851fd55324e0894e2a9f1cd0312142ca4b4e9924547c48c04300b320be84e8cd81e4a1a2f4f646920657420616d6f2e2051756172652069642066616369616d2c20666f7274617373652072657175697269732e3a400898af68bd57e17a51fc5caa06a4acbea3a3c5d70e917632e3cd27498d64b701eab0269065ee48701546eceaedcbd849912c7413f8d321979931686c7b9f0c013a40f616daae47cca08630a8a17d478c478ec8ef895393c650a01e2f754d4812041d196c813e2876eddfc0415d6cbdbf35f1d56b816bfbe0b198446d17842a7df20e
+080210001805209883fdc3042a206689d38d0d89e072b5339d24b4bff1bd6ef99eb26d8e02697819aecc8851fd55324e0894e2a9f1cd0312142ca4b4e9924547c48c04300b320be84e8cd81e4a1a2f4f646920657420616d6f2e2051756172652069642066616369616d2c20666f7274617373652072657175697269732e3a400e1540cdbdc23d4eab54ac3a6cd22c114a458f86c4f27b57fd999703b7193ab32c4f04eddd493111e641147235806b796f76c185cc9b2cac63d54825e946c2093a40a258f73cd99d68834f047ab18555457cdabfc060297433f3a708236c9fd9ec72009ecd6ca6b7d6428383d7af3c50baf66955d51fbe4c012cfa56612046bafb02
 ```
 
 #### **Transaction ID:**
 
 ```
-0x6ff4a496692a3926a30a74e8827dcc09cc79654f0f0f4682f17c13e908656b7d
+acc56a395c263b3d176c97fb7f0807d17e9e9c9037f0606bbbcce7448fd7b692
+```
+#### **First key pair:**
+
+```
+private key = 42d93fa53d631181540ad630b9ad913835db79e7d2510be915513836bc175edc
+public key = 6689d38d0d89e072b5339d24b4bff1bd6ef99eb26d8e02697819aecc8851fd55
 ```
 
-#### **Private keys:**
+#### **Second key pair:**
 
 ```
-0x42d93fa53d631181540ad630b9ad913835db79e7d2510be915513836bc175edc6689d38d0d89e072b5339d24b4bff1bd6ef99eb26d8e02697819aecc8851fd55
-
-0x3751d0dee5ee214809118514303fa50a1daaf7151ec8d30c98b12e0caa4bb7deaa3f553d66b58d6167d14fe9e91b1bd04d7cf5eef27fed0bec8aaac6c73c90b3
+private key = 3751d0dee5ee214809118514303fa50a1daaf7151ec8d30c98b12e0caa4bb7de
+public key = aa3f553d66b58d6167d14fe9e91b1bd04d7cf5eef27fed0bec8aaac6c73c90b3
 ```

--- a/proposals/lip-0028.md
+++ b/proposals/lip-0028.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/define-schema-and-use-generic-seriali
 Status: Draft
 Type: Standards Track
 Created: 2020-02-18
-Updated: 2020-09-09
+Updated: 2021-02-08
 Requires: 0027, 0036
 ```
 

--- a/proposals/lip-0029.md
+++ b/proposals/lip-0029.md
@@ -188,11 +188,12 @@ Consider a binary message `blockHeaderMsg` to be deserialized. The deserializati
 
 The `blockHeader` schema specifies how to serialize all the information necessary to sign a block header and generate the block ID. In the Lisk protocol, block headers are serialized and signed by the forging delegate.
 
-Given a data structure `unsignedBlockHeaderData` representing a block header with no `signature` property, the block signature is calculated as follows:
+Given a data structure `unsignedBlockHeaderData` representing a block header for a certain chain with no `signature` property, the block signature is calculated as follows:
 
-1. `unsignedBlockHeaderData` is serialized using the [method explained above](#serialization-1). In particular, the serialized data does not contain the signature.
-2. The block signature is calculated by signing the binary message from step 1.
-3. `unsignedBlockHeaderData.signature` is set to the output of step 2.
+1. `unsignedBlockHeaderData` is serialized using the [method explained above](#serialization-1). In particular, the serialized data does not contain the signature (non-required properties for which no value was provided do not appear in the binary message, as specified in [LIP 0027](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0027.md#uniqueness-of-binary-messages)).
+2. The network identifier of the chain is prepended to the binary message from step 1 as specified in [LIP 0024](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0024.md#update-to-the-block-header-signing-procedure).
+3. The block signature is calculated by signing the binary message from step 2.
+4. `unsignedBlockHeaderData.signature` is set to the output of step 3.
 
 ### Block Signature Validation
 
@@ -201,7 +202,7 @@ Given a binary message `signedBlockHeaderMsg` representing a serialized block he
 1. `signedBlockHeaderMsg` is deserialized using the `blockHeader` schema into  `blockHeaderData`, a data structure representing a signed block header.
 2. The block signature is read from `blockHeaderData.signature` and the `signature` property is then removed from `blockHeaderData`.
 3. `blockHeaderData` is re-serialized according to the [method described above](#serialization-1). In particular, the serialized message does not contain the signature.
-4. The block signature is verified against the output of step 3.
+4. The block signature is verified against the output of step 3 prepended by the chain's network identifier and the generator public key.
 
 ### Block ID
 
@@ -340,6 +341,11 @@ baseBlockSchema = {
 
 ## Appendix B: Serialization Example
 
+In this section, we present a serialization example for a block. To calculate the signature, we use the network identifier:
+`networkID = 9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee`.
+
+#### **Block object to serialize:**
+
 ```js
 blockData = {
   "header": {
@@ -355,11 +361,13 @@ blockData = {
       "maxHeightPrevoted": 10,
       "seedReveal": "8038ec83c421fa4844c5c65995cb2a66"
     },
-    "signature": "bfc186b17132180057c8604640c276b85169fcaba72255bdc24f9220e620aa3e9731e6308a131f87097979e5696a7c38a25212bcb4779b099fab7df576b50207"
+    "signature": "496f6b0789ed060926b200be384ec338a3a711440f699fc7b329139600cc53d352a5d92d39b77d95b5eaf0b6cb75ece0133d8a5c61fdbe2c549358ef72b8eb0e"
   },
   "payload": []
 }
 ```
+
+#### **Serialized block object:**
 
 ```
 blockMsg = {
@@ -376,21 +384,27 @@ blockMsg = {
       10: 0a,
       1a10: 8038ec83c421fa4844c5c65995cb2a66
     },
-    4a40: bfc186b17132180057c8604640c276b85169fcaba72255bdc24f9220e620aa3e9731e6308a131f87097979e5696a7c38a25212bcb4779b099fab7df576b50207
+    4a40: 496f6b0789ed060926b200be384ec338a3a711440f699fc7b329139600cc53d352a5d92d39b77d95b5eaf0b6cb75ece0133d8a5c61fdbe2c549358ef72b8eb0e
   }
 }
 ```
 
+#### **Binary message (175 bytes):**
 ```
-binaryMsg [175 bytes] = 0aac01080310b40118102220e194ce4e908c148ea4d11719cd40a016d07f393d31031ea150d7a8b7904a22d52a003220ed3b9fd50b188d35f5d2ea3fef05cb894363931c5ba50a5967c224ae5b16b3393880c2d72f42160803100a1a108038ec83c421fa4844c5c65995cb2a664a40bfc186b17132180057c8604640c276b85169fcaba72255bdc24f9220e620aa3e9731e6308a131f87097979e5696a7c38a25212bcb4779b099fab7df576b50207
-```
-
-```
-blockID = e4448ec3d3366680ef65f0fbc60d49979361f3c4767f562bad2bb2841fe4702d
+0aac01080310b40118102220e194ce4e908c148ea4d11719cd40a016d07f393d31031ea150d7a8b7904a22d52a003220ed3b9fd50b188d35f5d2ea3fef05cb894363931c5ba50a5967c224ae5b16b3393880c2d72f42160803100a1a108038ec83c421fa4844c5c65995cb2a664a40496f6b0789ed060926b200be384ec338a3a711440f699fc7b329139600cc53d352a5d92d39b77d95b5eaf0b6cb75ece0133d8a5c61fdbe2c549358ef72b8eb0e
 ```
 
+#### **Block ID:**
+
 ```
-privateKey = 13f10fde4d5aa4298fe248707e7ec7392b854cdc1a655c2d67864e4117c4db2eed3b9fd50b188d35f5d2ea3fef05cb894363931c5ba50a5967c224ae5b16b339
+2931050824bda2bbf3e0f186f7b33900052e00a743d88a61afb3bee5ad10c031
+```
+
+#### **Generator key pair:**
+
+```
+private key = 13f10fde4d5aa4298fe248707e7ec7392b854cdc1a655c2d67864e4117c4db2e
+public key = ed3b9fd50b188d35f5d2ea3fef05cb894363931c5ba50a5967c224ae5b16b339
 ```
 
 [generic-serialization]: https://github.com/LiskHQ/lips/blob/master/proposals/lip-0027.md

--- a/proposals/lip-0029.md
+++ b/proposals/lip-0029.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/define-schema-and-use-generic-seriali
 Status: Draft
 Type: Informational
 Created: 2020-02-18
-Updated: 2020-07-21
+Updated: 2021-02-08
 Requires: 0027
 ```
 

--- a/proposals/lip-0030.md
+++ b/proposals/lip-0030.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/define-schema-and-use-generic-seriali
 Status: Draft
 Type: Standards Track
 Created: 2020-02-18
-Updated: 2020-09-02
+Updated: 2021-02-08
 Requires: 0027
 ```
 

--- a/proposals/lip-0030.md
+++ b/proposals/lip-0030.md
@@ -98,7 +98,7 @@ account = {
       "fieldNumber": 5
     }
   },
-  required: ["address", "token", "sequence", "keys", "dpos"]
+  "required": ["address", "token", "sequence", "keys", "dpos"]
 }
 ```
 


### PR DESCRIPTION
Fix the following points:

- include network identifiers in the examples of LIP 28 and 29
- update the signature specification in LIP 28 and LIP 29 such that the netId is used
- private key should have only 32 bytes in the examples of LIP 28 and 29
- fix signature value in example of LIP 29
- fix formatting of LIP 27 in section _Lisk JSON Schemas_
- fix typo in LIP30
