### PR TITLE
Update block level logic

### DIFF
--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -722,9 +722,9 @@ In this step the BFT module does not execute any logic. However, the exposed fun
 
 The following steps are executed as part of the (non-genesis) block processing, see [LIP 0055][lip-0055] for details.
 
-#### After Transactions Execution
+#### Before Transactions Execution
 
-After the transactions of a block `b` are executed, the following logic is executed:
+Before the transactions of a block `b` are executed, the following logic is executed:
 
 1. The object `getBlockBFTProperties(b.header)` is added to the beginning of the array `bftVotes.blockBFTInfos`.
 2. If `bftVotes.blockBFTInfos[MAX_LENGTH_BLOCK_BFT_INFOS]` exists, then the corresponding value is removed from the array.

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2022-02-01
+Updated: 2022-03-30
 Requires: 0055, 0056, 0061
 ```
 


### PR DESCRIPTION
To ensure the BFT module block level logic is always executed before the DPoS or PoA logic, we use the *before transactions execution* hook instead of the *after transactions execution* hook.