### PR TITLE
Update LIP 0050

### DIFF
--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -45,7 +45,7 @@ We define the following constants:
 | Name                            | Type    | Value  | Description                                                                                                |
 |---------------------------------|---------| -------|------------------------------------------------------------------------------------------------------------|
 | `MODULE_ID_LEGACY `             | uint32  | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM `           | uint32  | 1000   | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_RECLAIM `           | uint32  | 0   | Command ID of the reclaim command.                                                                         |
 | `COMMAND_ID_REGISTER_BLS_KEY `  | uint32  | 1      | Command ID of the register BLS key command.                                                                |
 | `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes   | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 


### PR DESCRIPTION
- correct the command ID of the reclaim transaction to `0`.