### PR TITLE
Improve fee system

### DIFF
--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -69,11 +69,6 @@ This property defines the set of eligible [BLS public keys][lip-0038] with their
 
 The `certificateThreshold` property is an integer setting the required cumulative weight needed for a certificate signature from the sidechain to be valid.
 
-##### sidechainRegistrationFee
-
-The `sidechainRegistrationFee` property accounts for the extra fee required to register the sidechain. It should be set to the value of the `REGISTRATION_FEE` constant.
-
-
 ### Mainchain Registration on a Sidechain
 
 Once the sidechain has been registered on the mainchain, a similar registration process should happen in the sidechain before the interoperable channel is opened between the two chains. This is done by submitting a transaction with the mainchain registration command in the sidechain, which implies the creation of a _mainchain account_ in the sidechain state associated with the Lisk mainchain and other structures needed for interoperability. This mainchain account has a similar structure as the one depicted in Figure 1. By protocol, the chain ID of the mainchain is a constant equal to `CHAIN_ID_MAINCHAIN` in the ecosystem.
@@ -132,8 +127,7 @@ sidechainRegParams = {
         "name",
         "chainID",
         "initValidators",
-        "certificateThreshold",
-        "sidechainRegistrationFee"
+        "certificateThreshold"
     ],
     "properties": {
         "name": {
@@ -169,10 +163,6 @@ sidechainRegParams = {
         "certificateThreshold": {
             "dataType": "uint64",
             "fieldNumber": 4
-        },
-        "sidechainRegistrationFee": {
-            "type": "uint64",
-            "fieldNumber": 5
         }
     }
 }
@@ -232,13 +222,9 @@ def verify(trs: Transaction) -> None:
     if trs.params.certificateThreshold > totalWeight:
         raise Exception("Certificate threshold is too large.")
 
-    # sidechainRegistrationFee must equal REGISTRATION_FEE.
-    if trs.params.sidechainRegistrationFee != REGISTRATION_FEE:
-        raise Exception("Invalid extra command fee.")
-    # Sender must have enough balance to pay for extra command fee.
-    senderAddress = sha256(trs.senderPublicKey)[:ADDRESS_LENGTH]
-    if Token.getAvailableBalance(senderAddress, TOKEN_ID_LSK_MAINCHAIN) < REGISTRATION_FEE:
-        raise Exception("Sender does not have enough balance.")
+    # Transaction fee has to be greater or equal than the registration fee.
+    if trs.fee < REGISTRATION_FEE:
+        raise Exception("Insufficient transaction fee.")
 ```
 
 #### Execution
@@ -302,8 +288,8 @@ def execute(trs: Transaction) -> None:
         storeKey = trs.params.name
         storeValue = encode(chainIDSchema, {"chainID": chainID})
 
-    # Burn the registration fee.
-    Token.burn(senderAddress, TOKEN_ID_LSK_MAINCHAIN, REGISTRATION_FEE)
+    # Pay the registration fee.
+    Fee.payFee(REGISTRATION_FEE)
 
     # Emit chain account updated event.
     emitEvent(

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -57,6 +57,8 @@ We define the following constants:
 | `MIN_FEE_PER_BYTE` | uint64 | 1000 | Minimum amount of fee per byte required for transaction validity. |
 | `TOKEN_ID_FEE` | bytes | `TOKEN_ID_LSK = 0x0000000000000000` | Token ID of the token used to pay the transaction fees. |
 
+Furthermore, for the rest of this LIP we indicate with `ctx` the execution context which is passed as extra input to each method call.
+
 ### Fee Module Store
 
 The Fee module does not store information in the state.
@@ -67,9 +69,9 @@ The Fee module does not contain any commands.
 
 ### Event
 
-#### FeeProcessed
+#### GeneratorFeeProcessed
 
-This event has name `name = EVENT_NAME_FEE_PROCESSED`. The event is emitted each time when a transaction fee is processed. Event's data includes the amount of burnt fee tokens and the amount of fee tokens paid to the block generator.
+This event has name `name = EVENT_NAME_GENERATOR_FEE_PROCESSED`. The event is emitted when a transaction fee is assigned to the generator. Event's data includes the amount of burnt fee tokens and the amount of fee tokens paid to the block generator.
 
 ##### Topics
 
@@ -79,7 +81,7 @@ This event has name `name = EVENT_NAME_FEE_PROCESSED`. The event is emitted each
 ##### Data
 
 ```java
-feeProcessedEventDataSchema = {
+generatorFeeProcessedEventDataSchema = {
     "type": "object",
     "required" = ["senderAddress", "generatorAddress", "burntAmount", "generatorAmount"],
     "properties": {
@@ -99,15 +101,91 @@ feeProcessedEventDataSchema = {
         },
         "generatorAmount": {
             "dataType": "uint64",
-            "fieldNumber": 3
+            "fieldNumber": 4
         }
     }
 }
 ```
 
+#### RelayerFeeProcessed
+
+This event has name `name = EVENT_NAME_RELAYER_FEE_PROCESSED`. The event is emitted when a message fee is assigned to the CCU relayer. Event's data includes the amount of burnt fee tokens and the amount of fee tokens paid to the relayer.
+
+##### Topics
+
+- `relayerAddress`: the address of the relayer.
+
+##### Data
+
+```java
+relayerFeeProcessedEventDataSchema = {
+    "type": "object",
+    "required" = ["ccmID", "relayerAddress", "burntAmount", "relayerAmount"],
+    "properties": {
+        "ccmID": {
+            "dataType": "bytes",
+            "length": LENGTH_HASH,
+            "fieldNumber": 1
+        },
+        "relayerAddress": {
+            "dataType": "bytes",
+            "length": LENGTH_ADDRESS,
+            "fieldNumber": 2
+        },
+        "burntAmount": {
+            "dataType": "uint64",
+            "fieldNumber": 3
+        },
+        "relayerAmount": {
+            "dataType": "uint64",
+            "fieldNumber": 4
+        }
+    }
+}
+```
+
+#### InsuffiecientFeeAvailable
+
+This event has name `name = EVENT_NAME_INSUFFICIENT_FEE`. The event is emitted when there is not enough transaction or cross-chain message fee left.
+
+##### Topics
+
+This event has no extra topics (only the default transaction or cross-chain message ID).
+
+##### Data
+
+This event has an empty data field.
+
 ### Protocol Logic for Other Modules
 
-The Fee module does not expose any functions.
+```python
+def payFee(amount: uint64) -> None:
+    # ccm.ccmProcessing is set by the Interoperability module during the CCM processing.
+    # In particular, before the CCM is processed, ccm.ccmProcessing is set to True.
+    # After the CCM is processed, ccm.ccmProcessing is set to False.
+    if ctx.ccmProcessing:
+        ctx.availableCCMFee -= amount
+        if ctx.availableCCMFee < 0:
+            ctx.availableCCMFee = 0
+            emitPersistentEvent(
+                module = MODULE_NAME_FEE,
+                name = EVENT_NAME_INSUFFICIENT_FEE,
+                data = {},
+                topics = []
+            )
+            raise Exception("Cross-chain message ran out of fee.")
+    else:
+        ctx.availableTransactionFee -= amount
+        if ctx.availableTransactionFee < 0:
+            ctx.availableTransactionFee = 0
+            emitPersistentEvent(
+                module = MODULE_NAME_FEE,
+                name = EVENT_NAME_INSUFFICIENT_FEE,
+                data = {},
+                topics = []
+            )
+            raise Exception("Transaction ran out of fee.")
+```
 
 ### Block Processing
 
@@ -119,7 +197,7 @@ def verify(trs: Transaction) -> None:
     minFee = MIN_FEE_PER_BYTE * trsSize
     if trs.fee < minFee:
          raise Exception("Insufficient transaction fee")
-    senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     balance = Token.getAvailableBalance(senderAddress, TOKEN_ID_FEE)
     if trs.fee > balance:
         raise Exception("Insufficient balance")
@@ -129,33 +207,82 @@ def verify(trs: Transaction) -> None:
 
 ```python
 def beforeCommandExecute(trs: Transaction) -> None:
-    let b be the block including trs
-    trsSize = length(encodeTransaction(trs))
-    minFee = MIN_FEE_PER_BYTE * trsSize
-    senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
-    generatorAddress = b.header.generatorAddress
+    senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    Token.lock(senderAddress, MODULE_NAME_FEE, TOKEN_ID_FEE, trs.fee)
+    minFee = MIN_FEE_PER_BYTE * len(encodeTransaction(trs))
+    ctx.availableTransactionFee = trs.fee - minFee
+```
 
-    Token.burn(senderAddress,
-               TOKEN_ID_FEE,
-               minFee)
-    Token.transfer(senderAddress,
-                   generatorAddress,
-                   TOKEN_ID_FEE,
-                   trs.fee - minFee)
+The function `Token.lock` is defined in the [Token module][lip-0051]. Burning the fee was specified in [LIP 0013][lip-0013].
+
+#### After Command Execution
+
+```python
+def afterCommandExecute(trs: Transaction) -> None:
+    let b be the block including trs
+    generatorAddress = sha256(b.generatorPublicKey)[:LENGTH_ADDRESS]
+    senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    # The fee paid to the generator is the difference between the fee paid by the sender and the paid fees
+    Token.unlock(senderAddress, MODULE_NAME_FEE, TOKEN_ID_FEE, trs.fee)
+    Token.burn(senderAddress, TOKEN_ID_FEE, trs.fee - ctx.availableTransactionFee)
+    Token.transfer(senderAddress, generatorAddress, TOKEN_ID_FEE, ctx.availableTransactionFee)
+    
     emitEvent(
         module = MODULE_NAME_FEE,
-        name = EVENT_NAME_FEE_PROCESSED,
+        name = EVENT_NAME_GENERATOR_FEE_PROCESSED,
         data = {
             "senderAddress": senderAddress,
             "generatorAddress": generatorAddress,
-            "burntAmount": minFee,
-            "generatorAmount": trs.fee - minFee
+            "burntAmount": trs.fee - ctx.availableTransactionFee,
+            "generatorAmount": ctx.availableTransactionFee
         },
         topics = [senderAddress, generatorAddress]
     )
+    ctx.availableTransactionFee = 0
 ```
 
-The functions `Token.burn` and `Token.transfer` are defined in the [Token module][lip-0051]. Burning the fee was specified in [LIP 0013][lip-0013].
+### Cross-chain Update Processing
+
+#### Before Cross-chain Command Execution
+
+```python
+def beforeCrossChainCommandExecute(trs: Transaction, ccm: CCM) -> None:
+    # The Token module handles checks on the ccm.fee validity
+    # with respect to the escrow account of the ccm sending chain.
+    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+
+    # The Token module beforeCrossChainCommandExecute needs to be called first
+    # to ensure that the relayer has enough funds.
+    Token.lock(relayerAddress, MODULE_NAME_FEE, messageFeeTokenID, ccm.fee)
+    ctx.availableCCMFee = ccm.fee
+```
+
+#### After Cross-chain Command Execution
+
+```python
+def afterCrossChainCommandExecute(trs: Transaction, ccm: CCM) -> None:
+    # The fee paid to the relayer is the difference between the message fee and the paid fees
+    relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    Token.unlock(relayerAddress, MODULE_NAME_FEE, messageFeeTokenID, ccm.fee)
+    Token.burn(relayerAddress, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
+    # No need to transfer as the remaining fee is already in the relayer account.
+    ccmID = sha256(encodeCCM(ccm))
+    emitEvent(
+        module = MODULE_NAME_FEE,
+        name = EVENT_NAME_RELAYER_FEE_PROCESSED,
+        data = {
+            "ccmID": ccmID,
+            "relayerAddress": relayerAddress,
+            "burntAmount": ccm.fee - ctx.availableCCMFee,
+            "relayerAmount": ctx.availableCCMFee
+        },
+        topics = [relayerAddress]
+    )
+    ctx.availableCCMFee = 0
+```
+
 
 ### Endpoints for Off-Chain Services
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -189,13 +189,36 @@ crossChainMessageSchema = {
 
 The `module` and `crossChainCommand` properties can only contain alphanumeric characters.
 
+### Serialization
+
+The serialization of an object of type `CCM` is described in the following pseudocode.
+
+```python
+def encodeCCM(ccm: CCM) -> bytes:
+    paramsSchema = JSON schema corresponding to (ccm.module, ccm.crossChainCommand) pair
+    ccm.params = encode(paramsSchema,ccm.params)
+    return encode(crossChainMessageSchema, ccm)
+```
+
+### Deserialization
+
+Consider a binary message `ccmBytes`, corresponding to a serialized cross-chain message. The deserialization procedure is as follows:
+
+```python
+def decodeCCM(ccmBytes: bytes) -> CCM:
+    ccm = decode(crossChainMessageSchema, ccmBytes)
+    paramsSchema = JSON schema corresponding to (ccm.module, ccm.crossChainCommand) pair
+    ccm.params = decode(paramsSchema, ccm.params)
+    return ccm
+```
+
 ### Cross-chain Message ID
 
 The ID of a cross-chain message `ccm` is computed as `sha256(encode(crossChainMessageSchema, ccm))`.
 
 ### Internal Functions
 
-When processing a cross-chain message `ccm`, the functions below may be called by commands from the Interoperability module. Recall that `chainAccount(chainID)` returns the corresponding entry in the chain data substore, and `ownChainAccount` returns the object stored in the own chain account substore.
+When processing a cross-chain message `ccm`, the functions below may be called by commands from the Interoperability module. Recall that `chainAccount(chainID)` returns the corresponding entry in the chain data substore.
 
 #### validateFormat
 

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -115,7 +115,7 @@ As of writing this proposal, other modules exist in the Lisk protocol that make 
 
 * The voting process should use the `lock` and `unlock` function to lock and unlock voted tokens.
 * Block rewards should be assigned using the `mint` function.
-* The fee handling should use the `transfer` function to transfer the fee from the transaction sender to the block forger and, on the Lisk mainchain, the `burn` function to burn the minimum part of the fee.
+* The fee handling should use the `lock` function to lock the transaction fee in the sender account, the `transfer` function to transfer the remaining fee to the block forger and, on the Lisk mainchain, and the `burn` function to burn the used part of the fee.
 
 ## Specification
 
@@ -135,7 +135,6 @@ The following constants are used throughout the document:
 | `CCM_STATUS_OK` | uint32 | 0 |
 | `CCM_STATUS_TOKEN_NOT_SUPPORTED` | uint32 | 64 |
 | `CCM_STATUS_PROTOCOL_VIOLATION` | uint32 | 65 |
-| `CCM_STATUS_INSUFFICIENT_INIT_FEE` | uint32 | 66 |
 | `TOKEN_ID_LSK` | bytes | 0x 00 00 00 00 00 00 00 00 |
 | `ALL_SUPPORTED_TOKENS_KEY` | bytes | `EMPTY_BYTES` |
 | **Token Store Constants** | | |
@@ -146,17 +145,15 @@ The following constants are used throughout the document:
 | **Configurable Constants** | | Mainchain value |
 | `USER_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 |
 | `ESCROW_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 |
-| `FEE_CCM_INIT_USER_ACCOUNT` | uint64 | 5000000 |
-| `TOKEN_ID_STORE_INITIALIZATION` | bytes | `TOKEN_ID_LSK` |
 | **General Constants** | | |
 | `OWN_CHAIN_ID` | bytes | `chainID` of the chain. |
-| `TOKEN_ID_FEE` | bytes | Defined by the [fee module][lip-0048]. |
 | `ADDRESS_LENGTH` | uint32 | 20 |
 | `MIN_MODULE_NAME_LENGTH` | uint32 | 1 |
 | `MAX_MODULE_NAME_LENGTH` | uint32 | 32 |
 | `TOKEN_ID_LENGTH` | uint32 | 8 |
 | `CHAIN_ID_LENGTH` | uint32 | 4 |
 | `LOCAL_ID_LENGTH` | uint32 | 4 |
+| `HASH_LENGTH`     | uint32 | 32|
 | `MAX_DATA_LENGTH` | uint32 | 64 |
 | `EMPTY_BYTES` | bytes | "" |
 
@@ -187,20 +184,18 @@ The following constants are used throughout the document:
 | **Result codes** | | | |
 | `RESULT_SUCCESSFUL` | uint32 | 0 | Successful result code for events. |
 | `RESULT_INSUFFICIENT_BALANCE` | uint32 | 1 | Used when there is not sufficient balance in the user substore. |
-| `RESULT_RECIPIENT_NOT_INITIALIZED` | uint32 | 2 | Used when the recipient token store entry does not exist. |
-| `INVALID_INITIALIZATION_FEE_VALUE` | uint32 | 3 | Used when the specified user/store store initialization fee value is invalid. |
-| `DATA_TOO_LONG` | uint32 | 4 | Used when the data input is too long. |
-| `ESCROW_NOT_INITIALIZED` | uint32 | 5 | Used when the receiving chain's entry in escrow substore does not exist. |
-| `INVALID_TOKEN_ID` | uint32 | 6 | Used when the token is not native to either the sending chain, the receiving chain or the mainchain. |
-| `TOKEN_NOT_SUPPORTED` | uint32 | 7 | Used when the token is not supported in the chain. |
-| `INSUFFICIENT_LOCKED_AMOUNT` | uint32 | 8 | Used when the locked amount is insufficient. |
-| `RECOVER_FAIL_INVALID_INPUTS` | uint32 | 9 | Used when the recover function fails because of invalid inputs. |
-| `RECOVER_FAIL_INSUFFICIENT_ESCROW` | uint32 | 10 | Used when the recover function fails because of insufficient escrow. |
-| `MINT_FAIL_NON_NATIVE_TOKEN` | uint32 | 11 | Used when the mint function fails because the token to be minted is not native to the chain. |
-| `MINT_FAIL_TOTAL_SUPPLY_TOO_BIG` | uint32 | 12 | Used when the mint function fails because the total supply of the minted token would exceed uint64 range. |
-| `MINT_FAIL_TOKEN_NOT_INITIALIZED` | uint32 | 13 | Used when the mint function fails because the token to be minted is not initialized. |
-| `TOKEN_ID_NOT_AVAILABLE` | uint32 | 14 | Used when the specified token ID is not available. |
-| `INSUFFICIENT_ESCROW_BALANCE` | uint32 | 15 | Used when the escrowed account does not have sufficient balance. |
+| `DATA_TOO_LONG` | uint32 | 2 | Used when the data input is too long. |
+| `INVALID_TOKEN_ID` | uint32 | 3 | Used when the token is not native to either the sending chain, the receiving chain or the mainchain. |
+| `TOKEN_NOT_SUPPORTED` | uint32 | 4 | Used when the token is not supported in the chain. |
+| `INSUFFICIENT_LOCKED_AMOUNT` | uint32 | 5 | Used when the locked amount is insufficient. |
+| `RECOVER_FAIL_INVALID_INPUTS` | uint32 | 6 | Used when the recover function fails because of invalid inputs. |
+| `RECOVER_FAIL_INSUFFICIENT_ESCROW` | uint32 | 7 | Used when the recover function fails because of insufficient escrow. |
+| `MINT_FAIL_NON_NATIVE_TOKEN` | uint32 | 8 | Used when the mint function fails because the token to be minted is not native to the chain. |
+| `MINT_FAIL_TOTAL_SUPPLY_TOO_BIG` | uint32 | 9 | Used when the mint function fails because the total supply of the minted token would exceed uint64 range. |
+| `MINT_FAIL_TOKEN_NOT_INITIALIZED` | uint32 | 10 | Used when the mint function fails because the token to be minted is not initialized. |
+| `TOKEN_ID_NOT_AVAILABLE` | uint32 | 11 | Used when the specified token ID is not available. |
+| `TOKEN_ID_NOT_NATIVE` | uint32 | 12 | Used when the specified token ID is not native to the chain. |
+| `INSUFFICIENT_ESCROW_BALANCE` | uint32 | 12 | Used when the escrowed account does not have sufficient balance. |
 
 ### Type Definition
 
@@ -385,8 +380,7 @@ transferParamsSchema = {
         "tokenID",
         "amount",
         "recipientAddress",
-        "data",
-        "accountInitializationFee"
+        "data"
     ],
     "properties": {
         "tokenID": {
@@ -407,43 +401,19 @@ transferParamsSchema = {
             "dataType": "string",
             "maxLength": MAX_DATA_LENGTH,
             "fieldNumber": 4
-        },
-        "accountInitializationFee": {
-            "dataType": "uint64",
-            "fieldNumber": 5
         }
     }
 }
 ```
-
-The property `accountInitializationFee` is of interest only in cases where there is no entry `userStore(recipientAddress, tokenID)` and the sender needs to pay a fee for the creation of this entry. In such cases, it should have value `USER_ACCOUNT_INITIALIZATION_FEE`. The token for this fee is `TOKEN_ID_STORE_INITIALIZATION`; by default it is the token used for transaction fees in the chain, i.e., `TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_FEE`. In case the entry `userStore(recipientAddress, tokenID)` already exists and the sender of the transaction sets a non-zero amount for this property, then sender's account is not debited.
 
 ##### Verification
 
 ```python
 def verify(trs: Transaction):
     senderAddress = SHA256(trs.senderPublicKey)[:ADDRESS_LENGTH] # Derive sender address from trs.senderPublicKey.
-    tokenID = trs.params.tokenID
-    recipientAddress = trs.params.recipientAddress
-    amount = trs.params.amount
 
-    balanceChecks: dict[TokenID, uint64] = {}
-
-    # Check whether account initialization fee is relevant.
-    if  userStore(recipientAddress, tokenID) does not exist:
-        if trs.params.accountInitializationFee != USER_ACCOUNT_INITIALIZATION_FEE:
-            raise Exception("Invalid account initialization fee")
-
-        balanceChecks[TOKEN_ID_STORE_INITIALIZATION] = USER_ACCOUNT_INITIALIZATION_FEE
-
-    if tokenID in balanceChecks:
-        balanceChecks[tokenID] += amount
-    else:
-        balanceChecks[tokenID] = amount
-
-    for tkID in balanceChecks:
-        if availableBalance(senderAddress, tkID) < balanceChecks[tkID]:
-            raise Exception("Insufficient balance")
+    if availableBalance(senderAddress, trs.params.tokenID) < trs.params.amount:
+        raise Exception("Insufficient balance")
 ```
 
 ##### Execution
@@ -455,16 +425,16 @@ def execute(trs: Transaction):
     recipientAddress = trs.params.recipientAddress
     amount = trs.params.amount
 
-    if userStore(recipientAddress, tokenID) does not exist: # Initialize user substore if does not exist.
+    if userStore(recipientAddress, tokenID) does not exist:         # Initialize user substore if does not exist.
         initializeUserAccountInternal(
-            address = recipientAddress,
-            tokenID = tokenID,
-            initPayingAddress = senderAddress
-       )
-
+            address = recipientAddress, 
+            tokenID = tokenID
+        )
+            
     transferInternal(senderAddress, recipientAddress, tokenID, amount)    
 ```
 Here, the [initializeUserAccountInternal](#initializeuseraccountinternal) function creates an entry in the user substore and the [transferInternal](#transferinternal) function debits sender's account and credits recipient's account.
+
 
 #### Cross-chain Token Transfer
 
@@ -486,8 +456,7 @@ crossChainTransferParamsSchema = {
         "receivingChainID",
         "recipientAddress",
         "data",
-        "messageFee",
-        "escrowInitializationFee"
+        "messageFee"
     ],
     "properties": {
         "tokenID": {
@@ -517,16 +486,10 @@ crossChainTransferParamsSchema = {
         "messageFee": {
             "dataType": "uint64",
             "fieldNumber": 6
-        },
-        "escrowInitializationFee": {
-            "dataType": "uint64",
-            "fieldNumber": 7
         }
     }
 }
 ```
-
-The property `escrowInitializationFee` is of interest only in cases where the token sent is native to the chain and there is no entry `escrowStore(receivingChainID, tokenID)`, so the sender needs to pay a fee for the creation of this entry. In such cases, it should have value `ESCROW_ACCOUNT_INITIALIZATION_FEE`. The token for this fee is `TOKEN_ID_STORE_INITIALIZATION`; by default it is the token used for transaction fees in the chain, i.e., `TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_FEE`. In case the entry `escrowStore(receivingChainID, tokenID)` already exists and the sender of the transaction sets a non-zero amount for this property, then sender's account is not debited.
 
 ##### Verification
 
@@ -546,13 +509,6 @@ def verify(trs: Transaction) -> None:
         raise Exception("Token must be native to either the sending or the receiving chain or the mainchain.")
 
     balanceChecks: dict[TokenID, uint64] = {}
-
-    # Check whether escrow initialization fee is relevant.
-    if tokenChainID == OWN_CHAIN_ID and escrowStore(receivingChainID, tokenID) does not exist:
-        if trs.params.escrowInitializationFee != ESCROW_ACCOUNT_INITIALIZATION_FEE:
-            raise Exception("Invalid escrow initialization fee")
-
-        balanceChecks[TOKEN_ID_STORE_INITIALIZATION] = ESCROW_ACCOUNT_INITIALIZATION_FEE
 
     if tokenID in balanceChecks:
         balanceChecks[tokenID] += amount
@@ -581,13 +537,12 @@ def execute(trs: Transaction) -> None:
     recipientAddress = trs.params.recipientAddress
     messageFee = trs.params.messageFee,
     data = trs.params.data
-    escrowInitializationFee = trs.params.escrowInitializationFee
 
     tokenChainID = getChainID(tokenID)    
 
     # Create entry in escrow substore if necessary, this also debits the sender's account.
     if tokenChainID == OWN_CHAIN_ID and escrowStore(receivingChainID, tokenID) does not exist:
-        initializeEscrowAccountInternal(receivingChainID, tokenID, senderAddress)
+        initializeEscrowAccountInternal(receivingChainID, tokenID)
 
     transferCrossChainInternal(senderAddress, tokenID, amount, receivingChainID, recipientAddress, messageFee, data)
 ```
@@ -688,7 +643,7 @@ def execute(ccu: Transaction, ccm: CCM)-> None:
                 "receivingChainID": OWN_CHAIN_ID,
                 "result": TOKEN_NOT_SUPPORTED
             },
-            topics=[senderAddress, recipientAddress, OWN_CHAIN_ID]
+            topics=[senderAddress, recipientAddress]
         )
         raise Exception("Non-supported token.")
 
@@ -699,13 +654,8 @@ def execute(ccu: Transaction, ccm: CCM)-> None:
     # Check if the receiving account exists
     # and deduct the account initialization fee (from the relayer) if it does not.
     if userStore(recipientAddress, tokenID) does not exist:
-        if ccm.fee < FEE_CCM_INIT_USER_ACCOUNT:
-            raise Exception("Insufficient fee to initialize user account.")
-        else:
-            # Note that if  the relayer does not have enough balance, burn will raise exception.
-            relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
-            burn(relayerAddress, TOKEN_ID_FEE, USER_ACCOUNT_INITIALIZATION_FEE)
-
+        initializeUserAccountInternal(recipientAddress, tokenID)
+        
     if tokenChainID == OWN_CHAIN_ID:
         escrowAmount(sendingChainID, tokenID) -= amount
 
@@ -721,7 +671,7 @@ def execute(ccu: Transaction, ccm: CCM)-> None:
             "receivingChainID": receivingChainID,
             "result": RESULT_SUCCESSFUL
         },
-        topics=[senderAddress, recipientAddress, OWN_CHAIN_ID]
+        topics=[senderAddress, recipientAddress]
     )
 ```
 
@@ -840,7 +790,6 @@ This event has `name = EVENT_NAME_CCM_TRANSFER`. This event is emitted during th
 
 * `senderAddress`: the address of the account sending the transfer.
 * `recipientAddress`: the address of the account receiving the tokens.
-* `receivingChainID`: the chain ID where the tokens are transferred.
 
 ##### Data
 
@@ -1107,7 +1056,7 @@ This event has `name = EVENT_NAME_INITIALIZE_USER_ACCOUNT`. This event is emitte
 ```java
 initUserEventDataSchema = {
     "type": "object",
-    "required" = ["address", "tokenID", "initPayingAddress", "initializationFee" , "result"],
+    "required" = ["address", "tokenID", "initializationFee", "result"],
     "properties": {
         "address": {
             "dataType": "bytes",
@@ -1118,11 +1067,6 @@ initUserEventDataSchema = {
             "dataType": "bytes",
             "length": TOKEN_ID_LENGTH,
             "fieldNumber": 2
-        },
-        "initPayingAddress": {
-            "dataType": "bytes",
-            "length": ADDRESS_LENGTH,
-            "fieldNumber": 3
         },
         "initializationFee": {
             "dataType": "uint64",
@@ -1149,7 +1093,7 @@ This event has `name = EVENT_NAME_INITIALIZE_ESCROW_ACCOUNT`. This event is emit
 ```java
 initEscrowEventDataSchema = {
     "type": "object",
-    "required" = ["chainID", "tokenID", "initPayingAddress", "initializationFee" , "result"],
+    "required" = ["chainID", "tokenID", "initializationFee" , "result"],
     "properties": {
         "chainID": {
             "dataType": "bytes",
@@ -1160,11 +1104,6 @@ initEscrowEventDataSchema = {
             "dataType": "bytes",
             "length": TOKEN_ID_LENGTH,
             "fieldNumber": 2
-        },
-        "initPayingAddress": {
-            "dataType": "bytes",
-            "length": ADDRESS_LENGTH,
-            "fieldNumber": 3
         },
         "initializationFee": {
             "dataType": "uint64",
@@ -1227,7 +1166,7 @@ This event has `name = EVENT_NAME_BEFORE_CCC_EXECUTION`. This event is emitted d
 ##### Topics
 
 * `relayerAddress`: the address of the account that posted the cross-chain update transaction which includes this CCM.
-* `messageFeeTokenID`: the tokenID of the token used for message fees.
+* `messageFeeTokenID`: the tokenID of the token used for message fees. 
 
 ##### Data
 
@@ -1235,41 +1174,30 @@ This event has `name = EVENT_NAME_BEFORE_CCC_EXECUTION`. This event is emitted d
 beforeCCCExecutionEventDataSchema = {
     "type": "object",
     "required" = [
-        "sendingChainID",
-        "receivingChainID",
-        "messageFeeTokenID",
-        "messageFee",
+        "ccmID",
+        "messageFeeTokenID", 
         "relayerAddress",
         "result"
     ],
     "properties": {
-        "sendingChainID": {
+        "ccmID": {
             "dataType": "bytes",
-            "length": CHAIN_ID_LENGTH,
+            "length": HASH_LENGTH,
             "fieldNumber": 1
-        },
-        "receivingChainID": {
-            "dataType": "bytes",
-            "length": CHAIN_ID_LENGTH,
-            "fieldNumber": 2
         },
         "messageFeeTokenID": {
             "dataType": "bytes",
             "length": TOKEN_ID_LENGTH,
-            "fieldNumber": 3
-        },
-        "messageFee": {
-            "dataType": "uint64",
-            "fieldNumber": 4
+            "fieldNumber": 2
         },
         "relayerAddress": {
             "dataType": "bytes",
             "length": ADDRESS_LENGTH,
-            "fieldNumber": 5
+            "fieldNumber": 3
         },
         "result": {
             "dataType": "uint32",
-            "fieldNumber": 6
+            "fieldNumber": 4
         }
     }
 }
@@ -1290,35 +1218,24 @@ This event has `name = EVENT_NAME_BEFORE_CCM_FORWARDING`. This event is emitted 
 beforeCCMForwardingEventDataSchema = {
     "type": "object",
     "required" = [
-        "sendingChainID",
-        "receivingChainID",
+        "ccmID",
         "messageFeeTokenID",
-        "messageFee",
         "result"
     ],
     "properties": {
-        "sendingChainID": {
+        "ccmID": {
             "dataType": "bytes",
-            "length": CHAIN_ID_LENGTH,
+            "length": HASH_LENGTH,
             "fieldNumber": 1
-        },
-        "receivingChainID": {
-            "dataType": "bytes",
-            "length": CHAIN_ID_LENGTH,
-            "fieldNumber": 2
         },
         "messageFeeTokenID": {
             "dataType": "bytes",
             "length": TOKEN_ID_LENGTH,
-            "fieldNumber": 3
-        },
-        "messageFee": {
-            "dataType": "uint64",
-            "fieldNumber": 4
+            "fieldNumber": 2
         },
         "result": {
             "dataType": "uint32",
-            "fieldNumber": 5
+            "fieldNumber": 3
         }
     }
 }
@@ -1423,13 +1340,12 @@ tokenIDSupportRemovedEventDataSchema = {
 
 ```python
 def initializeEscrowAccountInternal(
-    chainID: ChainID,
-    tokenID: TokenID,
-    initPayingAddress: Address
+    chainID: ChainID, 
+    tokenID: TokenID
     ) -> None:
 
-    # Burn the initialization fee and create an entry in the escrow substore.
-    burn(initPayingAddress, TOKEN_ID_STORE_INITIALIZATION, ESCROW_ACCOUNT_INITIALIZATION_FEE)
+    # This may fail if there is not enough fee left.
+    Fee.payFee(ESCROW_ACCOUNT_INITIALIZATION_FEE)
 
     create an escrow substore entry with
         key = chainID + tokenID
@@ -1441,7 +1357,6 @@ def initializeEscrowAccountInternal(
         data={
             "chainID": chainID,
             "tokenID": tokenID,
-            "initPayingAddress": initPayingAddress,
             "initializationFee": ESCROW_ACCOUNT_INITIALIZATION_FEE,
             "result": RESULT_SUCCESSFUL
         },
@@ -1453,14 +1368,13 @@ def initializeEscrowAccountInternal(
 
 ```python
 def initializeUserAccountInternal(
-    address: Address,
-    tokenID: TokenID,
-    initPayingAddress: Address
+    address: Address, 
+    tokenID: TokenID
     ) -> None:
-
-    # Burn the initialization fee and create an entry in the user substore.
-    burn(initPayingAddress, TOKEN_ID_STORE_INITIALIZATION, USER_ACCOUNT_INITIALIZATION_FEE)
-
+    
+    # This may fail if there is not enough fee left.
+    Fee.payFee(USER_ACCOUNT_INITIALIZATION_FEE) 
+    
     create a user substore entry with
         key = address + tokenID
         value = encode(
@@ -1477,41 +1391,11 @@ def initializeUserAccountInternal(
         data={
             "address": address,
             "tokenID": tokenID,
-            "initPayingAddress": initPayingAddress,
             "initializationFee":USER_ACCOUNT_INITIALIZATION_FEE,
             "result": RESULT_SUCCESSFUL
         },
         topics=[address]
     )
-```
-
-#### isTokenSupported
-
-```python
-def isTokenSupported(tokenID: TokenID) -> bool:
-    chainID = getChainID(tokenID)
-
-    # Native tokens and LSK token are always supported.
-    if chainID == OWN_CHAIN_ID or tokenID == TOKEN_ID_LSK:
-        return True
-
-    if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
-        return True
-
-    if supportedTokens(chainID) exists:
-        if supportedTokens(chainID).supportedTokenIDs == []:
-            return True
-        if tokenID is in supportedTokens(chainID).supportedTokenIDs:
-            return True
-
-    return False
-```
-
-#### getChainID
-
-```python
-def getChainID(tokenID: TokenID) -> ChainID:
-    return tokenID[:CHAIN_ID_LENGTH]
 ```
 
 #### transferInternal
@@ -1598,6 +1482,36 @@ def transferCrossChainInternal(
 
 The Token module provides the following methods to modify the token state. Any other modules should use those to modify the token state. The token state should never be modified from outside the module without using one of the proposed functions as this could result in unexpected behavior and could cause an improper state transition.
 
+
+#### isTokenSupported
+
+```python
+def isTokenSupported(tokenID: TokenID) -> bool:
+    chainID = getChainID(tokenID)
+
+    # Native tokens and LSK token are always supported.
+    if chainID == OWN_CHAIN_ID or tokenID == TOKEN_ID_LSK:
+        return True
+
+    if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
+        return True
+
+    if supportedTokens(chainID) exists:
+        if supportedTokens(chainID).supportedTokenIDs == []:
+            return True
+        if tokenID is in supportedTokens(chainID).supportedTokenIDs:
+            return True
+
+    return False
+```
+
+#### getChainID
+
+```python
+def getChainID(tokenID: TokenID) -> ChainID:
+    return tokenID[:CHAIN_ID_LENGTH]
+```
+
 #### isNativeToken
 
 ```python
@@ -1644,7 +1558,7 @@ def getTotalSupply(tokenID: TokenID) -> uint64:
 def getEscrowedAmount(escrowChainID: ChainID, tokenID: TokenID) -> uint64:
     if getChainID(tokenID) != OWN_CHAIN_ID:
         raise Exception("Token ID is not from the current chain")
-
+    
     return escrowAmount(escrowChainID, tokenID)
 ```
 
@@ -1672,10 +1586,6 @@ def getNextAvailableTokenID() -> TokenID:
 
 ```python
 def isTokenIDAvailable(tokenID: TokenID) -> bool:
-    tokenChainID = getChainID(tokenID)
-    if tokenChainID != OWN_CHAIN_ID:
-        raise Exception('Invalid chain ID')
-
     if there exists an entry supplyStore(tokenID) in the supply substore:
         return False
 
@@ -1686,8 +1596,19 @@ def isTokenIDAvailable(tokenID: TokenID) -> bool:
 
 ```python
 def initializeToken(tokenID: TokenID) -> None:
-
-    if isTokenAvailable(tokenID) == False:
+    tokenChainID = getChainID(tokenID)
+    if tokenChainID != OWN_CHAIN_ID:
+        emitPersistentEvent(
+            module=MODULE_NAME_TOKEN,
+            name=EVENT_NAME_INITIALIZE_TOKEN,
+            data={
+                "tokenID": tokenID
+                "result": TOKEN_ID_NOT_NATIVE
+            },
+            topics=[tokenID]
+        )
+        raise Exception('The specified token ID is not native to the current chain.')
+    if isTokenIDAvailable(tokenID) == False:
             emitPersistentEvent(
                 module=MODULE_NAME_TOKEN,
                 name=EVENT_NAME_INITIALIZE_TOKEN,
@@ -1698,7 +1619,7 @@ def initializeToken(tokenID: TokenID) -> None:
                 topics=[tokenID]
             )
 
-        raise Exception('The specified tokenID is not available')
+        raise Exception('The specified token ID is not available.')
 
     # Create a supply substore entry for this tokenID.
     create an entry in the supply substore with
@@ -1736,13 +1657,12 @@ def mint(
         emitFailedMintEvent(address, tokenID, amount, MINT_FAIL_TOKEN_NOT_INITIALIZED)
         raise Exception('No entry in supply substore for the specified token.')
 
-    if userStore(address, tokenID) does not exist:
-        emitFailedMintEvent(address, tokenID, amount, RESULT_RECIPIENT_NOT_INITIALIZED)
-        raise Exception('Recipient does not have an account for the specified token.')
-
-    if totalSupply(tokenID) + amount >= 2^64:
+    if totalSupply(tokenID) + amount >= 2**64:
         emitFailedMintEvent(address, tokenID, amount, MINT_FAIL_TOTAL_SUPPLY_TOO_BIG)
         raise Exception('Total supply of token outside allowed range.')
+
+    if userStore(address, tokenID) does not exist:
+        initializeUserAccountInternal(address, tokenID)
 
     availableBalance(address, tokenID) += amount
     totalSupply(tokenID) += amount
@@ -1824,106 +1744,35 @@ def burn(
 
 ```python
 def initializeUserAccount(
-    address: Address,
-    tokenID: TokenID,
-    initPayingAddress: Address,
-    initializationFee: uint64
+    address: Address, 
+    tokenID: TokenID
 ) -> None:
-
-    ### Checks ###
 
     # If the store entry already exists, nothing is done.
     if userStore(address, tokenID) exists:
-        return
+        return 
 
-    # Check if initializationFee value is valid.
-    if initializationFee != USER_ACCOUNT_INITIALIZATION_FEE:
-        emitFailedUserStoreEvent(address, tokenID, initPayingAddress, initializationFee, INVALID_INITIALIZATION_FEE_VALUE)
-        raise Exception("Invalid account initialization fee")
-
-    # Check available balance of the address creating the new account.
-    if availableBalance(initPayingAddress, TOKEN_ID_STORE_INITIALIZATION) < initializationFee:
-        emitFailedUserStoreEvent(address, tokenID, initPayingAddress, initializationFee, RESULT_INSUFFICIENT_BALANCE)
-        raise Exception("Insufficient balance to pay for initialization fee.")
-
-    ### End of checks ###
-
-    initializeUserAccountInternal(address, tokenID, initPayingAddress)
-
-def emitFailedUserStoreEvent(
-    address: Address,
-    tokenID: TokenID,
-    initPayingAddress: Address,
-    initializationFee: uint64,
-    result: uint32) -> None:
-
-    emitPersistentEvent(
-        module=MODULE_NAME_TOKEN,
-        name=EVENT_NAME_INITIALIZE_USER_ACCOUNT,
-        data={
-            "address": address,
-            "tokenID": tokenID,
-            "initPayingAddress": initPayingAddress,
-            "initializationFee":initializationFee,
-            "result": result
-        },
-        topics=[address]
-    )
+    initializeUserAccountInternal(address, tokenID)
 ```
+
 
 #### initializeEscrowAccount
 
 ```python
 def initializeEscrowAccount(
-    chainID: ChainID,
-    tokenID: TokenID,
-    initPayingAddress: Address,
-    initializationFee: uint64
+    chainID: ChainID, 
+    tokenID: TokenID
 ) -> None:
 
-    ### Checks ###
-    tokenChainID = getChainID(tokenID)
-
-    # Escrow can be initialized only for native tokens.
-    if OWN_CHAIN_ID != tokenChainID:
-        raise Exception('Token is not native, can not create an entry in escrow substore')    
+    # escrow can be initialized only for native tokens
+    if OWN_CHAIN_ID != getChainID(tokenID):
+        raise Exception('Token is not native, cannot create an entry in escrow substore')    
 
     # If the store entry already exists, nothing is done.
     if escrowStore(chainID, tokenID) exists:
-        return
-
-    # Check if initializationFee value is valid.
-    if initializationFee != ESCROW_ACCOUNT_INITIALIZATION_FEE:
-        emitFailedEscrowStoreEvent(chainID, tokenID, initPayingAddress, initializationFee, INVALID_INITIALIZATION_FEE_VALUE)
-        raise Exception("Invalid escrow initialization fee")
-
-    # Check available balance of the address creating the new account.
-    if availableBalance(initPayingAddress, TOKEN_ID_STORE_INITIALIZATION) < initializationFee:
-        emitFailedEscrowStoreEvent(chainID, tokenID, initPayingAddress, initializationFee, RESULT_INSUFFICIENT_BALANCE)
-        raise Exception("Insufficient balance to pay for initialization fee.")
-    ### End of checks ###
-
-    initializeEscrowAccountInternal(chainID, tokenID, initPayingAddress)
-
-def emitFailedEscrowStoreEvent(
-    chainID: ChainID,
-    tokenID: TokenID,
-    initPayingAddress: Address,
-    initializationFee: uint64,
-    result: uint32) -> None:
-
-    emitPersistentEvent(         
-        module=MODULE_NAME_TOKEN,
-        name=EVENT_NAME_INITIALIZE_ESCROW_ACCOUNT,
-        data={
-            "chainID": chainID,
-            "tokenID": tokenID,
-            "initPayingAddress": initPayingAddress,
-            "initializationFee":initializationFee,
-            "result": result
-        },
-        topics=[chainID]
-    )
+        return 
+ 
+    initializeEscrowAccountInternal(chainID, tokenID)
 ```
 
 #### transfer
@@ -1942,9 +1791,11 @@ def transfer(
         raise Exception("Insufficient sender available balance.")
 
     if userStore(recipientAddress, tokenID) does not exist:
-        emitFailedTransferEvent(senderAddress, recipientAddress, tokenID, amount, RESULT_RECIPIENT_NOT_INITIALIZED)
-        raise Exception("Recipient does not have an account for the specified token.")
-    ### End of checks ###
+        initializeUserAccountInternal(
+            address = recipientAddress, 
+            tokenID = tokenID
+        )
+    ### end of checks ####
 
     transferInternal(senderAddress, recipientAddress, tokenID, amount)
 
@@ -1990,13 +1841,8 @@ def transferCrossChain(
     if len(data) > MAX_DATA_LENGTH:
         emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, DATA_TOO_LONG)
         raise Exception("Data field too long.")
-
-    # Check if there is escrow substore entry.
-    if tokenChainID == OWN_CHAIN_ID and escrowStore(receivingChainID, tokenID) does not exist:
-        emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, ESCROW_NOT_INITIALIZED)
-        raise Exception("Escrow account for the receiving chain not initialized.")
-
-    # Balance checks.
+                
+    # balance checks
     balanceChecks: dict[TokenID, uint64] = {}
     balanceChecks[tokenID] = amount
 
@@ -2015,7 +1861,12 @@ def transferCrossChain(
     if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, MAINCHAIN_ID]:
         emitFailedCrossChainTransferEvent(senderAddress, tokenID, balanceChecks[tkID], receivingChainID, recipientAddress, INVALID_TOKEN_ID)
         raise Exception("Token must be native to either the sending, the receiving chain or the mainchain.")
-    ### End of checks ###
+
+    # check if there is escrow substore entry
+    if tokenChainID == OWN_CHAIN_ID and escrowStore(receivingChainID, tokenID) does not exist:
+        initializeEscrowAccountInternal(receivingChainID, tokenID)
+
+    ##### end of checks   ######
 
     transferCrossChainInternal(senderAddress, tokenID, amount, receivingChainID, recipientAddress, messageFee, data)
 
@@ -2040,7 +1891,6 @@ def emitFailedCrossChainTransferEvent(
         },
         topics=[senderAddress, recipientAddress, receivingChainID]
     )
-
 ```
 
 #### lock
@@ -2238,7 +2088,7 @@ def supportAllTokens() -> None:
 
 #### removeAllTokensSupport
 
-This function removes the support from all tokens. After calling this function the supported tokens substore becomes empty, therefore the only remaining supported tokens are the ones native to the chain and the LSK token.
+This function removes the support from all tokens. After calling this function the supported tokens substore becomes empty, therefore the only remaining supported tokens are the ones native to the chain and the LSK token. 
 
 ```python
 def removeAllTokensSupport() -> None:
@@ -2616,10 +2466,9 @@ The following steps are executed as part of the execution of a cross-chain updat
 ```python
 def verifyCrossChainMessage(ccu: Transaction, ccm: CCM) -> None:
     # This is TOKEN_ID_LSK for channels with the mainchain.
-    feeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
-    # If the chain is the fee token native chain, un-escrow and assign fee to relayer.
-    if getChainID(feeTokenID) == OWN_CHAIN_ID:
-        if escrowAmount(ccm.sendingChainID, feeTokenID) < ccm.fee:
+    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    if getChainID(messageFeeTokenID) == OWN_CHAIN_ID:
+        if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:
             raise Exception("Insufficient escrow amount.")
 ```
 
@@ -2628,45 +2477,30 @@ def verifyCrossChainMessage(ccu: Transaction, ccm: CCM) -> None:
 ```python
 def beforeCrossChainCommandExecution(ccu: Transaction, ccm: CCM) -> None:
     relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
-    fee = ccm.fee
 
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID)
-    # If the chain is the fee token native chain, un-escrow and assign fee to relayer.
+    # If the chain is the fee token native chain, un-escrow before assigning fee to relayer.
     if getChainID(messageFeeTokenID) == OWN_CHAIN_ID:
         # This should never fail since it is checked in verifyCrossChainMessage.
-        if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < fee:
+        if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:
             emitPersistentEvent(
                 module=MODULE_NAME_TOKEN,
                 name=EVENT_NAME_BEFORE_CCC_EXECUTION,
                 data={
-                    "sendingChainID": ccm.sendingChainID,
-                    "receivingChainID":ccm.receivingChainID,
+                    "ccmID": Interoperability.encodeCCM(ccm), 
                     "messageFeeTokenID": messageFeeTokenID,
-                    "messageFee": fee,
                     "relayerAddress": relayerAddress,
-                    "result": RESULT_INSUFFICIENT_BALANCE
+                    "result": RESULT_INSUFFICIENT_BALANCE 
                 },
                 topics=[relayerAddress, messageFeeTokenID]
             )
             raise Exception("Insufficient balance in the sending chain for the message fee.")
-
-        escrowAmount(ccm.sendingChainID, messageFeeTokenID) -= fee
-
-    availableBalance(relayerAddress, messageFeeTokenID) += fee
-
-    emitEvent(
-        module=MODULE_NAME_TOKEN,
-        name=EVENT_NAME_BEFORE_CCC_EXECUTION,
-        data={
-            "sendingChainID": ccm.sendingChainID,
-            "receivingChainID":ccm.receivingChainID,
-            "messageFeeTokenID": messageFeeTokenID,
-            "messageFee": fee,
-            "relayerAddress": relayerAddress,
-            "result": RESULT_SUCCESSFUL
-        },
-        topics=[relayerAddress, messageFeeTokenID]
-    )
+            
+        escrowAmount(ccm.sendingChainID, messageFeeTokenID) -= ccm.fee
+    
+    # Notice that the relayer account is guaranteed to exist 
+    # since we initialize it at the beginning of the CCU execution. 
+    availableBalance(relayerAddress, messageFeeTokenID) += ccm.fee
 ```
 
 #### beforeCrossChainMessageForwarding
@@ -2676,7 +2510,7 @@ def beforeCrossChainMessageForwarding(ccu: Transaction, ccm: CCM) -> None:
     # This should never fail since it is checked in verifyCrossChainMessage.
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID) # Always TOKEN_ID_LSK.
     if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:
-        emitFailedCCMForwardEvent(ccm.sendingChainID, ccm.receivingChainID, messageFeeTokenID, ccm.fee, RESULT_INSUFFICIENT_BALANCE)
+        emitFailedCCMForwardEvent(ccm, RESULT_INSUFFICIENT_BALANCE)
         raise Exception("Insufficient balance in the sending chain for the message fee.")
 
     # Transfer the fee from escrow to escrow. messageFeeTokenID is always TOKEN_ID_LSK.
@@ -2685,7 +2519,7 @@ def beforeCrossChainMessageForwarding(ccu: Transaction, ccm: CCM) -> None:
 
     if ccm.module == MODULE_NAME_TOKEN and ccm.crossChainCommand == CROSS_CHAIN_COMMAND_NAME_TRANSFER and getChainID(ccm.params.tokenID) == OWN_CHAIN_ID:
         if escrowAmount(ccm.sendingChainID, ccm.params.tokenID) < ccm.params.amount:
-            emitFailedCCMForwardEvent(ccm.sendingChainID, ccm.receivingChainID, messageFeeTokenID, ccm.fee, INSUFFICIENT_ESCROW_BALANCE)
+            emitFailedCCMForwardEvent(ccm, INSUFFICIENT_ESCROW_BALANCE)
             raise Exception("Insufficient balance in the sending chain for the transfer.")
 
         # Transfer the amount from escrow to escrow.
@@ -2696,31 +2530,24 @@ def beforeCrossChainMessageForwarding(ccu: Transaction, ccm: CCM) -> None:
             module=MODULE_NAME_TOKEN,
             name=EVENT_NAME_BEFORE_CCM_FORWARDING,
             data={
-                "sendingChainID": ccm.sendingChainID,
-                "receivingChainID":ccm.receivingChainID,
+                "ccmID": Interoperability.encodeCCM(ccm),
                 "messageFeeTokenID": messageFeeTokenID,
-                "messageFee": ccm.fee,
                 "result": RESULT_SUCCESSFUL
             },
             topics=[ccm.sendingChainID, ccm.receivingChainID]
         )
 
 def emitFailedCCMForwardEvent(
-    sendingChainID: ChainID,
-    receivingChainID: ChainID,
-    messageFeeTokenID: TokenID,
-    messageFee: uint64,
+    ccm: CCM,
     result: uint32
 ) -> None:
-
+    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID)
     emitPersistentEvent(
         module=MODULE_NAME_TOKEN,
         name=EVENT_NAME_BEFORE_CCM_FORWARDING,
         data={
-            "sendingChainID": sendingChainID,
-            "receivingChainID": receivingChainID,
+            "ccmID": Interoperability.encodeCCM(ccm),
             "messageFeeTokenID": messageFeeTokenID,
-            "messageFee": messageFee,
             "result": result
         },
         topics=[ccm.sendingChainID, ccm.receivingChainID]

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -419,6 +419,15 @@ _Figure 1: A schematic of the steps of a mainchain CCU execution. Some details a
 def execute(ccu: Transaction) -> None:
     # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
     verifyCertificateSignature(ccu)
+
+    if ccu.params.inboxUpdate is not empty:
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
+
     # Process cross-chain messages in inbox update.
     crossChainMessages = ccu.params.inboxUpdate.crossChainMessages
 
@@ -459,6 +468,9 @@ def execute(ccu: Transaction) -> None:
     if ccu.params.inboxUpdate is not empty: # An empty object has all properties set to their default values.
         updatePartnerChainOutboxRoot(ccu)
 
+    # Update the context to indicate that now we start the CCM processing.
+    ctx.ccmProcessing = True
+
     for ccmBytes in crossChainMessages:
         ccm = decode(crossChainMessageSchema, ccmBytes)
 
@@ -475,6 +487,8 @@ def execute(ccu: Transaction) -> None:
         # it is still possible to recover it (because the channel terminated message
         # would refer to an inbox where the message has not been appended yet).
         appendToInboxTree(ccu.params.sendingChainID, ccmBytes)
+    # Update the context to indicate that now we stop the CCM processing.
+    ctx.ccmProcessing = False
 ```
 
 #### SidechainCrossChainUpdate
@@ -522,6 +536,14 @@ def execute(ccu: Transaction) -> None:
     # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
     verifyCertificateSignature(ccu)
 
+    if ccu.params.inboxUpdate is not empty:
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
+
     # Process cross-chain messages in inbox update.
     crossChainMessages = ccu.params.inboxUpdate.crossChainMessages
 
@@ -560,10 +582,14 @@ def execute(ccu: Transaction) -> None:
     if ccu.params.inboxUpdate is not empty: # An empty object has all properties set to their default values.
         updatePartnerChainOutboxRoot(ccu)
 
+    # Update the context to indicate that now we start the CCM processing.
+    ctx.ccmProcessing = True
     for ccmBytes in crossChainMessages:
         ccm = decode(crossChainMessageSchema, ccmBytes)
         apply(ccu, ccm)
         appendToInboxTree(ccu.params.sendingChainID, ccmBytes)
+    # Update the context to indicate that now we stop the CCM processing.
+    ctx.ccmProcessing = False
 ```
 
 ## Backwards Compatibility


### PR DESCRIPTION
Improve the fee system to handle fee payment and assignment consistently within the Fee module.

- Update LIP0048 to include new (cross-chain) command processing stages and `payFee` method.
- Update LIP0043 to remove extra registration fee and use `payFee`.
- Update LIP0049 to include methods to serialize/deserialize CCMs.
- Update LIP0053 to set the ccm processing context and initialize the relayer token account.
- Update LIP0051 to remove initialization fees and automatically initialize non-existing accounts and use `payFee`.