### PR TITLE
Add genesis block hooks to lip 0050

### DIFF
--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -219,7 +219,7 @@ getLegacyAccount(publicKey)
 
 Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets for the legacy module and let `genesisBlockAssetObject` be the deserialization of `genesisBlockAssetBytes` according to the `genesisLegacyStoreSchema` schema given below. If the deserialization fails, reject the block.
 
-```json
+```java
 genesisLegacyStoreSchema = {
     "type": "object",
     "required": ["accounts"],

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -86,7 +86,7 @@ This substore contains an entry for each legacy address for which no [reclaim tr
 
 The module store will be initialized with these legacy addresses and their respective balances during the execution of the genesis block.
 
-#### Internal Functions
+### Internal Functions
 
 #### Legacy Addresses
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -28,7 +28,7 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 
 Once [LIP 0018][lip-0018] is active on the Lisk mainchain, all nodes for the Lisk mainchain must maintain the accounts that received some funds before the implementation of [LIP 0018][lip-0018], but do not have an associated public key. The balance of these accounts is maintained in the legacy accounts substore and can be recovered with a reclaim transaction.
 
-Furthermore, delegates registered before the implementation of the [Validators module][research:validator] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process.
+Furthermore, delegates registered before the implementation of the [Validators module][lip-0044] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process.
 
 Implementing the Legacy module avoids the need for other modules (specifically the Token module and the Validators module) to handle legacy behaviors present only on the Lisk mainchain. This module is only part of the Lisk mainchain, and should not be implemented in any sidechain.
 
@@ -146,7 +146,7 @@ When a reclaim transaction `trs` is executed, the following is done:
 
 * Delete the entry from the legacy accounts substore with store key `getLegacyAddress(trs.senderPublicKey)`.
 * Call the function `mint(newAddress, 0, trs.params.amount)`, where `newAddress` is the [20-byte address][lip-0018#addressComputation] derived from `trs.senderPublicKey`.
-  The function `mint` is defined in the [Token module][research:token#mint].
+  The function `mint` is defined in the [Token module][lip-0051#mint].
 
 #### Register BLS Key
 
@@ -178,7 +178,7 @@ registerBLSKeyParamsSchema = {
 
 ##### Execution
 
-Executing a transaction `trs` triggering an register BLS key command is done by calling the function `setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)` where `validatorAddress` is the 20-byte address derived from `trs.senderPublicKey` and `setValidatorBLSKey` is defined in the [Validators module][research:validator#setValidatoBLSKey]. If this function returns false, the transaction is invalid.
+Executing a transaction `trs` triggering an register BLS key command is done by calling the function `setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)` where `validatorAddress` is the 20-byte address derived from `trs.senderPublicKey` and `setValidatorBLSKey` is defined in the [Validators module][lip-0044#setValidatoBLSKey]. If this function returns false, the transaction is invalid.
 
 ### Protocol Logic for Other Modules
 
@@ -262,6 +262,6 @@ TBA
 [lip-0018#AccountsWithoutPKey]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0018.md#accounts-without-public-key
 [lip-0018#addressComputation]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0018.md#address-computation
 [lip-0018#ReclaimTransaction]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0018.md#reclaim-transaction
-[research:token#mint]: https://research.lisk.com/t/define-state-and-state-transitions-of-token-module/295#mint-64
-[research:validator]: https://research.lisk.com/t/introduce-the-validators-module/317
-[research:validator#setValidatoBLSKey]: https://research.lisk.com/t/introduce-the-validators-module/317#setvalidatorblskey-38
+[lip-0044]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md
+[lip-0044#setValidatoBLSKey]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#setvalidatorblskey
+[lip-0051#mint]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#mint-1

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/introduce-legacy-module/319
 Status: Draft
 Type: Standards Track
 Created: 2021-08-18
-Updated: 2021-12-01
+Updated: 2022-02-11
 Requires: 0018
 ```
 
@@ -243,7 +243,9 @@ genesisLegacyStoreSchema = {
     }
 }
 ```
+
 Then, do the following:
+
 - Check if the `address` properties of the entries in `genesisBlockAssetObject.accounts` are pairwise distinct. If not, reject the block.
 - Check if the sum of the `balance` properties of the entries in `genesisBlockAssetObject.accounts` is less than 2<sup>64</sup>. If not, reject the block.
 - For every `account` in `genesisBlockAssetObject.accounts`:

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -245,9 +245,12 @@ genesisLegacyStoreSchema = {
     }
 }
 ```
-Then, for every entry `account` in `genesisBlockAssetObject.accounts`:
-- Check if `account.address` has length 8. If not, reject the block.
-- Create an entry in the legacy accounts substore with `storeKey = account.address` and `storeValue ` being the serialized value of `account.balance` according to `legacyAccountsSchema`.
+Then, do the following:
+- Check if the `address` properties of the entries in `genesisBlockAssetObject.accounts` are pairwise distinct. If not, reject the block.
+- Check if the sum of the `balance` properties of the entries in `genesisBlockAssetObject.accounts` is less than 2<sup>64</sup>. If not, reject the block.
+- For every `account` in `genesisBlockAssetObject.accounts`:
+    - Check if `account.address` has length 8. If not, reject the block.
+    - Create an entry in the legacy accounts substore with `storeKey = account.address` and `storeValue ` being the serialized value of `account.balance` according to `legacyAccountsSchema`.
 
 ## Backwards Compatibility
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -150,7 +150,7 @@ When a reclaim transaction `trs` is executed, the following is done:
 
 #### Register BLS Key
 
-This command allows migrated legacy validators without a BLS key to register one. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transaction executing this command have:
+This command allows migrated legacy validators without a BLS key to register one. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transactions executing this command have:
 
 * `moduleID = MODULE_ID_LEGACY`,
 * `commandID = COMMAND_ID_REGISTER_BLS_KEY`.

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -213,6 +213,42 @@ getLegacyAccount(publicKey)
                 "balance": balance}
 ```
 
+### Genesis Block Processing
+
+#### Genesis State Initialization
+
+Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets for the legacy module and let `genesisBlockAssetObject` be the deserialization of `genesisBlockAssetBytes` according to the `genesisLegacyStoreSchema` schema given below. If the deserialization fails, reject the block.
+
+```json
+genesisLegacyStoreSchema = {
+    "type": "object",
+    "required": ["accounts"],
+    "properties": {
+        "accounts": {
+            "type": "array",
+            "fieldNumber": 1,
+            "items":{
+              "type": "object",
+              "required": ["address", "balance"],
+              "properties": {
+                "address": {
+                  "dataType": "bytes",
+                  "fieldNumber": 1
+                },
+                "balance": {
+                  "dataType": "uint64",
+                  "fieldNumber": 2
+                }
+              }
+            }
+        }
+    }
+}
+```
+Then, for every entry `account` in `genesisBlockAssetObject.accounts`:
+- Check if `account.address` has length 8. If not, reject the block.
+- Create an entry in the legacy accounts substore with `storeKey = account.address` and `storeValue ` being the serialized value of `account.balance` according to `legacyAccountsSchema`.
+
 ## Backwards Compatibility
 
 This LIP defines a new module and specifies its store, which in turn will become part of the state tree and will be authenticated by the state root. As such, it will induce a hardfork.

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -227,19 +227,19 @@ genesisLegacyStoreSchema = {
         "accounts": {
             "type": "array",
             "fieldNumber": 1,
-            "items":{
-              "type": "object",
-              "required": ["address", "balance"],
-              "properties": {
-                "address": {
-                  "dataType": "bytes",
-                  "fieldNumber": 1
-                },
-                "balance": {
-                  "dataType": "uint64",
-                  "fieldNumber": 2
+            "items": {
+                "type": "object",
+                "required": ["address", "balance"],
+                "properties": {
+                    "address": {
+                        "dataType": "bytes",
+                        "fieldNumber": 1
+                    },
+                    "balance": {
+                        "dataType": "uint64",
+                        "fieldNumber": 2
+                    }
                 }
-              }
             }
         }
     }

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -45,7 +45,7 @@ We define the following constants:
 | Name                            | Type    | Value  | Description                                                                                                |
 |---------------------------------|---------| -------|------------------------------------------------------------------------------------------------------------|
 | `MODULE_ID_LEGACY `             | uint32  | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM `           | uint32  | 1000   | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_RECLAIM `           | uint32  | 0      | Command ID of the reclaim command.                                                                         |
 | `COMMAND_ID_REGISTER_BLS_KEY `  | uint32  | 1      | Command ID of the register BLS key command.                                                                |
 | `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes   | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -84,8 +84,6 @@ legacyAccountsSchema = {
 
 This substore contains an entry for each legacy address for which no [reclaim transaction][lip-0018#ReclaimTransaction] was included. See also the [“Accounts without Public Key” section][lip-0018#AccountsWithoutPKey] in [LIP 0018][lip-0018].
 
-The module store will be initialized with these legacy addresses and their respective balances during the execution of the genesis block.
-
 ### Internal Functions
 
 #### Legacy Addresses


### PR DESCRIPTION
Add the _Genesis State Initialization_ section to LIP 0050.

Also, fix the following:
- one header level
- command ID of the _reclaim command_
- outdated links
- typo