### PR TITLE
Mention size of public key and signature in LIP 0038

### DIFF
--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -29,7 +29,7 @@ Very recent advancements have pushed the BLS signature scheme to a state that gi
 
 ## Specification
 
-The BLS signature scheme as specified in the IETF draft [BLS Signatures draft-irtf-cfrg-bls-signature-04](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04) is used. More specifically, the ciphersuite [BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-4.2.3) is chosen. This ciphersuite uses the _[proof of possession](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-3.3)_ scheme and the _[minimal-pubkey-size](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.1)_ variant.
+The BLS signature scheme as specified in the IETF draft [BLS Signatures draft-irtf-cfrg-bls-signature-04](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04) is used. More specifically, the ciphersuite [BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-4.2.3) is chosen. This ciphersuite uses the _[proof of possession](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-3.3)_ scheme and the _[minimal-pubkey-size](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.1)_ variant. Public keys use 48 bytes and signatures 96 bytes.
 
 The ciphersuite exposes the following functions:
 

--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bls-signatures/282
 Status: Draft
 Type: Informational
 Created: 2021-04-13
-Updated: 2021-09-24
+Updated: 2021-11-29
 ```
 
 ## Abstract


### PR DESCRIPTION
The size of a public key and a signature were not explicitly stated in LIP 0038 yet. This is done here.