### PR TITLE
Update LIP0046 for typos

### DIFF
--- a/proposals/lip-0046.md
+++ b/proposals/lip-0046.md
@@ -111,7 +111,7 @@ seedRevealSchema = {
 
 In this section, we describe the properties in the `validatorReveals` array of the seed reveal object:
 
-* `generatorAddress`: The address of the generator of the block. A valid generator address is 16 bytes long.
+* `generatorAddress`: The address of the generator of the block. A valid generator address is 20 bytes long.
 * `seedReveal`: The value revealed by the generator of the block for the commit and reveal process. A valid seed reveal is 16 bytes long.
 * `height`: The height of the block where the generator added their revealed seed.
 * `valid`: The flag stating the validity of `seedReveal` for the random seed computation.

--- a/proposals/lip-0046.md
+++ b/proposals/lip-0046.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-06-30
-Updated: 2021-12-01
+Updated: 2021-05-10
 Requires: 0022, 0040
 ```
 

--- a/proposals/lip-0046.md
+++ b/proposals/lip-0046.md
@@ -111,7 +111,7 @@ seedRevealSchema = {
 
 In this section, we describe the properties in the `validatorReveals` array of the seed reveal object:
 
-* `generatorAddress`: The address of the generator of the block. A valid generator address is 20 bytes long.
+* `generatorAddress`: The address of the generator of the block. A valid generator address is 16 bytes long.
 * `seedReveal`: The value revealed by the generator of the block for the commit and reveal process. A valid seed reveal is 16 bytes long.
 * `height`: The height of the block where the generator added their revealed seed.
 * `valid`: The flag stating the validity of `seedReveal` for the random seed computation.
@@ -209,7 +209,7 @@ isSeedRevealValid(generatorAddress, seedReveal):
 
 #### getRandomBytes
 
-This function is used to return the random seed as a 32-bytes value.
+This function is used to return the random seed as a 16-bytes value.
 
 ##### Parameters
 
@@ -218,7 +218,7 @@ This function is used to return the random seed as a 32-bytes value.
 
 ##### Returns
 
-`randomSeed`: A 32-bytes value representing the random seed.
+`randomSeed`: A 16-bytes value representing the random seed.
 
 ##### Execution
 
@@ -264,7 +264,7 @@ As part of the verification of the `assets` property of a block `b`, the followi
 Let `blockAssetBytes` be the bytes included in the block asset for the Random module:
 
 1. Let `blockAssetObject` be the deserialization of `blockAssetBytes` according to `blockHeaderAssetRandomModule` in the [Block Initialization](#block-initialization) subsection.
-2. The property `blockAssetObject.seedReveal` has to have a length of 20 bytes.
+2. The property `blockAssetObject.seedReveal` has to have a length of 16 bytes.
 
 #### After Transactions Execution
 


### PR DESCRIPTION
The byte size of the seed reveal was wrong in some places, this PR fixes them.