### PR TITLE
Update LIP 0050

### DIFF
--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -72,7 +72,7 @@ This substore contains an array with the addresses and the balances of all legac
 * The store prefix is set to `STORE_PREFIX_LEGACY_ACCOUNTS`.
 * The store key is an 8-byte value representing the legacy address.
 * The store value is set to the serialization using `legacyAccountsSchema` of the balance of the legacy account.
-* Notation: For the rest of this proposal, let `legacyAccounts(legacyAddress)` be the legacy accounts substore with store key `legacyAddress`.
+* Notation: For the rest of this proposal, let `legacyAccounts(legacyAddress)` be the legacy accounts substore entry with store key `legacyAddress`.
 
 ##### JSON Schema
 
@@ -113,6 +113,41 @@ def getLegacyAddress(publicKey: PublicKeyEd25519) -> bytes:
     return reversedEightBytes
 ```
 
+### Events
+
+#### AccountReclaimed
+
+This event has `typeID = TYPE_ID_ACCOUNT_RECLAIM`.
+This event is emitted when a legacy account is reclaimed.
+
+##### Topics
+
+* `legacyAddress`: the legacy address of the reclaimed account.
+* `address`: the address of the reclaimed account.
+
+##### Data
+
+```java
+accountReclaimedEventDataSchema = {
+    "type": "object",
+    "required" = ["legacyAddress", "address", "amount"],
+    "properties": {
+        "legacyAddress": {
+            "dataType": "bytes",
+            "fieldNumber": 1
+        },
+        "address": {
+            "dataType": "bytes",
+            "fieldNumber": 2
+        },
+        "amount": {
+            "dataType": "uint64",
+            "fieldNumber": 3
+        },
+    }
+}
+```
+
 ### Commands
 
 #### Reclaim
@@ -144,7 +179,7 @@ reclaimParamsSchema = {
 ##### Verification
 
 ```python
-def verify(trs) -> NoReturn:
+def verify(trs: Transaction) -> None:
     legacyAddress = getLegacyAddress(trs.senderPublicKey)
     if legacyAccounts(legacyAddress) does not exists :
         raise Exception('Public key does not correspond to a reclaimable account.')
@@ -156,12 +191,26 @@ def verify(trs) -> NoReturn:
 ##### Execution
 
 ```python
-def execute(trs) -> NoReturn:
+def execute(trs: Transaction) -> None:
     legacyAddress = getLegacyAddress(trs.senderPublicKey)
     delete legacyAccounts(legacyAddress) from the legacy accounts substore
 
     newAddress = 20-byte address derived from trs.senderPublicKey
     token.mint(newAddress, LOCAL_ID_LSK, trs.params.amount)
+
+    emitEvent(
+        moduleID=MODULE_ID_LEGACY,
+        typeID=TYPE_ID_ACCOUNT_RECLAIM,
+        topics=[
+            legacyAddress, 
+            newAddress
+        ],
+        data={
+            "legacyAddress": legacyAddress,
+            "address":newAddress,
+            "amount":trs.params.amount
+        }
+    )
 ```
 
 #### Register Keys
@@ -199,7 +248,7 @@ registerBLSKeyParamsSchema = {
 #### Verification
 
 ```python
-def verify(trs) -> NoReturn:
+def verify(trs: Transaction) -> None:
     validatorAddress = 20-byte address derived from trs.senderPublicKey
 
     if validator.getValidatorAccount(validatorAddress) does not exists :
@@ -218,7 +267,7 @@ def verify(trs) -> NoReturn:
 ##### Execution
 
 ```python
-def execute(trs) -> NoReturn:
+def execute(trs: Transaction) -> None:
     validatorAddress = 20-byte address derived from trs.senderPublicKey
         
     if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -47,8 +47,8 @@ We define the following constants:
 | `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
 | `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
 | `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                                   |
-| `TYPE_ID_ACCOUNT_RECLAIM`      | bytes | 0x0000 | The type ID of the account reclaim event.                                                                  |
-| `TYPE_ID_KEYS_REGISTERED`      | bytes | 0x0001 | The type ID of the keys registered event.                                                                  |
+| `TYPE_ID_ACCOUNT_RECLAIM`      | bytes | 0x0001 | The type ID of the account reclaim event.                                                                  |
+| `TYPE_ID_KEYS_REGISTERED`      | bytes | 0x0002 | The type ID of the keys registered event.                                                                  |
 | `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 | `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token.                                                                     |
 | `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain.                                        |

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -150,7 +150,7 @@ When a reclaim transaction `trs` is executed, the following is done:
 
 #### Register Keys
 
-This command allows migrated legacy validators register the required keys. In particular, this command is used by all delegates to register a BLS key. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transactions executing this command have:
+This command allows migrated legacy validators register the required keys. In particular, this command is used by all migrated delegates to register a BLS key. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transactions executing this command have:
 
 * `moduleID = MODULE_ID_LEGACY`,
 * `commandID = COMMAND_ID_REGISTER_KEYS`.

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -46,7 +46,7 @@ We define the following constants:
 |---------------------------------|---------| -------|------------------------------------------------------------------------------------------------------------|
 | `MODULE_ID_LEGACY `             | uint32  | TBD    | Module ID of the Legacy module.                                                                            |
 | `COMMAND_ID_RECLAIM `           | uint32  | 0      | Command ID of the reclaim command.                                                                         |
-| `COMMAND_ID_REGISTER_BLS_KEY `  | uint32  | 1      | Command ID of the register BLS key command.                                                                |
+| `COMMAND_ID_REGISTER_KEYS `     | uint32  | 1      | Command ID of the register keys command.                                                                |
 | `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes   | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 
 #### Functions from Other Modules
@@ -148,12 +148,12 @@ When a reclaim transaction `trs` is executed, the following is done:
 * Call the function `mint(newAddress, 0, trs.params.amount)`, where `newAddress` is the [20-byte address][lip-0018#addressComputation] derived from `trs.senderPublicKey`.
   The function `mint` is defined in the [Token module][lip-0051#mint].
 
-#### Register BLS Key
+#### Register Keys
 
-This command allows migrated legacy validators without a BLS key to register one. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transactions executing this command have:
+This command allows migrated legacy validators register the required keys. In particular, this command is used by all delegates to register a BLS key. This command cannot be used to modify an existing BLS key, as this is forbidden by the Validators module. Transactions executing this command have:
 
 * `moduleID = MODULE_ID_LEGACY`,
-* `commandID = COMMAND_ID_REGISTER_BLS_KEY`.
+* `commandID = COMMAND_ID_REGISTER_KEYS`.
 
 ##### Parameters
 
@@ -171,6 +171,10 @@ registerBLSKeyParamsSchema = {
         "proofOfPossession": {
             "dataType": "bytes",
             "fieldNumber": 2
+        },
+        "generatorKey": {
+            "dataType": "bytes",
+            "fieldNumber": 3
         }
     }
 }
@@ -178,7 +182,25 @@ registerBLSKeyParamsSchema = {
 
 ##### Execution
 
-Executing a transaction `trs` triggering an register BLS key command is done by calling the function `setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)` where `validatorAddress` is the 20-byte address derived from `trs.senderPublicKey` and `setValidatorBLSKey` is defined in the [Validators module][lip-0044#setValidatoBLSKey]. If this function returns false, the transaction is invalid.
+Executing a transaction `trs` triggering an register keys command is done by calling the logic below
+
+```python
+validatorAddress = 20-byte address derived from trs.senderPublicKey
+
+if validator.getValidatorAccount(address) does not exists :
+    trs fails
+    
+if validator.getValidatorAccount(address).generatorKey == INVALID_ED25519_KEY:
+    setGeneratorKey = validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
+elif validator.getValidatorAccount(address).generatorKey == trs.params.generatorKey):
+    setGeneratorKey = True
+    
+setBLSKey = validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
+
+return (setBLSKey and setGeneratorKey)
+```
+
+Those functions are defined in the [Validators module][lip-0044#setValidatoBLSKey]. If the above logic returns false, the transaction is invalid.
 
 ### Protocol Logic for Other Modules
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -201,15 +201,18 @@ def execute(trs: Transaction) -> None:
     emitEvent(
         moduleID=MODULE_ID_LEGACY,
         typeID=TYPE_ID_ACCOUNT_RECLAIM,
+        data=serialize(
+            {
+                "legacyAddress": legacyAddress,
+                "address":newAddress,
+                "amount":trs.params.amount
+            }, 
+            accountReclaimedEventDataSchema
+        ),
         topics=[
             legacyAddress, 
             newAddress
-        ],
-        data={
-            "legacyAddress": legacyAddress,
-            "address":newAddress,
-            "amount":trs.params.amount
-        }
+        ]
     )
 ```
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -28,7 +28,7 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 
 Once [LIP 0018][lip-0018] is active on the Lisk mainchain, all nodes for the Lisk mainchain must maintain the accounts that received some funds before the implementation of [LIP 0018][lip-0018], but do not have an associated public key. The balance of these accounts is maintained in the legacy accounts substore and can be recovered with a reclaim transaction.
 
-Furthermore, delegates registered before the implementation of the [Validators module][lip-0044] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process.
+Furthermore, delegates registered before the implementation of the [Validators module][lip-0044] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process. The same command is also used to allow delegates to set their generator key if it is not set yet.
 
 Implementing the Legacy module avoids the need for other modules (specifically the Token module and the Validators module) to handle legacy behaviors present only on the Lisk mainchain. This module is only part of the Lisk mainchain, and should not be implemented in any sidechain.
 
@@ -295,7 +295,7 @@ This function provides the legacy address and balance of the corresponding legac
 
 ##### Returns
 
-Either an object with the properties `legacyAddress` and `balance`, where `legacyAddress` is the legacy address for `publicKey` and `balance` is the balance of the corresponding legacy account, or `undefined`.
+An object with the properties `legacyAddress` and `balance`, where `legacyAddress` is the legacy address for `publicKey` and `balance` is the balance of the corresponding legacy account, or with `0` balance if the account is not available for reclaim.
 
 ##### Execution
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -28,7 +28,7 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal](https://cre
 
 Once [LIP 0018][lip-0018] is active on the Lisk mainchain, all nodes for the Lisk mainchain must maintain the accounts that received some funds before the implementation of [LIP 0018][lip-0018], but do not have an associated public key. The balance of these accounts is maintained in the legacy accounts substore and can be recovered with a reclaim transaction.
 
-Furthermore, delegates registered before the implementation of the [Validators module][lip-0044] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process. The same command is also used to allow delegates to set their generator key if it is not set yet.
+Furthermore, delegates registered before the implementation of the [Validators module][lip-0044] do not have a registered BLS key. This module implements a command to allow those delegates to register a BLS key and hence participate in the certification generation process. With the same command, delegates can update their generator key, note that this update can only be done once when setting the BLS key.
 
 Implementing the Legacy module avoids the need for other modules (specifically the Token module and the Validators module) to handle legacy behaviors present only on the Lisk mainchain. This module is only part of the Lisk mainchain, and should not be implemented in any sidechain.
 
@@ -159,7 +159,7 @@ accountReclaimedEventDataSchema = {
 #### KeysRegistered
 
 This event has `typeID = TYPE_ID_KEYS_REGISTERED`.
-This event is emitted when a legacy account is reclaimed.
+This event is emitted when validator keys are registered.
 
 ##### Topics
 
@@ -277,7 +277,7 @@ This command allows migrated legacy validators register the required keys. In pa
 The `params` property of a register BLS key transaction must obey the following schema:
 
 ```java
-registerBLSKeyParamsSchema = {
+registerKeysParamsSchema = {
     "type": "object",
     "required": ["blsKey", "proofOfPossession", "generatorKey"],
     "properties": {
@@ -310,7 +310,7 @@ def verify(trs: Transaction) -> None:
     if validator.getValidatorAccount(validatorAddress) does not exists :
         raise Exception('Public key does not correspond to a registered validator.')
 
-    if validatorAccount.blsKey != INVALID_BLS_KEY:
+    if validator.getValidatorAccount(validatorAddress).blsKey != INVALID_BLS_KEY:
         raise Exception('Validator already has a registered keys.')
 ```
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -298,10 +298,10 @@ Either an object with the properties `legacyAddress` and `balance`, where `legac
 ##### Execution
 
 ```python
-def getLegacyAccount(publicKey: PublicKeyEd25519):
+def getLegacyAccount(publicKey: PublicKeyEd25519) -> dict:
     legacyAddress = getLegacyAddress(publicKey)
     if there exists no entry in the legacy accounts substore with store key equal to legacyAddress:
-        return None
+        return {}
     else:
         let balance be the value of the balance property of the legacy accounts substore entry with store key legacyAddress
         return {"legacyAddress": legacyAddress,

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -254,19 +254,14 @@ registerBLSKeyParamsSchema = {
 
 ```python
 def verify(trs: Transaction) -> None:
+    
     validatorAddress = 20-byte address derived from trs.senderPublicKey
 
     if validator.getValidatorAccount(validatorAddress) does not exists :
         raise Exception('Public key does not correspond to a registered validator.')
-        
-    validatorAccount = validator.getValidatorAccount(validatorAddress)
-    if (validatorAccount.generatorKey != INVALID_ED25519_KEY
-        and validatorAccount.generatorKey == trs.params.generatorKey
-    ):
-        raise Exception('Input generator key does not equal the one set in the store.')
 
     if validatorAccount.blsKey != INVALID_BLS_KEY:
-        raise Exception('Validator already has a registered BLS key.')
+        raise Exception('Validator already has a registered keys.')
 ```
 
 ##### Execution
@@ -274,11 +269,10 @@ def verify(trs: Transaction) -> None:
 ```python
 def execute(trs: Transaction) -> None:
     validatorAddress = 20-byte address derived from trs.senderPublicKey
-        
-    if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:
-        validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
 
-    # the call below will raise an exception if the proof of possession is invalid
+    validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
+
+    # the calls below will raise an exception if the proof of possession is invalid
     # with respect to the given BLS key.
     validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
 ```

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -42,19 +42,19 @@ The Legacy module has the module ID `MODULE_ID_LEGACY` (defined in the table bel
 
 We define the following constants:
 
-| Name                            | Type  | Value  | Description                                                                                                |
-|---------------------------------|-------| -------|------------------------------------------------------------------------------------------------------------|
-| `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                             |
-| `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                          |
-| `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                                    |
-| `TYPE_ID_ACCOUNT_RECLAIM`      | bytes | 0x0000 | The type ID of the account reclaim event.                                                                   |
-| `TYPE_ID_KEYS_REGISTERED`      | bytes | 0x0001 | The type ID of the keys registered event.                                                                   |
-| `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts.  |
-| `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token.                                                                      |
-| `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain.                                         |
-| `INVALID_BLS_KEY`              | bytes | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.            |
+| Name                           | Type  | Value  | Description                                                                                                |
+|--------------------------------|-------| -------|------------------------------------------------------------------------------------------------------------|
+| `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
+| `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                                   |
+| `TYPE_ID_ACCOUNT_RECLAIM`      | bytes | 0x0000 | The type ID of the account reclaim event.                                                                  |
+| `TYPE_ID_KEYS_REGISTERED`      | bytes | 0x0001 | The type ID of the keys registered event.                                                                  |
+| `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
+| `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token.                                                                     |
+| `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain.                                        |
+| `INVALID_BLS_KEY`              | bytes | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.             |
 | `INVALID_ED25519_KEY`          | bytes | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
-| `ADDRESS_LEGACY_RESERVE`       | bytes | `SHA-256(b'legacyReserve')[:20]` | The address used to store all tokens of legacy accounts.                        |
+| `ADDRESS_LEGACY_RESERVE`       | bytes | `SHA-256(b'legacyReserve')[:20]` | The address used to store all tokens of legacy accounts.                         |
 
 ### Type Definition
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -49,6 +49,8 @@ We define the following constants:
 | `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
 | `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 | `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token. |
+| `INVALID_BLS_KEY` | bytes   | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.   |
+| `INVALID_ED25519_KEY` | bytes   | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
 
 ### Type Definition
 
@@ -274,7 +276,7 @@ def execute(trs: Transaction) -> None:
     validatorAddress = 20-byte address derived from trs.senderPublicKey
         
     if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:
-        setGeneratorKey = validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
+        validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
 
     # the call below will raise an exception if the proof of possession is invalid
     # with respect to the given BLS key.
@@ -301,7 +303,8 @@ Either an object with the properties `legacyAddress` and `balance`, where `legac
 def getLegacyAccount(publicKey: PublicKeyEd25519) -> dict:
     legacyAddress = getLegacyAddress(publicKey)
     if there exists no entry in the legacy accounts substore with store key equal to legacyAddress:
-        return {}
+        return {"legacyAddress": legacyAddress,
+                "balance": 0}
     else:
         let balance be the value of the balance property of the legacy accounts substore entry with store key legacyAddress
         return {"legacyAddress": legacyAddress,

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -162,7 +162,7 @@ The `params` property of a register BLS key transaction must obey the following 
 ```java
 registerBLSKeyParamsSchema = {
     "type": "object",
-    "required": ["blsKey", "proofOfPossession"],
+    "required": ["blsKey", "proofOfPossession", "generatorKey"],
     "properties": {
         "blsKey": {
             "dataType": "bytes",

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -42,12 +42,20 @@ The Legacy module has the module ID `MODULE_ID_LEGACY` (defined in the table bel
 
 We define the following constants:
 
-| Name                            | Type    | Value  | Description                                                                                                |
-|---------------------------------|---------| -------|------------------------------------------------------------------------------------------------------------|
-| `MODULE_ID_LEGACY `             | bytes  | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM `           | bytes  | 0x0000 | Command ID of the reclaim command.                                                                         |
-| `COMMAND_ID_REGISTER_KEYS `     | bytes  | 0x0001 | Command ID of the register keys command.                                                                |
-| `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes  | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
+| Name                            | Type  | Value  | Description                                                                                                |
+|---------------------------------|-------| -------|------------------------------------------------------------------------------------------------------------|
+| `MODULE_ID_LEGACY `             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
+| `COMMAND_ID_RECLAIM `           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_REGISTER_KEYS `     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
+| `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
+| `LOCAL_ID_LSK`                  | bytes | 0x00000000 | Local identifier of the LSK token. |
+
+### Type Definition
+
+| Name               | Type    | Validation            | Description                     |
+|--------------------|---------|-----------------------|---------------------------------|
+| `PublicKeyEd25519` | bytes   | Must be of length 32. | Used for Ed25519 public keys.   |
+
 
 #### Functions from Other Modules
 
@@ -64,6 +72,7 @@ This substore contains an array with the addresses and the balances of all legac
 * The store prefix is set to `STORE_PREFIX_LEGACY_ACCOUNTS`.
 * The store key is an 8-byte value representing the legacy address.
 * The store value is set to the serialization using `legacyAccountsSchema` of the balance of the legacy account.
+* Notation: For the rest of this proposal, let `legacyAccounts(legacyAddress)` be the legacy accounts substore with store key `legacyAddress`.
 
 ##### JSON Schema
 
@@ -80,7 +89,7 @@ legacyAccountsSchema = {
 }
 ```
 
-##### Properties and Default values
+##### Properties
 
 This substore contains an entry for each legacy address for which no [reclaim transaction][lip-0018#ReclaimTransaction] was included. See also the [“Accounts without Public Key” section][lip-0018#AccountsWithoutPKey] in [LIP 0018][lip-0018].
 
@@ -90,10 +99,6 @@ This substore contains an entry for each legacy address for which no [reclaim tr
 
 Obtaining the legacy 8-byte address from a public key.
 
-##### Parameters
-
-A 32-byte value representing a public key.
-
 ##### Returns
 
 The 8-byte legacy address corresponding to the given input.
@@ -101,7 +106,7 @@ The 8-byte legacy address corresponding to the given input.
 ##### Execution
 
 ```python
-getLegacyAddress(publicKey):
+def getLegacyAddress(publicKey: PublicKeyEd25519) -> bytes:
     hashedKey = SHA-256(publicKey)
     firstEightBytes = first 8 bytes of hashedKey
     reversedEightBytes = firstEightBytes reversed
@@ -138,15 +143,26 @@ reclaimParamsSchema = {
 
 ##### Verification
 
-For a reclaim transaction `trs` to be valid, the legacy accounts substore must contain an entry with store key equal to `getLegacyAddress(trs.senderPublicKey)` and store value `{"balance": trs.params.amount}`, serialized using `legacyAccountsSchema`.
+```python
+def verify(trs) -> NoReturn:
+    legacyAddress = getLegacyAddress(trs.senderPublicKey)
+    if legacyAccounts(legacyAddress) does not exists :
+        raise Exception('Public key does not correspond to a reclaimable account.')
+
+    if legacyAccounts(legacyAddress).balance != trs.params.amount:
+        raise Exception('Input amount does not equal the balance of the legacy account.')
+```
 
 ##### Execution
 
-When a reclaim transaction `trs` is executed, the following is done:
+```python
+def execute(trs) -> NoReturn:
+    legacyAddress = getLegacyAddress(trs.senderPublicKey)
+    delete legacyAccounts(legacyAddress) from the legacy accounts substore
 
-* Delete the entry from the legacy accounts substore with store key `getLegacyAddress(trs.senderPublicKey)`.
-* Call the function `mint(newAddress, 0, trs.params.amount)`, where `newAddress` is the [20-byte address][lip-0018#addressComputation] derived from `trs.senderPublicKey`.
-  The function `mint` is defined in the [Token module][lip-0051#mint].
+    newAddress = 20-byte address derived from trs.senderPublicKey
+    token.mint(newAddress, LOCAL_ID_LSK, trs.params.amount)
+```
 
 #### Register Keys
 
@@ -180,27 +196,38 @@ registerBLSKeyParamsSchema = {
 }
 ```
 
-##### Execution
-
-Executing a transaction `trs` triggering an register keys command is done by calling the logic below.
+#### Verification
 
 ```python
-validatorAddress = 20-byte address derived from trs.senderPublicKey
+def verify(trs) -> NoReturn:
+    validatorAddress = 20-byte address derived from trs.senderPublicKey
 
-if validator.getValidatorAccount(validatorAddress) does not exists :
-    trs fails
-    
-if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:
-    setGeneratorKey = validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
-elif validator.getValidatorAccount(validatorAddress).generatorKey == trs.params.generatorKey):
-    setGeneratorKey = True
-    
-setBLSKey = validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
+    if validator.getValidatorAccount(validatorAddress) does not exists :
+        raise Exception('Public key does not correspond to a registered validator.')
+        
+    validatorAccount = validator.getValidatorAccount(validatorAddress)
+    if (validatorAccount.generatorKey != INVALID_ED25519_KEY
+        and validatorAccount.generatorKey == trs.params.generatorKey
+    ):
+        raise Exception('Input generator key does not equal the one set in the store.')
 
-return (setBLSKey and setGeneratorKey)
+    if validatorAccount.blsKey != INVALID_BLS_KEY:
+        raise Exception('Validator already has a registered BLS key.')
 ```
 
-Those functions are defined in the [Validators module][lip-0044#setValidatoBLSKey]. If the above logic returns false, the transaction is invalid.
+##### Execution
+
+```python
+def execute(trs) -> NoReturn:
+    validatorAddress = 20-byte address derived from trs.senderPublicKey
+        
+    if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:
+        setGeneratorKey = validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
+
+    # the call below will raise an exception if the proof of possession is invalid
+    # with respect to the given BLS key.
+    validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
+```
 
 ### Protocol Logic for Other Modules
 
@@ -212,10 +239,6 @@ This module does not expose any functions.
 
 This function provides the legacy address and balance of the corresponding legacy accounts.
 
-##### Parameters
-
-* inputParameter1: `publicKey`, an Ed25519 public key
-
 ##### Returns
 
 Either an object with the properties `legacyAddress` and `balance`, where `legacyAddress` is the legacy address for `publicKey` and `balance` is the balance of the corresponding legacy account, or `undefined`.
@@ -223,10 +246,10 @@ Either an object with the properties `legacyAddress` and `balance`, where `legac
 ##### Execution
 
 ```python
-getLegacyAccount(publicKey)
-    let legacyAddress be the legacy address of publicKey
+def getLegacyAccount(publicKey: PublicKeyEd25519):
+    legacyAddress = getLegacyAddress(publicKey)
     if there exists no entry in the legacy accounts substore with store key equal to legacyAddress:
-        return undefined
+        return None
     else:
         let balance be the value of the balance property of the legacy accounts substore entry with store key legacyAddress
         return {"legacyAddress": legacyAddress,

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -44,11 +44,11 @@ We define the following constants:
 
 | Name                            | Type  | Value  | Description                                                                                                |
 |---------------------------------|-------| -------|------------------------------------------------------------------------------------------------------------|
-| `MODULE_ID_LEGACY `             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM `           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
-| `COMMAND_ID_REGISTER_KEYS `     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
-| `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
-| `LOCAL_ID_LSK`                  | bytes | 0x00000000 | Local identifier of the LSK token. |
+| `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
+| `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
+| `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
+| `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token. |
 
 ### Type Definition
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -44,15 +44,17 @@ We define the following constants:
 
 | Name                            | Type  | Value  | Description                                                                                                |
 |---------------------------------|-------| -------|------------------------------------------------------------------------------------------------------------|
-| `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                         |
-| `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
-| `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
-| `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token. |
-| `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain. |
-| `INVALID_BLS_KEY`              | bytes   | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.   |
-| `INVALID_ED25519_KEY`          | bytes   | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
-| `ADDRESS_LEGACY_RESERVE`       | bytes   | `SHA-256(b'legacyReserve')[:20]` | The address used to store all tokens of legacy accounts. |
+| `MODULE_ID_LEGACY`             | bytes | TBD    | Module ID of the Legacy module.                                                                             |
+| `COMMAND_ID_RECLAIM`           | bytes | 0x0000 | Command ID of the reclaim command.                                                                          |
+| `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                                    |
+| `TYPE_ID_ACCOUNT_RECLAIM`      | bytes | 0x0000 | The type ID of the account reclaim event.                                                                   |
+| `TYPE_ID_KEYS_REGISTERED`      | bytes | 0x0001 | The type ID of the keys registered event.                                                                   |
+| `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts.  |
+| `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token.                                                                      |
+| `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain.                                         |
+| `INVALID_BLS_KEY`              | bytes | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.            |
+| `INVALID_ED25519_KEY`          | bytes | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
+| `ADDRESS_LEGACY_RESERVE`       | bytes | `SHA-256(b'legacyReserve')[:20]` | The address used to store all tokens of legacy accounts.                        |
 
 ### Type Definition
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -49,8 +49,10 @@ We define the following constants:
 | `COMMAND_ID_REGISTER_KEYS`     | bytes | 0x0001 | Command ID of the register keys command.                                                               |
 | `STORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 | `LOCAL_ID_LSK`                 | bytes | 0x00000000 | Local identifier of the LSK token. |
-| `INVALID_BLS_KEY` | bytes   | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.   |
-| `INVALID_ED25519_KEY` | bytes   | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
+| `TOKEN_ID_LSK_MAINCHAIN`       | bytes | 8 bytes all set to `0`  | Identifier of the LSK token on the Lisk mainchain. |
+| `INVALID_BLS_KEY`              | bytes   | 48 bytes all set to `0` | The BLS public key set during the migration for validators without a BLS key.   |
+| `INVALID_ED25519_KEY`          | bytes   | 32 bytes all set to `255` | The Ed25519 public key set during the migration for validators without a generator key. |
+| `ADDRESS_LEGACY_RESERVE`       | bytes   | `SHA-256(b'legacyReserve')[:20]` | The address used to store all tokens of legacy accounts. |
 
 ### Type Definition
 
@@ -136,10 +138,12 @@ accountReclaimedEventDataSchema = {
     "properties": {
         "legacyAddress": {
             "dataType": "bytes",
+            "length": 8,
             "fieldNumber": 1
         },
         "address": {
             "dataType": "bytes",
+            "length": 20,
             "fieldNumber": 2
         },
         "amount": {
@@ -198,7 +202,11 @@ def execute(trs: Transaction) -> None:
     delete legacyAccounts(legacyAddress) from the legacy accounts substore
 
     newAddress = 20-byte address derived from trs.senderPublicKey
-    token.mint(newAddress, LOCAL_ID_LSK, trs.params.amount)
+    # Unlock the tokens in the legacy reserve account and transfer them to the 
+    # account reclaiming the tokens.
+    token.unlock(ADDRESS_LEGACY_RESERVE, MODULE_ID_LEGACY, TOKEN_ID_LSK_MAINCHAIN, trs.params.amount)
+
+    token.transfer(ADDRESS_LEGACY_RESERVE, newAddress, TOKEN_ID_LSK_MAINCHAIN, trs.params.amount)
 
     emitEvent(
         moduleID=MODULE_ID_LEGACY,
@@ -236,14 +244,17 @@ registerBLSKeyParamsSchema = {
     "properties": {
         "blsKey": {
             "dataType": "bytes",
+            "length": 48,
             "fieldNumber": 1
         },
         "proofOfPossession": {
             "dataType": "bytes",
+            "length": 96,
             "fieldNumber": 2
         },
         "generatorKey": {
             "dataType": "bytes",
+            "length": 32,
             "fieldNumber": 3
         }
     }
@@ -254,7 +265,7 @@ registerBLSKeyParamsSchema = {
 
 ```python
 def verify(trs: Transaction) -> None:
-    
+
     validatorAddress = 20-byte address derived from trs.senderPublicKey
 
     if validator.getValidatorAccount(validatorAddress) does not exists :
@@ -325,6 +336,7 @@ genesisLegacyStoreSchema = {
                 "properties": {
                     "address": {
                         "dataType": "bytes",
+                        "length": 8,
                         "fieldNumber": 1
                     },
                     "balance": {
@@ -342,8 +354,8 @@ Then, do the following:
 
 - Check if the `address` properties of the entries in `genesisBlockAssetObject.accounts` are pairwise distinct. If not, reject the block.
 - Check if the sum of the `balance` properties of the entries in `genesisBlockAssetObject.accounts` is less than 2<sup>64</sup>. If not, reject the block.
+- Check if the sum of the `balance` properties of the entries in `genesisBlockAssetObject.accounts` equals `token.getLockedAmount(ADDRESS_LEGACY_RESERVE, MODULE_ID_LEGACY, TOKEN_ID_LSK_MAINCHAIN)`.
 - For every `account` in `genesisBlockAssetObject.accounts`:
-    - Check if `account.address` has length 8. If not, reject the block.
     - Create an entry in the legacy accounts substore with `storeKey = account.address` and `storeValue ` being the serialized value of `account.balance` according to `legacyAccountsSchema`.
 
 ## Backwards Compatibility

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -44,10 +44,10 @@ We define the following constants:
 
 | Name                            | Type    | Value  | Description                                                                                                |
 |---------------------------------|---------| -------|------------------------------------------------------------------------------------------------------------|
-| `MODULE_ID_LEGACY `             | uint32  | TBD    | Module ID of the Legacy module.                                                                            |
-| `COMMAND_ID_RECLAIM `           | uint32  | 0      | Command ID of the reclaim command.                                                                         |
-| `COMMAND_ID_REGISTER_KEYS `     | uint32  | 1      | Command ID of the register keys command.                                                                |
-| `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes   | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
+| `MODULE_ID_LEGACY `             | bytes  | TBD    | Module ID of the Legacy module.                                                                            |
+| `COMMAND_ID_RECLAIM `           | bytes  | 0x0000 | Command ID of the reclaim command.                                                                         |
+| `COMMAND_ID_REGISTER_KEYS `     | bytes  | 0x0001 | Command ID of the register keys command.                                                                |
+| `STORE_PREFIX_LEGACY_ACCOUNTS ` | bytes  | 0x0000 | Store prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
 
 #### Functions from Other Modules
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -330,7 +330,7 @@ def execute(trs: Transaction) -> None:
         typeID=TYPE_ID_KEYS_REGISTERED,
         data=encode(
             schema=keysRegisteredEventDataSchema,
-            data={
+            object={
                 "address": validatorAddress,
                 "generatorKey": trs.params.generatorKey,
                 "blsKey": trs.params.blsKey

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/introduce-legacy-module/319
 Status: Draft
 Type: Standards Track
 Created: 2021-08-18
-Updated: 2022-02-11
+Updated: 2022-06-17
 Requires: 0018
 ```
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -62,7 +62,6 @@ We define the following constants:
 |--------------------|---------|-----------------------|---------------------------------|
 | `PublicKeyEd25519` | bytes   | Must be of length 32. | Used for Ed25519 public keys.   |
 
-
 #### Functions from Other Modules
 
 Calling a function `fct` from another module (named `moduleName`) is represented by `moduleName.fct(required inputs)`.
@@ -241,7 +240,7 @@ def execute(trs: Transaction) -> None:
     delete legacyAccounts(legacyAddress) from the legacy accounts substore
 
     newAddress = 20-byte address derived from trs.senderPublicKey
-    # Unlock the tokens in the legacy reserve account and transfer them to the 
+    # Unlock the tokens in the legacy reserve account and transfer them to the
     # account reclaiming the tokens.
     token.unlock(ADDRESS_LEGACY_RESERVE, MODULE_ID_LEGACY, TOKEN_ID_LSK_MAINCHAIN, trs.params.amount)
 
@@ -259,7 +258,7 @@ def execute(trs: Transaction) -> None:
             }
         ),
         topics=[
-            legacyAddress, 
+            legacyAddress,
             newAddress
         ]
     )
@@ -322,7 +321,7 @@ def execute(trs: Transaction) -> None:
 
     validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
 
-    # the calls below will raise an exception if the proof of possession is invalid
+    # The calls below will raise an exception if the proof of possession is invalid
     # with respect to the given BLS key.
     validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
     emitEvent(
@@ -337,7 +336,7 @@ def execute(trs: Transaction) -> None:
             }
         ),
         topics=[
-            validatorAddress, 
+            validatorAddress,
             trs.params.generatorKey,
             trs.params.blsKey
         ]

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -182,17 +182,17 @@ registerBLSKeyParamsSchema = {
 
 ##### Execution
 
-Executing a transaction `trs` triggering an register keys command is done by calling the logic below
+Executing a transaction `trs` triggering an register keys command is done by calling the logic below.
 
 ```python
 validatorAddress = 20-byte address derived from trs.senderPublicKey
 
-if validator.getValidatorAccount(address) does not exists :
+if validator.getValidatorAccount(validatorAddress) does not exists :
     trs fails
     
-if validator.getValidatorAccount(address).generatorKey == INVALID_ED25519_KEY:
+if validator.getValidatorAccount(validatorAddress).generatorKey == INVALID_ED25519_KEY:
     setGeneratorKey = validator.setValidatorGeneratorKey(validatorAddress, trs.params.generatorKey)
-elif validator.getValidatorAccount(address).generatorKey == trs.params.generatorKey):
+elif validator.getValidatorAccount(validatorAddress).generatorKey == trs.params.generatorKey):
     setGeneratorKey = True
     
 setBLSKey = validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -154,6 +154,43 @@ accountReclaimedEventDataSchema = {
 }
 ```
 
+#### KeysRegistered
+
+This event has `typeID = TYPE_ID_KEYS_REGISTERED`.
+This event is emitted when a legacy account is reclaimed.
+
+##### Topics
+
+* `address`: the address sending the command.
+* `generatorKey`: the registered generator key.
+* `blsKey`: the registered BLS key.
+
+##### Data
+
+```java
+keysRegisteredEventDataSchema = {
+    "type": "object",
+    "required" = ["address", "generatorKey", "blsKey"],
+    "properties": {
+        "address": {
+            "dataType": "bytes",
+            "length": 20,
+            "fieldNumber": 1
+        },
+        "generatorKey": {
+            "dataType": "bytes",
+            "length": 32,
+            "fieldNumber": 2
+        },
+        "blsKey": {
+            "dataType": "bytes",
+            "length": 48,
+            "fieldNumber": 3
+        },
+    }
+}
+```
+
 ### Commands
 
 #### Reclaim
@@ -286,6 +323,23 @@ def execute(trs: Transaction) -> None:
     # the calls below will raise an exception if the proof of possession is invalid
     # with respect to the given BLS key.
     validator.setValidatorBLSKey(validatorAddress, trs.params.proofOfPossession, trs.params.blsKey)
+    emitEvent(
+        moduleID=MODULE_ID_LEGACY,
+        typeID=TYPE_ID_KEYS_REGISTERED,
+        data=serialize(
+            {
+                "address": validatorAddress,
+                "generatorKey": trs.params.generatorKey,
+                "blsKey": trs.params.blsKey
+            }, 
+            keysRegisteredEventDataSchema
+        ),
+        topics=[
+            validatorAddress, 
+            trs.params.generatorKey,
+            trs.params.blsKey
+        ]
+    )
 ```
 
 ### Protocol Logic for Other Modules

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -250,13 +250,13 @@ def execute(trs: Transaction) -> None:
     emitEvent(
         moduleID=MODULE_ID_LEGACY,
         typeID=TYPE_ID_ACCOUNT_RECLAIM,
-        data=serialize(
-            {
+        data=encode(
+            schema=accountReclaimedEventDataSchema,
+            object={
                 "legacyAddress": legacyAddress,
                 "address":newAddress,
                 "amount":trs.params.amount
-            }, 
-            accountReclaimedEventDataSchema
+            }
         ),
         topics=[
             legacyAddress, 
@@ -328,13 +328,13 @@ def execute(trs: Transaction) -> None:
     emitEvent(
         moduleID=MODULE_ID_LEGACY,
         typeID=TYPE_ID_KEYS_REGISTERED,
-        data=serialize(
-            {
+        data=encode(
+            schema=keysRegisteredEventDataSchema,
+            data={
                 "address": validatorAddress,
                 "generatorKey": trs.params.generatorKey,
                 "blsKey": trs.params.blsKey
-            }, 
-            keysRegisteredEventDataSchema
+            }
         ),
         topics=[
             validatorAddress, 


### PR DESCRIPTION
The register BLS key command is updated to also allow the update of the generator key, in case the latter was not set by the migration.
If the generator key was already set during the migration, the public key given in the parameters must equal the one in the state store.

