### PR TITLE
LIP 0039: fix bytes concatenation symbol

### DIFF
--- a/proposals/lip-0039.md
+++ b/proposals/lip-0039.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-sparse-merkle-trees
 Status: Draft
 Type: Informational
 Created: 2021-04-22
-Updated: 2021-06-08
+Updated: 2021-06-09
 ```
 
 ## Abstract

--- a/proposals/lip-0039.md
+++ b/proposals/lip-0039.md
@@ -27,7 +27,7 @@ In this LIP, we specify the SMT data structure for the Lisk protocol. We do not 
 
 ### General Description and Properties
 
-For the rest of the LIP, we indicate with N the number of elements present in the tree, with L the binary length of a key, with Log the base 2 logarithm, and with the symbol `|` the bytes-concatenation operation.
+For the rest of the LIP, we indicate with N the number of elements present in the tree, with L the binary length of a key, with Log the base 2 logarithm, and with the symbol `||` the bytes-concatenation operation.
 
 A sparse Merkle tree is an authenticated data structure organized as a tree. Unlike regular Merkle trees (specified in [LIP 0031](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0031.md) for the Lisk protocol), a SMT contains a distinct leaf node for every possible key. Therefore, the size of the tree is exponential in the length of the keys. For example, for 32-byte keys, a SMT contains 2<sup>256</sup> leaves and 256 layers. Such an enormous number of nodes cannot actually be generated and stored, hence the tree is only ''simulated''.
 
@@ -99,12 +99,12 @@ Each node in the tree has a `data` and a `hash` property. Leaf nodes store the k
 
 ```java
 leafNode(key, value) = {
-    data: key|value,
+    data: key || value,
     hash: leafHash(data)
 },
 
 branchNode(child1, child2) = {
-    data: child1.hash|child2.hash,
+    data: child1.hash || child2.hash,
     hash: branchHash(data)
 },
 
@@ -116,8 +116,8 @@ defaultEmptyNode() = {
 Similar to what we do for regular Merkle trees, we use a different hash function for leaf and branch nodes to protect against second preimage attacks:
 
 ```java
-leafHash(msg) = hash(LEAF_PREFIX | msg)
-branchHash(msg) = hash(BRANCH_PREFIX | msg).
+leafHash(msg) = hash(LEAF_PREFIX || msg)
+branchHash(msg) = hash(BRANCH_PREFIX || msg).
 ```
 
 Here the function `hash` returns the SHA-256 hash of the input. Leaf nodes are ''hardened'' by hashing their keys together with their values. Otherwise, in a subtree with only one non-empty node several keys would correspond to the same leaf node.
@@ -205,11 +205,11 @@ function update(k, v):
         let p be the element of ancestorNodes at position h-1
         if d == 0:
             let siblingNode be the right child node of p
-            update p.data to bottomNode.hash|siblingNode.hash
+            update p.data to bottomNode.hash || siblingNode.hash
             update p.hash to branchHash(p.data)
         else if d == 1:
             let siblingNode be the left child node of p
-            update p.data to siblingNode.hash|bottomNode.hash
+            update p.data to siblingNode.hash || bottomNode.hash
             update p.hash to branchHash(p.data)
         set bottomNode to p
         set h to h-1
@@ -274,11 +274,11 @@ function remove(k):
 
         if d == 0:
             let siblingNode be the right child node of p
-            update p.data to bottomNode.hash|siblingNode.hash
+            update p.data to bottomNode.hash || siblingNode.hash
             update p.hash to branchHash(p.data)
         else if d == 1:
             let siblingNode be the left child node of p
-            update p.data to siblingNode.hash|bottomNode.hash
+            update p.data to siblingNode.hash || bottomNode.hash
             update p.hash to branchHash(p.data)
         set bottomNode to p
         set h to h-1
@@ -302,7 +302,7 @@ proof={siblingHashes:[cc956a85, 3c516152, e041e1c0, 6400721e, 3c32b131],
            {key:a9, value:9e8e8c37, bitmap:07}]}.
 ```
 
-*Given these keys and values, the hash of the node can be recomputed. For example, to the leaf node with <code>key=00110011</code> corresponds the hash  <code>leafHash(33|4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce) = 00be9f2ec46f47e14965f0cb9903f09bc6fe30244109c7c5310180a2251c75cc</code>.*
+*Given these keys and values, the hash of the node can be recomputed. For example, to the leaf node with <code>key=00110011</code> corresponds the hash  <code>leafHash(33 || 4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce) = 00be9f2ec46f47e14965f0cb9903f09bc6fe30244109c7c5310180a2251c75cc</code>.*
 
 
 #### Proof Construction


### PR DESCRIPTION
Replace `|` --> `||` to indicate bytes concatenation.