### PR TITLE
Fix username length specification in LIP 0030

### DIFF
--- a/proposals/lip-0030.md
+++ b/proposals/lip-0030.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.io/t/define-schema-and-use-generic-seriali
 Status: Draft
 Type: Standards Track
 Created: 2020-02-18
-Updated: 2021-02-08
+Updated: 2021-04-26
 Requires: 0027
 ```
 

--- a/proposals/lip-0030.md
+++ b/proposals/lip-0030.md
@@ -189,7 +189,7 @@ dposObject = {
 
 The `delegateObject` schema contains the following properties:
 
-1. `username`: A string representing the delegate username, with a minimum length of 1 character and a maximum length of 20 characters.
+1. `username`: A string representing the delegate username. For non-delegate accounts, the string must be empty. For delegate accounts, the string must have a length between 1 and 20 characters.
 2. <code>[pomHeights](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0024.md)</code>: An array containing the heights (in ascending order) at which a Proof-of-Misbehaviour Transaction regarding the delegate has been included in the blockchain.
 3. <code>[consecutiveMissedBlocks](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0023.md)</code>: Number of consecutive blocks missed by the delegate, used to determine if the delegate has to be banned.
 4. <code>[lastForgedHeight](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0023.md)</code>: The height of the last block forged by the delegate, used to determine if the delegate has to be banned.


### PR DESCRIPTION
The `username` property of the `delegateObject` should be the empty string for non-delegate accounts.