### PR TITLE
Make lip 0044 more precise

### DIFF
--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -443,7 +443,7 @@ This function returns an object whose keys are generator addresses, with value c
 
 ```python
 getGeneratorsBetweenTimestamps(startTimestamp, endTimestamp):
-    if endTimestamp < startTimestamp:
+    if (endTimestamp < startTimestamp) or (startTimestamp < genesisData.timestamp):
         return invalid timestamps error
 
     result = {}

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -54,15 +54,15 @@ In this section, we specify the substores that are part of the Validators module
 
 We define the following constants:
 
-| Name                          | Type    | Value                             | Description                                                                     |
-|-------------------------------|---------|-----------------------------------|---------------------------------------------------------------------------------|
-|`MODULE_ID_VALIDATORS`         | uint32  | TBD                               | ID of the Validators module.                                                    |
-|`STORE_PREFIX_VALIDATORS_DATA` | bytes   | 0x0000                            | Store prefix of the validators data substore.                                   |
-|`STORE_PREFIX_GENERATOR_LIST`  | bytes   | 0x4000                            | Store prefix of the generator list substore.                                    |
-|`STORE_PREFIX_BLS_KEYS`        | bytes   | 0x8000                            | Store prefix of the registered BLS keys substore.                               |
-|`STORE_PREFIX_GENESIS_DATA`    | bytes   | 0xc000                            | Store prefix of the genesis data substore.                                      |
-|`INVALID_BLS_KEY`              | bytes   | 48 bytes all set to 0x00          | An invalid BLS key, used as a placeholder before a valid BLS key is registered. |
-|`BLOCK_TIME`                   | integer | 10 (value for the Lisk mainchain) | Block time (in seconds) set in the chain configuration.                         |
+Name                           | Type    | Value                             | Description
+------------------------------ | ------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`MODULE_ID_VALIDATORS`         | uint32  | TBD                               | ID of the Validators module.
+`STORE_PREFIX_VALIDATORS_DATA` | bytes   | 0x0000                            | Store prefix of the validators data substore.
+`STORE_PREFIX_GENERATOR_LIST`  | bytes   | 0x4000                            | Store prefix of the generator list substore.
+`STORE_PREFIX_BLS_KEYS`        | bytes   | 0x8000                            | Store prefix of the registered BLS keys substore.
+`STORE_PREFIX_GENESIS_DATA`    | bytes   | 0xc000                            | Store prefix of the genesis data substore.
+`INVALID_BLS_KEY`              | bytes   | 48 bytes all set to 0x00          | An invalid BLS key, used as a placeholder before a valid BLS key is registered. It is invalid as deserialization fails since the most significant bit of the first byte is zero while the total length is 48 (see second point [here](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-07#appendix-C.2))
+`BLOCK_TIME`                   | integer | 10 (value for the Lisk mainchain) | Block time (in seconds) set in the chain configuration.
 
 ### Validators Module Store
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -387,7 +387,7 @@ This function returns the slot time corresponding to the input slot number.
 
 ##### Parameters
 
-`slotNumber`: An integer value corresponding to a slot number.
+`slotNumber`: An unsigned integer value corresponding to a slot number.
 
 ##### Returns
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -130,7 +130,7 @@ generatorListSchema = {
 
 ##### Properties and Default values
 
-This substore stores an array of addresses, corresponding to the ordered list of eligible generators for the current round. An address is 20 bytes long. The array is initialized to the initial generator list specified in the genesis block.
+This substore stores an array of addresses, corresponding to the ordered list of eligible generators for the current round. An address is 20 bytes long.
 
 #### Registered BLS Keys Substore
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/introduce-validators-module/317
 Status: Draft
 Type: Standards Track
 Created: 2021-08-06
-Updated: 2021-12-01
+Updated: 2022-02-11
 Requires: 0040
 ```
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -210,7 +210,7 @@ This function has the following input parameters in the order given below:
 
 ##### Returns
 
-* `success`: A boolean, indicating success or failure of the command execution.
+* `success`: A boolean, indicating success or failure of the registration.
 
 ##### Execution
 
@@ -279,7 +279,7 @@ This function has the following input parameters in the order given below:
 
 ##### Returns
 
-* `success`: A boolean, indicating success or failure of the command execution.
+* `success`: A boolean, indicating success or failure of the function execution.
 
 ##### Execution
 
@@ -314,7 +314,7 @@ This function has the following input parameters in the order given below:
 
 ##### Returns
 
-* `success`: A boolean, indicating success or failure of the command execution.
+* `success`: A boolean, indicating success or failure of the function execution.
 
 ##### Execution
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -375,6 +375,8 @@ This function returns an integer, indicating the generator slot number.
 
 ```python
 getSlotNumber(timestamp):
+    if timestamp < genesisData.timestamp:
+        throw an error
     elapsedTime = timestamp - genesisData.timestamp
     return floor(elapsedTime / BLOCK_TIME)
 ```

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -249,7 +249,7 @@ This function returns the validator account corresponding to the input address.
 
 ##### Execution
 
-This function returns `validatorAccount(address)`. If there is no entry corresponding to `address`, it returns an empty object.
+This function returns `validatorAccount(address)`. If there is no entry corresponding to `address`, it returns an empty object. If `address` is not 20 bytes long, an error is thrown.
 
 #### getGenesisData
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -55,13 +55,13 @@ In this section, we specify the substores that are part of the Validators module
 We define the following constants:
 
 Name                           | Type    | Value                             | Description
------------------------------- | ------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------ | ------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 `MODULE_ID_VALIDATORS`         | uint32  | TBD                               | ID of the Validators module.
 `STORE_PREFIX_VALIDATORS_DATA` | bytes   | 0x0000                            | Store prefix of the validators data substore.
 `STORE_PREFIX_GENERATOR_LIST`  | bytes   | 0x4000                            | Store prefix of the generator list substore.
 `STORE_PREFIX_BLS_KEYS`        | bytes   | 0x8000                            | Store prefix of the registered BLS keys substore.
 `STORE_PREFIX_GENESIS_DATA`    | bytes   | 0xc000                            | Store prefix of the genesis data substore.
-`INVALID_BLS_KEY`              | bytes   | 48 bytes all set to 0x00          | An invalid BLS key, used as a placeholder before a valid BLS key is registered. It is invalid as deserialization fails since the most significant bit of the first byte is zero while the total length is 48 (see second point [here](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-07#appendix-C.2))
+`INVALID_BLS_KEY`              | bytes   | 48 bytes all set to 0x00          | An invalid BLS key, used as a placeholder before a valid BLS key is registered. It is invalid as deserialization fails since the most significant bit of the first byte is zero while the total length is 48 (see second point [here](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-07#appendix-C.2)).
 `BLOCK_TIME`                   | integer | 10 (value for the Lisk mainchain) | Block time (in seconds) set in the chain configuration.
 
 ### Validators Module Store

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -132,7 +132,7 @@ generatorListSchema = {
 
 ##### Properties and Default values
 
-This substore stores an array of addresses, corresponding to the list of eligible generators for the current round. An address is 20 bytes long. Note that a position in the generator list does NOT reflect the position in a round. The assignment of a generator for a block slot is defined by the function  [getGeneratorAtTimestamp](#getgeneratorattimestamp).
+This substore stores an array of addresses, corresponding to the list of eligible generators for the current round. An address is 20 bytes long. Note that a position in the generator list does NOT reflect the position in a round. The assignment of a generator for a block slot is defined by the function [getGeneratorAtTimestamp](#getgeneratorattimestamp).
 
 #### Registered BLS Keys Substore
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -403,7 +403,7 @@ getSlotTime(slotNumber):
 
 #### getGeneratorAtTimestamp
 
-This function returns the address of the generator active at the input timestamp. Notice that if the input timestamp corresponds to a time before the beginning of the current round, this function may not return the correct generator address.
+This function returns the address of the generator active at the input timestamp. Notice that if the input timestamp corresponds to a time slot before or after the current round, this function may not return the correct generator address.
 
 ##### Parameters
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -42,7 +42,9 @@ The Validators module store maintains an account for each validator registered i
 
 ### Block Slots
 
-In the Lisk protocol, time is divided into intervals of fixed length. These intervals are called _block slots_ and at most one block can be added to the blockchain during each slot. The length of a block slot is a constant called _block time_. The validator module provides the functions to calculate the block slot given the timestamp and viceversa. Furthermore, it maintains the _generator list_, an array of addresses corresponding to the accounts that are eligible to generate a block in the current round. Each entry of the generator list is assigned to a block slot.
+In the Lisk protocol, time is divided into intervals of fixed length. These intervals are called _block slots_ and at most one block can be added to the blockchain during each slot. The length of a block slot is a constant called _block time_. The validator module provides the functions to calculate the block slot given the timestamp and viceversa.
+
+Furthermore, the validators module maintains the _generator list_, an array of addresses corresponding to the accounts that are eligible to generate a block in the current round. Note that a position in the generator list does NOT reflect the position in a round. For example, when the DPoS module in a DPoS chain provides a generator list `generatorList` via the function [setGeneratorList](#setgeneratorlist), then `generatorList[0]` does not necessarily represent the first generator of the round. Instead, `generatorList[n]` does represent the first generator of the round for an integer `n` with `0 < n < length(generatorList)`, where `n` depends on the number of missed block slots in the past. The block slots of a round are then assigned round-robin using `[generatorList[n], generatorList[n+1], ..., generatorList[-1], generatorList[0], ..., generatorList[n-1]]`. The exact assignment of a generator for a timestamp is defined by the function [getGeneratorAtTimestamp](#getgeneratorattimestamp).
 
 ## Specification
 
@@ -130,7 +132,7 @@ generatorListSchema = {
 
 ##### Properties and Default values
 
-This substore stores an array of addresses, corresponding to the ordered list of eligible generators for the current round. An address is 20 bytes long.
+This substore stores an array of addresses, corresponding to the list of eligible generators for the current round. An address is 20 bytes long. Note that a position in the generator list does NOT reflect the position in a round. The assignment of a generator for a block slot is defined by the function  [getGeneratorAtTimestamp](#getgeneratorattimestamp).
 
 #### Registered BLS Keys Substore
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -424,7 +424,7 @@ getGeneratorAtTimestamp(timestamp):
 
 #### getGeneratorsBetweenTimestamps
 
-This function returns the address of the generators active between the two input timestamps and the number of block slots assigned to them. Notice that if the input timestamps corresponds to times before the beginning of the current round, this function may not return the correct generator addresses.
+This function returns the addresses of the generators active between the two input timestamps and the number of block slots assigned to them. The slots corresponding to the input timestamps are NOT counted, only the slots in between. Notice that for all counted slots, the current `generatorList` must be the used generator list. Otherwise, the behaviour is undefined. It’s the calling module’s responsibility to ensure that. 
 
 ##### Parameters
 
@@ -435,7 +435,7 @@ This function has the following input parameters in the order given below:
 
 ##### Returns
 
-This function returns an object whose keys are generator addresses, with value corresponding to the number of block slots assigned to them in between the input timestamps.
+This function returns an object whose keys are generator addresses, with value corresponding to the number of block slots assigned to them in between the input timestamps, where the slots corresponding to the input timestamps are NOT counted.
 
 ##### Execution
 
@@ -446,8 +446,12 @@ getGeneratorsBetweenTimestamps(startTimestamp, endTimestamp):
 
     result = {}
 
-    startSlotNumber = floor((startTimestamp - genesisData.timestamp) / BLOCK_TIME)
-    endSlotNumber = floor((endTimestamp - genesisData.timestamp) / BLOCK_TIME)
+    startSlotNumber = floor((startTimestamp - genesisData.timestamp) / BLOCK_TIME) + 1
+    endSlotNumber = floor((endTimestamp - genesisData.timestamp) / BLOCK_TIME) - 1
+    
+    if startSlotNumber > endSlotNumber:
+        return result
+    
     totalSlots = endSlotNumber - startSlotNumber + 1
 
     # Quick skip to directly assign many block slots to every generator in the list

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -1119,10 +1119,6 @@ newHeight = b.header.height
 # previousTimestamp is the value in the previous timestamp substore
 missedBlocks = validators.getGeneratorsBetweenTimestamps(previousTimestamp, b.header.timestamp)
 
-# Remove the start and end blocks, as those are not missed
-missedBlocks[validators.getGeneratorAtTimestamp(previousTimestamp)] -= 1
-missedBlocks[validators.getGeneratorAtTimestamp(b.header.timestamp)] -= 1
-
 for address in missedBlocks:
     delegateStore(address).consecutiveMissedBlocks += missedBlocks[address]
 


### PR DESCRIPTION
- Remove an outdated statement about the initialization of the generator list substore
- Improve explanation of `generatorList` and the assignment of a generator for a block slot
- Specify behavior of `getValidatorAccount` for invalid address length
- Specify behavior of `getSlotNumber` for timestamp before genesis block timestamp
- Restrict `getSlotNumber` to unsigned integers
- Fix explanation of `getGeneratorAtTimestamp`
- Change behavior of `getGeneratorsBetweenTimestamps` by not counting the slots corresponding to the input timestamps. Also, adapt its usage in LIP 0057.
 
