### PR TITLE
Update LIP0040

### DIFF
--- a/proposals/lip-0040.md
+++ b/proposals/lip-0040.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/state-model-and-state-root
 Status: Draft
 Type: Informational
 Created: 2021-05-22
-Updated: 2021-12-01
+Updated: 2022-06-23
 Requires: 0039
 ```
 


### PR DESCRIPTION
Update LIP 40 to specify module IDs as type bytes. We may consider changing the length as well.