### PR TITLE
Update LIP 61 due application-engine separation

### DIFF
--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -650,7 +650,7 @@ def verifyValidatorsHash():
 
 ##### Aggregate Commit
 
-The aggregate commit contains an aggregate BLS signature of a certificate corresponding to the block at the given height. It attests that all signing validators consider the corresponding block final. It is verified by calling the `verifyAggregateCommit` function, defined in [LIP 0061][lip-0061]. This function takes the aggregate commit `block.header.aggregateCommit` as input and returns a boolean, indicating the success of the check.
+The aggregate commit contains an aggregate BLS signature of a certificate corresponding to the block at the given height. It attests that all signing validators consider the corresponding block final. It is verified by calling the `verifyAggregateCommit` function, defined in [LIP 0061][lip-0061]. This function takes `block.header` as input and returns a boolean, indicating the success of the check.
 
 ##### Signature
 

--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -645,8 +645,10 @@ The validators hash authenticates the set of validators participating to Lisk-BF
 
 ```python
 def verifyValidatorsHash():
-  return block.header.validatorsHash == bft.getBFTParameters(block.header.height + 1).validatorsHash
+  return block.header.validatorsHash == getBFTParameters(block.header.height + 1).validatorsHash
 ```
+
+The function [getBFTParameters][lip-0058#getbftparameters] is specified in [LIP 0058][lip-0058].
 
 ##### Aggregate Commit
 
@@ -692,6 +694,7 @@ TBA
 [lip-0046]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0046.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
 [lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md
+[lip-0058#getbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getbftparameters
 [lip-0058#getSlotNumber]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getSlotNumber
 [lip-0058#getGeneratorAtTimestamp]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getGeneratorAtTimestamp
 [lip-0058#getBFTHeights]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getBFTHeights

--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/update-block-schema-and-block-proces
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2022-11-11
+Updated: 2022-11-25
 Requires: 0040, 0061, 0065
 ```
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -765,7 +765,7 @@ The following steps are executed as part of the (non-genesis) block processing, 
 
 #### Before Application Processing
 
-In the before application processing stage of a block `b`, the following logic is executed:
+In the before application processing stage of a block `b`, the BFT store is updated according to the logic below. These steps should be executed only *after* the "before application processing" steps defined in [LIP 0055][lip-0055#block-header-processing] are executed.
 
 1. The object `getBlockBFTProperties(b.header)` is added to the beginning of the array `bftVotes.blockBFTInfos`.
 2. If `bftVotes.blockBFTInfos[MAX_LENGTH_BLOCK_BFT_INFOS]` exists, then the corresponding value is removed from the array.
@@ -777,7 +777,7 @@ In the before application processing stage of a block `b`, the following logic i
 
 #### After Application Processing
 
-In the after application processing stage of a block `b`, the following logic is executed:
+In the after application processing stage of a block `b`,the BFT store is updated according to the logic below:
 
 - Whenever new BFT parameters are forwarded from the application domain to the consensus domain (this happens whenever the function [setValidatorParams][lip-0044#setValidatorParams] of the Validators module is called by the PoA module or DPoS module), the function `setBFTParameters` is called in this stage with the respective parameters as input to update the BFT parameters store. If the call of `setBFTParameters` results in an exception as the parameters are invalid, the block is invalid and discarded.
 
@@ -813,6 +813,7 @@ TBD
 [lip-0044#setValidatorParams]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#setValidatorParams
 [lip-0047]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0047.md
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
+[lip-0055#block-header-processing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-header-processing
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
 [lip-0056#comparison-to-the-lisk-bft-paper]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#comparison-to-the-lisk-bft-paper
 [lip-0057]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2022-11-11
+Updated: 2022-11-25
 Requires: 0055, 0056, 0061
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -61,7 +61,7 @@ It further is important that the protocol provides enough incentives for validat
 
 The goal of the P2P gossip mechanism for single commits is to  ensure that the validators have the necessary data to generate aggregate commits which satisfy the chain of trust (see section below) as quickly and reliably as possible. In particular, we want to share single commits as fast as possible while being robust in case of adverse network conditions, such as a temporary network split, a longer time without finalized blocks or a significant number of validators not sharing single commits. The design decisions and choice of parameters explained in the list below are based on this overarching goal.
 
-- For the `COMMIT_RANGE_STORED+1` most recent blocks of height at most `getBFTHeights().maxHeightPrecommitted` ([getBFTHeights][lip-0058#getbftheights] is defined in LIP 0058) we store and gossip all single commits, while for older blocks we only store single commits for blocks for which the `validatorsHash` property is different from that of its parent block. The reason is that certificates or aggregate commits are only required to be generated for blocks that authenticate a change of [BFT parameters][lip-0058], see Section "Chain of Trust" for details. For more recent blocks we want to create and gossip single commits as soon as possible so we store and gossip them for all blocks.
+- For the `COMMIT_RANGE_STORED+1` most recent blocks of height at most `getBFTHeights().maxHeightPrecommitted` ([`getBFTHeights`][lip-0058#getbftheights] is defined in LIP 0058) we store and gossip all single commits, while for older blocks we only store single commits for blocks for which the `validatorsHash` property is different from that of its parent block. The reason is that certificates or aggregate commits are only required to be generated for blocks that authenticate a change of [BFT parameters][lip-0058], see Section "Chain of Trust" for details. For more recent blocks we want to create and gossip single commits as soon as possible so we store and gossip them for all blocks.
 - For blocks of height at most `getBFTHeights().maxHeightCertified` we do not need to store any single commits, as an aggregate commit has been already generated for the height `getBFTHeights().maxHeightCertified`.
 - We gossip single commits every `BLOCK_TIME/2` seconds. This means single commits are shared at a higher frequency than blocks so that ideally after a block is finalized, an aggregate commit for that block is included in the chain only one or two blocks later.
 - An aggregate commit requires single commits by a certain subset of the active validators, depending on the value of the certificate threshold described in the next section. One P2P message can contain up to `2*numActiveValidators` single commits, where `numActiveValidators` is the number of active validators at that height. Such a message can therefore contain enough single commits to create two aggregate commits. Together with the gossiping frequency of `BLOCK_TIME/2` seconds this allows to share single commits four times faster than blocks are created, allowing for a significant buffer.
@@ -77,7 +77,7 @@ During the commit phase an additional threshold is used, called **certificate th
 * Commit messages are aggregated to aggregate commits, which are then included in blocks. The sum of BFT weights of the validators signing an aggregate commit has to be at least the certificate threshold value. Here the validators are those that are active at the height of the certificate and the BFT weights are the corresponding weights at that height.
 * When submitting a certificate via a cross-chain update transaction, the weights of all signers have to be above the certificate threshold value that is currently known to the other chain, see [LIP 0053][lip-0053] for details.
 
-The certificate threshold is stored as part of the BFT store in the consensus domain, see [LIP 0058][lip-0058] for details. The value of this parameters is set by the DPoS or PoA module via the [setValidatorParams][lip-0044#setValidatorParams] of the Validators module and then forwarded to the consensus domain. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
+The certificate threshold is stored as part of the BFT store in the consensus domain, see [LIP 0058][lip-0058] for details. The value of this parameters is set by the DPoS or PoA module via the [`setValidatorParams`][lip-0044#setValidatorParams] of the Validators module and then forwarded to the consensus domain. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
 
 In general, for a height `h`, the certificate threshold could be chosen within the following range:
 
@@ -106,9 +106,9 @@ Intuitively, the chain of trust property means that for any validator change a s
 
 _Figure 1: Example of a sequence of three certificates satisfying the chain of trust._
 
-For maintaining interoperability via certification, it is therefore crucial that the chain of trust is always maintained. Every block and also any certificate derived from a block has a `validatorsHash` property. This property is computed from the BLS keys of the active validators, their BFT weights and the certificate threshold after the block is applied, see the function [computeValidatorsHash][lip-0058#computevalidatorshash] in LIP 0058 for details. As the active validators are the same within one round, only blocks which are the last block of a round may have a different `validatorsHash` property than their parent block. This means that the chain of trust property is satisfied if the certificate generation mechanism ensures that a certificate is generated for all blocks for which the `validatorsHash` property is distinct from the `validatorsHash` property of the parent block. This way there is a certificate authenticating any validator transition that happened in the chain.
+For maintaining interoperability via certification, it is therefore crucial that the chain of trust is always maintained. Every block and also any certificate derived from a block has a `validatorsHash` property. This property is computed from the BLS keys of the active validators, their BFT weights and the certificate threshold after the block is applied, see the function [`computeValidatorsHash`][lip-0058#computevalidatorshash] in LIP 0058 for details. As the active validators are the same within one round, only blocks which are the last block of a round may have a different `validatorsHash` property than their parent block. This means that the chain of trust property is satisfied if the certificate generation mechanism ensures that a certificate is generated for all blocks for which the `validatorsHash` property is distinct from the `validatorsHash` property of the parent block. This way there is a certificate authenticating any validator transition that happened in the chain.
 
-The certificate generation specified in this LIP therefore generates an aggregate commit for any block at height `h` for which  `existBFTParameters(h+1)` returns `True`, where [existBFTParameters][lip-0058#existbftparameters] is defined in LIP 0058. This means that at height `h+1` the [BFT store][lip-0058#bft-parameters] contains new and possibly different BFT parameters that need to be authenticated by the block at height `h`. As already mentioned, from the on-chain data, i.e., the aggregate commit and referenced block header, the corresponding certificates can be computed. Hence, the mechanism specified in this LIP guarantees that the generated certificates satisfy the chain of trust property.
+The certificate generation specified in this LIP therefore generates an aggregate commit for any block at height `h` for which  `existBFTParameters(h+1)` returns `True`, where [`existBFTParameters`][lip-0058#existbftparameters] is defined in LIP 0058. This means that at height `h+1` the [BFT store][lip-0058#bft-parameters] contains new and possibly different BFT parameters that need to be authenticated by the block at height `h`. As already mentioned, from the on-chain data, i.e., the aggregate commit and referenced block header, the corresponding certificates can be computed. Hence, the mechanism specified in this LIP guarantees that the generated certificates satisfy the chain of trust property.
 
 Note that if possible, also aggregate commits for blocks that are not at the end of the round are created and added to blocks so that a certificate is created as soon as a block is finalized and it is not required to wait for a change of BFT parameters.
 
@@ -118,10 +118,10 @@ Note that if possible, also aggregate commits for blocks that are not at the end
 
 In this LIP, we will frequently use the following functions specified in LIP 0058 without reference to the function definition:
 
-- [existBFTParameters][lip-0058#existbftparameters]
-- [getBFTHeights][lip-0058#getbftheights]
-- [getBFTParameters][lip-0058#getbftparameters]
-- [getNextHeightBFTParameters][lip-0058#getnextheightbftparameters]
+- [`existBFTParameters`][lip-0058#existbftparameters]
+- [`getBFTHeights`][lip-0058#getbftheights]
+- [`getBFTParameters`][lip-0058#getbftparameters]
+- [`getNextHeightBFTParameters`][lip-0058#getnextheightbftparameters]
 
 ### Constants
 
@@ -663,7 +663,7 @@ def getNextCertificateFromAggregateCommits(lastCertifiedHeight: uint32) -> Certi
 ```
 
 ```python
-def checkChainOfTrust(lastValidatorsHash: bytes, blsKeyToBFTWeight: dict[bytes, uint64], lastCertificateThreshold: uint32, aggregateCommit: AggregateCommit) -> bool:
+def checkChainOfTrust(lastValidatorsHash: bytes, blsKeyToBFTWeight: dict[bytes, uint64], lastCertificateThreshold: uint64, aggregateCommit: AggregateCommit) -> bool:
     blockHeader = block header at height aggregateCommit.height - 1
     # Certificate signers and certificate threshold for aggregateCommit are those authenticated by the last certificate
     if lastValidatorsHash == blockHeader.validatorsHash:

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -136,10 +136,11 @@ In this LIP, we will frequently use the following functions specified in LIP 005
 
 | Name               | Type   | Validation | Description |
 |--------------------|--------|------------|-------------|
+| `AggregateCommit`  | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
 | `BlockHeader`      | object | Must follow `blockHeaderSchema` schema defined in [LIP 0055][lip-0055]. | An object representing a block header. |
 | `Certificate`      | object | Must follow `certificateSchema` schema. | An object representing a certificate. |
 | `SingleCommit`     | object | Must follow `singleCommitSchema` schema. | An object representing a single commit. |
-| `AggregateCommit`  | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
+| `Validator`        | object | Must follow `validatorSchema` schema defined in [LIP 0058][lip-0058]. | An object representing a validator with properties `address`, `bftWeight`, `generatorKey` and `blsKey`. |
 
 ### Certificate
 
@@ -272,8 +273,7 @@ The following function verifies the aggregate BLS signature which is provided as
 
 ###### Parameters
 
-* `keysList` is an array of BLS public keys,
-* `bftWeights` is an array of BFT weights corresponding to the BLS public keys, i.e., `bftWeights[i]` is the BFT weight of the validator with public key `keysList[i]`,
+* `validatorList` is an array of objects of type `Validator` corresponding to the validators eligible to sign the certificate,
 * `threshold` is the required threshold value for the signatures,
 * `chainID` is the chain ID of the chain that the certificate corresponds to,
 * `c` is a certificate object.
@@ -285,7 +285,10 @@ The functions returns `True` if and only if the aggregate certificate signature 
 ###### Execution
 
 ```python
-def verifyAggregateCertificateSignature(keysList: list[bytes], bftWeights: list[uint64], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
+def verifyAggregateCertificateSignature(validatorList: list[Validator], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
+    sort validatorList lexicographically by blsKey property
+    keysList = [validator.blsKey for validator in validatorList]
+    bftWeights = [validator.bftWeight for validator in validatorList]
     aggregateSignature = c.signature
     aggregationBits = c.aggregationBits
     c.aggregationBits = EMPTY_BYTES
@@ -522,12 +525,13 @@ def selectAggregateCommit() -> AggregateCommit:
     return aggregateCommit
 ```
 
-### Block Verification
+### Block Processing
 
-As part of the verification of a block header `blockHeader` as described in [LIP 0055][lip-0055], the property `aggregateCommit` has to be verified, i.e., the following function has to return `True`.
+As described in the ["before application processing" stage of the block processing in LIP 0055][lip-0055#aggregate-commit], the property block header property `aggregateCommit` is verified using the function `verifyAggregateCommit` defined below. Note that it is important that the validation defined below is performed before the BFT store is updated, i.e., before the "before application processing" logic defined in [LIP 0058][lip-0058#before-application-processing-1] is executed.
 
 ```python
-def verifyAggregateCommit(aggregateCommit):
+def verifyAggregateCommit(blockHeader: BlockHeader)-> bool:
+    aggregateCommit = blockHeader.aggregateCommit
     # Check if the aggregate commit object is the default object with empty signature
     if aggregateCommit.aggregationBits == EMPTY_BYTES
        and aggregateCommit.certificateSignature == EMPTY_BYTES
@@ -539,7 +543,7 @@ def verifyAggregateCommit(aggregateCommit):
     if aggregateCommit.height <= getBFTHeights().maxHeightCertified:
         return False
     # Check that the height of the aggregate commit is at most the value of
-    # maxHeightPrecommitted before processing b
+    # maxHeightPrecommitted before processing blockHeader and updating the BFT store.
     if aggregateCommit.height > getBFTHeights().maxHeightPrecommitted:
         return False
     # If there are new BFT parameters for a height h, then the chain needs to include
@@ -559,13 +563,7 @@ def verifyAggregateCommit(aggregateCommit):
     c.signature = aggregateCommit.certificateSignature
     chainID = chain ID of the current chain
     bftParams = getBFTParameters(aggregateCommit.height)
-    validatorKeys = list of BLS public keys of validators in bftParams.validators obtained via
-                    validatorsModule.getValidatorAccount
-    sort validatorKeys lexicographically
-    weights = array of validator BFT weights obtained from bftParams.validators such that
-              weights[i] is the BFT weight of the validator with the BLS key validatorKeys[i]
-    threshold = bftParams.certificationThreshold
-    return verifyAggregateCertificateSignature(validatorKeys, weights, threshold, chainID, c)
+    return verifyAggregateCertificateSignature(bftParams.validators, bftParams.certificationThreshold, chainID, c)
 ```
 
 If the validation above fails, the block is discarded and the peer sending the respective block receives a ban score of 100, see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md).
@@ -600,7 +598,7 @@ The function computes a certificate object from the aggregate commit given as in
 
 ###### Parameters
 
-* `aggregateCommit`: An object following `aggregateCommitSchema` which has non-default values.
+* `aggregateCommit`: An object following `aggregateCommitSchema` with non-empty `aggregationBits` and `certificateSignature` property.
 
 ###### Returns
 
@@ -609,7 +607,7 @@ The certificate object corresponding to the aggregate commit object given as inp
 ###### Execution
 
 ```python
-def getCertificateFromAggregateCommit(aggregateCommit):
+def getCertificateFromAggregateCommit(aggregateCommit: AggregateCommit) -> Certificate:
     blockHeader = block header at height aggregateCommit.height
     certificate = computeCertificateFromBlockHeader(blockHeader)
     certificate.aggregationBits = aggregateCommit.aggregationBits
@@ -622,7 +620,7 @@ def getCertificateFromAggregateCommit(aggregateCommit):
 In this section, we describe how to compute the certificate of largest height that can be submitted to a blockchain *B* given the data from a node running blockchain *A*. We let `lastCertifiedHeight` be the height of the last certificate from blockchain *A* that has been submitted to blockchain *B*. For the computation, we require the following data from blockchain *A*:
 
 - All block headers of blockchain *A* with height at least `lastCertifiedHeight`.
-- All aggregate commits included in blockchain *A* with height at least `lastCertifiedHeight`. For the specifications here, we assume that there is a key-value map `aggregateCommits` storing the aggregate commits included in blockchain *A*. That is `aggregateCommits[h]` for a height `h` is an aggregate commit object with height property equal to `h` that was included in blockchain *A*. There is no key-value entry in `aggregateCommits` if no such aggregate commit exists.
+- All aggregate commits included in blockchain *A* with height at least `lastCertifiedHeight`. For the specifications here, we assume that there is a key-value map `aggregateCommits` storing the aggregate commits included in blockchain *A*. That is `aggregateCommits[h]` for a height `h` is an aggregate commit object with height property equal to `h` that was included in blockchain *A*. There is no key-value entry in `aggregateCommits` if the aggregate commit has empty `aggregationBits` and `certificateSignature` property.
 - The validators with BFT weight and BLS key and the certificate thresholds used for the computation of the `validatorsHash` property of the blocks from height `lastCertifiedHeight` onwards. For the specifications, we assume that there is a key-value store `validatorsHashPreimage` such that for a validators hash `validatorsHash`, `validatorsHashPreimage[validatorsHash]` is an object following `validatorsHashInputSchema` which yields the value of `validatorsHash` given as input.
 
 The function `getNextCertificateFromAggregateCommits` which computes the certificate from the data described above is specified in the next section.
@@ -644,7 +642,7 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromAggregateCommits` and the auxiliary function `checkChainOfTrust`.
 
 ```python
-def getNextCertificateFromAggregateCommits(lastCertifiedHeight):
+def getNextCertificateFromAggregateCommits(lastCertifiedHeight: uint32) -> Certificate:
     lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
     lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
     lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold
@@ -665,7 +663,7 @@ def getNextCertificateFromAggregateCommits(lastCertifiedHeight):
 ```
 
 ```python
-def checkChainOfTrust(lastValidatorsHash, blsKeyToBFTWeight, lastCertificateThreshold, aggregateCommit):
+def checkChainOfTrust(lastValidatorsHash: bytes, blsKeyToBFTWeight: dict[bytes, uint64], lastCertificateThreshold: uint32, aggregateCommit: AggregateCommit) -> bool:
     blockHeader = block header at height aggregateCommit.height - 1
     # Certificate signers and certificate threshold for aggregateCommit are those authenticated by the last certificate
     if lastValidatorsHash == blockHeader.validatorsHash:
@@ -713,15 +711,16 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromSingleCommits` and the auxiliary function `computeEligibleSingleCommits`.
 
 ```python
-def getNextCertificateFromSingleCommits(lastCertifiedHeight):
+def getNextCertificateFromSingleCommits(lastCertifiedHeight: uint32) -> Certificate:
     lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
     lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
     lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold
 
     addressToBFTWeight = {}
-    for validator in lastCertifiedValidators:
-        validatorAddress = validatorsModule.getAddressFromBLSKey(validator.blsKey)
-        addressToBFTWeight[validatorAddress] = validator.bftWeight
+    # Obtain the BFT Parameters that were certified by the last certificate.
+    bftParams = getBFTParameters(lastCertifiedHeight + 1)
+    for validator in bftParams.validators:
+        addressToBFTWeight[validator.address] = validator.bftWeight
 
     h = getBFTHeights().maxHeightCertified
     while h > lastCertifiedHeight:
@@ -738,7 +737,7 @@ def getNextCertificateFromSingleCommits(lastCertifiedHeight):
 ```
 
 ```python
-def computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singleCommitsArray):
+def computeEligibleSingleCommits(addressToBFTWeight: dict[bytes, uint64], lastCertificateThreshold: uint64, singleCommitsArray: list[SingleCommit]) -> list[SingleCommit]:
     eligibleSingleCommits = []
     aggregateBFTWeight = 0
     for singleCommit in singleCommitsArray:
@@ -757,9 +756,11 @@ def computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, s
 [lip-0047]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0047.md
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
+[lip-0055#aggregate-commit]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#aggregate-commit
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
 [lip-0057]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md
 [lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md
+[lip-0058#before-application-processing-1]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#before-application-processing-1
 [lip-0058#bft-parameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#bft-parameters
 [lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash
 [lip-0058#existbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#existbftparameters

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -286,7 +286,7 @@ The following function verifies that the BLS signature provided as input is a va
 
 ###### Returns
 
-The functions returns `True` if and only if the certificate signature is valid with respect to the provided BLS public key, signature and network identifier.
+The functions returns `True` if and only if the certificate signature is valid with respect to the provided BLS public key, signature and chain identifier.
 
 ###### Execution
 
@@ -310,7 +310,7 @@ The following function verifies the aggregate BLS signature which is provided as
 
 ###### Returns
 
-The functions returns `True` if and only if the aggregate certificate signature is valid with respect to the provided BLS public keys, weights, threshold and network identifier.
+The functions returns `True` if and only if the aggregate certificate signature is valid with respect to the provided BLS public keys, weights, threshold and chain identifier.
 
 ###### Execution
 
@@ -720,7 +720,7 @@ In this section, we describe how to compute the certificate of largest height th
 
 - All block headers of blockchain *A* with height at least `lastCertifiedHeight`.
 - The single commits collected by the node running blockchain *A* with height at least `lastCertifiedHeight`. For the specifications here, we assume that there is a key-value map `singleCommits` storing the single commits shared via the P2P network of blockchain *A* and collected by the node. That is `singleCommits[h]` for a height `h` is an array of valid single commit object, i.e., single commit objects that passed the validation steps 1 - 7 described in the section [Single Commit P2P Gossip](#single-commit-p2p-gossip), each with height property equal to `h` and with distinct `validatorAddress` properties. There is no key-value entry in `singleCommits` if no single commits for that height were collected.
-- In Step 7 of the ["before application processing" stage][lip-0058#before-application-processing-1] defined in LIP 0058, no longer needed entries in the [BFT Parameters substore][lip-0058#bft-parameters] are deleted. However, for the approach described here, we may need BFT parameters that would be deleted in this stage. Hence, the implementation should be able to provide past BFT parameters such that it is always possible to obtain them via `getBFTParameters(lastCertifiedHeight + 1)`. For this is is sufficient if from a height `h` onwards, where `h` is the largest integer such that `h <= lastCertifiedHeight + 1`, all BFT parameters in the BFT parameters substore are maintained. In particular, the implementation could allow to maintain all past BFT parameters for nodes that allow to obtain certificates with the approach described here.
+- In Step 7 of the ["before application processing" stage][lip-0058#before-application-processing-1] defined in LIP 0058, no longer needed entries in the [BFT Parameters substore][lip-0058#bft-parameters] are deleted. However, for the approach described here, we may need BFT parameters that would be deleted in this stage. Hence, the implementation should be able to provide past BFT parameters such that it is always possible to obtain them via `getBFTParameters(lastCertifiedHeight + 1)`. For this it is sufficient if from a height `h` onwards, where `h` is the largest integer such that `h <= lastCertifiedHeight + 1`, all BFT parameters in the BFT parameters substore are maintained. In particular, the implementation could allow to maintain all past BFT parameters for nodes that allow to obtain certificates with the approach described here.
 
 The function `getNextCertificateFromSingleCommits` which computes the certificate from the data described above is specified in the next section.
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -139,6 +139,7 @@ In this LIP, we will frequently use the following functions specified in LIP 005
 | `AggregateCommit`  | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
 | `BlockHeader`      | object | Must follow `blockHeaderSchema` schema defined in [LIP 0055][lip-0055]. | An object representing a block header. |
 | `Certificate`      | object | Must follow `certificateSchema` schema. | An object representing a certificate. |
+| `UnsignedCertificate`| object | Must follow `unsignedCertificateSchema` schema. | An object representing a certificate without `aggregationBits` and `signature` property. |
 | `SingleCommit`     | object | Must follow `singleCommitSchema` schema. | An object representing a single commit. |
 | `Validator`        | object | Must follow `validatorSchema` schema defined in [LIP 0058][lip-0058]. | An object representing a validator with properties `address`, `bftWeight`, `generatorKey` and `blsKey`. |
 
@@ -147,6 +148,43 @@ In this LIP, we will frequently use the following functions specified in LIP 005
 Certificates are the key object for transferring information about the state of one chain to another chain. Every certificate references a finalized block via the `blockID` property and contains a subset of the properties of that block, namely those properties important for interoperability.
 
 #### Schema
+
+As all [schema properties need to be required][lip-0064], we distinguish between signed and unsigned certificates.
+
+```java
+unsignedCertificateSchema = {
+    "type": "object",
+    "required": [
+        "blockID",
+        "height",
+        "timestamp",
+        "stateRoot",
+        "validatorsHash"
+    ],
+    "properties": {
+        "blockID": {
+            "dataType": "bytes",
+            "fieldNumber": 1
+        },
+        "height": {
+            "dataType": "uint32",
+            "fieldNumber": 2
+        },
+        "timestamp": {
+            "dataType": "uint32",
+            "fieldNumber": 3
+        },
+        "stateRoot": {
+            "dataType": "bytes",
+            "fieldNumber": 4
+        },
+        "validatorsHash": {
+            "dataType": "bytes",
+            "fieldNumber": 5
+        }
+    }
+}
+```
 
 ```java
 certificateSchema = {
@@ -195,22 +233,18 @@ certificateSchema = {
 
 #### Creation
 
-A certificate is always created from a finalized block in the current chain. A certificate `c` is computed from a block header `blockHeader` in the following canonical way:
+A certificate is always created from a finalized block in the current chain. An unsigned certificate is computed from a block header `blockHeader` in the following canonical way:
 
 ```python
-def computeCertificateFromBlockHeader(blockHeader: BlockHeader) -> Certificate:
-    c = object following certificateSchema
-    c.blockID = block ID of blockHeader
-    c.height = blockHeader.height
-    c.timestamp = blockHeader.timestamp
-    c.stateRoot = blockHeader.stateRoot
-    c.validatorsHash = blockHeader.validatorsHash
-    c.aggregationBits = EMPTY_BYTES
-    c.signature = EMPTY_BYTES
-    return c
+def computeUnsignedCertificateFromBlockHeader(blockHeader: BlockHeader) -> UnsignedCertificate:
+    unsignedCertificate = object following unsignedCertificateSchema
+    unsignedCertificate.blockID = block ID of blockHeader
+    unsignedCertificate.height = blockHeader.height
+    unsignedCertificate.timestamp = blockHeader.timestamp
+    unsignedCertificate.stateRoot = blockHeader.stateRoot
+    unsignedCertificate.validatorsHash = blockHeader.validatorsHash
+    return unsignedCertificate
 ```
-
-Note that as all certificate properties are required, we initialize `aggregationBits` and `signature` with the default value (empty bytes).
 
 #### Signature Computation and Validation
 
@@ -224,7 +258,7 @@ The following function computes a certificate signature.
 
 * `sk` is the BLS secret key for signing,
 * `chainID` is the chain ID of the chain that the certificate corresponds to,
-* `c` is a certificate object.
+* `unsignedCertificate` is an unsigned certificate object.
 
 ###### Returns
 
@@ -233,10 +267,8 @@ The certificate signature as byte array.
 ###### Execution
 
 ```python
-def signCertificate(sk: bytes, chainID: bytes, c: Certificate) -> bytes:
-    c.aggregationBits = EMPTY_BYTES
-    c.signature = EMPTY_BYTES
-    message = encode(certificateSchema, c)
+def signCertificate(sk: bytes, chainID: bytes, unsignedCertificate: UnsignedCertificate) -> bytes:
+    message = encode(unsignedCertificateSchema, unsignedCertificate)
     tag = MESSAGE_TAG_CERTIFICATE
     return signBLS(sk, tag, chainID, message)
 ```
@@ -250,7 +282,7 @@ The following function verifies that the BLS signature provided as input is a va
 * `pk` is the BLS public key used for validating the signature,
 * `sig` is the BLS signature,
 * `chainID` is the chain ID of the chain that the certificate corresponds to,
-* `c` is a certificate object.
+* `unsignedCertificate` is an unsigned certificate object.
 
 ###### Returns
 
@@ -259,10 +291,8 @@ The functions returns `True` if and only if the certificate signature is valid w
 ###### Execution
 
 ```python
-def verifySingleCertificateSignature(pk: bytes, sig: bytes, chainID: bytes, c: Certificate) -> bool:
-    c.aggregationBits = EMPTY_BYTES
-    c.signature = EMPTY_BYTES
-    message = encode(certificateSchema, c)
+def verifySingleCertificateSignature(pk: bytes, sig: bytes, chainID: bytes, unsignedCertificate: UnsignedCertificate) -> bool:
+    message = encode(unsignedCertificateSchema, unsignedCertificate)
     tag = MESSAGE_TAG_CERTIFICATE
     return verifyBLS(pk, tag, chainID, message, sig)
 ```
@@ -276,7 +306,7 @@ The following function verifies the aggregate BLS signature which is provided as
 * `validatorList` is an array of objects of type `Validator` corresponding to the validators eligible to sign the certificate,
 * `threshold` is the required threshold value for the signatures,
 * `chainID` is the chain ID of the chain that the certificate corresponds to,
-* `c` is a certificate object.
+* `certificate` is a certificate object.
 
 ###### Returns
 
@@ -285,17 +315,14 @@ The functions returns `True` if and only if the aggregate certificate signature 
 ###### Execution
 
 ```python
-def verifyAggregateCertificateSignature(validatorList: list[Validator], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
+def verifyAggregateCertificateSignature(validatorList: list[Validator], threshold: uint64, chainID: bytes, certificate: Certificate) -> bool:
     sort validatorList lexicographically by blsKey property
     keysList = [validator.blsKey for validator in validatorList]
     bftWeights = [validator.bftWeight for validator in validatorList]
-    aggregateSignature = c.signature
-    aggregationBits = c.aggregationBits
-    c.aggregationBits = EMPTY_BYTES
-    c.signature = EMPTY_BYTES
-    message = encode(certificateSchema, c)
+    unsignedCertificate = UnsignedCertificate object derived from certificate
+    message = encode(unsignedCertificateSchema, unsignedCertificate)
     tag = MESSAGE_TAG_CERTIFICATE
-    return verifyWeightedAggSig(keysList, aggregationBits, aggregateSignature, tag, chainID, bftWeights, threshold, message)
+    return verifyWeightedAggSig(keysList, certificate.aggregationBits, certificate.signature, tag, chainID, bftWeights, threshold, message)
 ```
 
 ### Single Commits
@@ -357,8 +384,8 @@ def createSingleCommit(blockHeader: BlockHeader, validatorAddress: bytes, sk: by
     m.blockID = block ID of blockHeader
     m.height = b.header.height
     m.validatorAddress = validatorAddress
-    c = computeCertificateFromBlockHeader(blockHeader)
-    m.certificateSignature = signCertificate(sk, chainID, c)
+    unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader)
+    m.certificateSignature = signCertificate(sk, chainID, unsignedCertificate)
     return m
 ```
 
@@ -405,7 +432,7 @@ Every new incoming single commit message `m` is validated as follows:
 3. Discard `m` if `m.height` is not in `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` and `existBFTParameters(m.height+1)` returns `False` (i.e., `m.height` is not the height of a block authenticating a change of BFT parameters).
 4. Discard `m` if `m.blockID` is not the ID of the block `b` in the current chain at height `m.height`.
 5. Discard `m` if the validator given by `m.validatorAddress` is not active at height `m.height`. The active validators at height `m.height` can be obtained via `getBFTParameters(m.height).validators`.
-6. Let `b` be the block in the current chain at height `m.height`, `c = computeCertificateFromBlockHeader(b)`, `pk` be the BLS public key of the validator given by `m.validatorAddress` (obtained using `getBFTParameters(m.height).validators` and checking for BLS key in the array entry with the corresponding address) and `chainID` be the chain ID of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, chainID, c)` returns `True`.
+6. Let `b` be the block in the current chain at height `m.height`, `unsignedCertificate = computeUnsignedCertificateFromBlockHeader(b)`, `pk` be the BLS public key of the validator given by `m.validatorAddress` (obtained using `getBFTParameters(m.height).validators` and checking for BLS key in the array entry with the corresponding address) and `chainID` be the chain ID of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, chainID, unsignedCertificate)` returns `True`.
 7. If all validations above pass, `m` is added to `nonGossipedCommits`. If steps 1 through 4 above pass, but step 5 or 6 fail, the corresponding peer receives a ban score of 100 (see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md)).
 
 Let `h` be the height of the current tip of the chain. Commit messages in `nonGossipedCommits` are gossiped every `BLOCK_TIME/2` seconds as follows:
@@ -558,12 +585,14 @@ def verifyAggregateCommit(blockHeader: BlockHeader)-> bool:
     # Check the aggregate signature with respect to the BFT weights
     # and certificate threshold
     blockHeader1 = block header of block at height aggregateCommit.height
-    c = computeCertificateFromBlockHeader(blockHeader1)
-    c.aggregationBits = aggregateCommit.aggregationBits
-    c.signature = aggregateCommit.certificateSignature
+    unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader1)
+    certificate = Certificate object with properties set to corresponding property of unsignedCertificate
+                  and aggregationBits, signature set to empty bytes
+    certificate.aggregationBits = aggregateCommit.aggregationBits
+    certificate.signature = aggregateCommit.certificateSignature
     chainID = chain ID of the current chain
     bftParams = getBFTParameters(aggregateCommit.height)
-    return verifyAggregateCertificateSignature(bftParams.validators, bftParams.certificationThreshold, chainID, c)
+    return verifyAggregateCertificateSignature(bftParams.validators, bftParams.certificationThreshold, chainID, certificate)
 ```
 
 If the validation above fails, the block is discarded and the peer sending the respective block receives a ban score of 100, see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md).
@@ -609,7 +638,9 @@ The certificate object corresponding to the aggregate commit object given as inp
 ```python
 def getCertificateFromAggregateCommit(aggregateCommit: AggregateCommit) -> Certificate:
     blockHeader = block header at height aggregateCommit.height
-    certificate = computeCertificateFromBlockHeader(blockHeader)
+    unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader)
+    certificate = Certificate object with properties set to corresponding property of unsignedCertificate
+                  and aggregationBits, signature set to empty bytes
     certificate.aggregationBits = aggregateCommit.aggregationBits
     certificate.signature = aggregateCommit.certificateSignature
     return certificate
@@ -769,3 +800,4 @@ def computeEligibleSingleCommits(addressToBFTWeight: dict[bytes, uint64], lastCe
 [lip-0058#getnextheightbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getnextheightbftparameters
 [lip-0058#header-initialization]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#header-initialization
 [lip-0059]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0059.md
+[lip-0064]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0064.md

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -125,23 +125,23 @@ In this LIP, we will frequently use the following functions specified in LIP 005
 
 ### Constants
 
-| **Name**                   | **Value**              | **Description**                                   |
-|----------------------------|------------------------|---------------------------------------------------|
-| `BLOCK_TIME`               | configurable per chain, <br> default: 10 seconds | Length of a block slot. |
-| `MESSAGE_TAG_CERTIFICATE`  | `"LSK_CE_"`            | Message tag prepended when signing a certificate object, see [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md). |
-| `COMMIT_RANGE_STORED`      | 100                    | The commit messages at heights `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` are always stored. For smaller heights only the single commits for blocks authenticating a change of BFT parameters are stored. |
-| `EMPTY_BYTES`              |  ""                    | The empty byte string.                            |
+| Name | Value | Description |
+|------|-------|-------------|
+| `BLOCK_TIME` | configurable per chain, <br> default: 10 seconds | Length of a block slot. |
+| `MESSAGE_TAG_CERTIFICATE` | `"LSK_CE_"` | Message tag prepended when signing a certificate object, see [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md). |
+| `COMMIT_RANGE_STORED` | 100 | The commit messages at heights `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` are always stored. For smaller heights only the single commits for blocks authenticating a change of BFT parameters are stored. |
+| `EMPTY_BYTES` | "" | The empty byte string. |
 
 ### Type Definition
 
-| Name               | Type   | Validation | Description |
-|--------------------|--------|------------|-------------|
-| `AggregateCommit`  | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
-| `BlockHeader`      | object | Must follow `blockHeaderSchema` schema defined in [LIP 0055][lip-0055]. | An object representing a block header. |
-| `Certificate`      | object | Must follow `certificateSchema` schema. | An object representing a certificate. |
+| Name | Type | Validation | Description |
+|------|------|------------|-------------|
+| `AggregateCommit` | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
+| `BlockHeader` | object | Must follow `blockHeaderSchema` schema defined in [LIP 0055][lip-0055]. | An object representing a block header. |
+| `Certificate` | object | Must follow `certificateSchema` schema. | An object representing a certificate. |
 | `UnsignedCertificate`| object | Must follow `unsignedCertificateSchema` schema. | An object representing a certificate without `aggregationBits` and `signature` property. |
-| `SingleCommit`     | object | Must follow `singleCommitSchema` schema. | An object representing a single commit. |
-| `Validator`        | object | Must follow `validatorSchema` schema defined in [LIP 0058][lip-0058]. | An object representing a validator with properties `address`, `bftWeight`, `generatorKey` and `blsKey`. |
+| `SingleCommit` | object | Must follow `singleCommitSchema` schema. | An object representing a single commit. |
+| `Validator` | object | Must follow `validatorSchema` schema defined in [LIP 0058][lip-0058]. | An object representing a validator with properties `address`, `bftWeight`, `generatorKey` and `blsKey`. |
 
 ### Certificate
 
@@ -526,7 +526,7 @@ An object following the schema `aggregateCommitSchema`, which can be added the n
 
 ```python
 def selectAggregateCommit() -> AggregateCommit:
-    # Note that the BFT parameters at height maxHeightCertified+1 are already authenticated by the previous certificate
+    # Note that the BFT parameters at height maxHeightCertified+1 are already authenticated by the previous certificate.
     heightNextBFTParameters = getNextHeightBFTParameters(getBFTHeights().maxHeightCertified + 1)
     if previous function call returns valid height:
         nextHeight = min(heightNextBFTParameters-1, getBFTHeights().maxHeightPrecommitted)
@@ -544,7 +544,7 @@ def selectAggregateCommit() -> AggregateCommit:
             return aggregateSingleCommits(singleCommits)
         else:
             nextHeight -= 1
-    # Return default aggregate commit object
+    # Return default aggregate commit object.
     aggregateCommit = object following aggregateCommitSchema
     aggregateCommit.height =  getBFTHeights().maxHeightCertified
     aggregateCommit.aggregationBits =  EMPTY_BYTES
@@ -559,14 +559,14 @@ As described in the ["before application processing" stage of the block processi
 ```python
 def verifyAggregateCommit(blockHeader: BlockHeader)-> bool:
     aggregateCommit = blockHeader.aggregateCommit
-    # Check if the aggregate commit object is the default object with empty signature
+    # Check if the aggregate commit object is the default object with empty signature.
     if aggregateCommit.aggregationBits == EMPTY_BYTES
        and aggregateCommit.certificateSignature == EMPTY_BYTES
        and aggregateCommit.height == getBFTHeights().maxHeightCertified:
         return True
     if aggregateCommit.aggregationBits == EMPTY_BYTES or aggregateCommit.certificateSignature == EMPTY_BYTES:
         return False
-    # The heights of aggregate commits must be strictly increasing
+    # The heights of aggregate commits must be strictly increasing.
     if aggregateCommit.height <= getBFTHeights().maxHeightCertified:
         return False
     # Check that the height of the aggregate commit is at most the value of
@@ -583,7 +583,7 @@ def verifyAggregateCommit(blockHeader: BlockHeader)-> bool:
         return False
 
     # Check the aggregate signature with respect to the BFT weights
-    # and certificate threshold
+    # and certificate threshold.
     blockHeader1 = block header of block at height aggregateCommit.height
     unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader1)
     certificate = Certificate object with properties set to corresponding property of unsignedCertificate
@@ -686,7 +686,7 @@ def getNextCertificateFromAggregateCommits(lastCertifiedHeight: uint32) -> Certi
     while h > lastCertifiedHeight:
         if h in aggregateCommits:
             # Verify whether the chain of trust is maintained, i.e., the certificate corresponding to
-            # aggregateCommits[h] would be accepted by blockchain B
+            # aggregateCommits[h] would be accepted by blockchain B.
             if checkChainOfTrust(lastValidatorsHash, blsKeyToBFTWeight, lastCertificateThreshold, aggregateCommits[h]):
                 return getCertificateFromAggregateCommit(aggregateCommits[h])
         h -= 1
@@ -768,7 +768,7 @@ def computeEligibleSingleCommits(addressToBFTWeight: dict[bytes, uint64], lastCe
     eligibleSingleCommits = []
     aggregateBFTWeight = 0
     for singleCommit in singleCommitsArray:
-        # Certificate must only be signed by BLS keys known to the other chain
+        # Certificate must only be signed by BLS keys known to the other chain.
         if singleCommit.validatorAddress in addressToBFTWeight:
             append singleCommit to eligibleSingleCommits
             aggregateBFTWeight += addressToBFTWeight[singleCommit.validatorAddress]

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -199,7 +199,7 @@ A certificate is always created from a finalized block in the current chain. A c
 
 ```python
 def computeCertificateFromBlockHeader(blockHeader: BlockHeader) -> Certificate:
-    c = object following unsignedCertificateSchema
+    c = object following certificateSchema
     c.blockID = block ID of blockHeader
     c.height = blockHeader.height
     c.timestamp = blockHeader.timestamp

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-certificate-generation-mec
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2022-01-10
+Updated: 2022-11-25
 Requires: 0044, 0055, 0058
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -61,12 +61,12 @@ It further is important that the protocol provides enough incentives for validat
 
 The goal of the P2P gossip mechanism for single commits is to  ensure that the validators have the necessary data to generate aggregate commits which satisfy the chain of trust (see section below) as quickly and reliably as possible. In particular, we want to share single commits as fast as possible while being robust in case of adverse network conditions, such as a temporary network split, a longer time without finalized blocks or a significant number of validators not sharing single commits. The design decisions and choice of parameters explained in the list below are based on this overarching goal.
 
-- For the `COMMIT_RANGE_STORED+1` most recent blocks of height at most `bftModule.getBFTHeights().maxHeightPrecommitted` we store and gossip all single commits, while for older blocks we only store single commits for blocks for which the `validatorsHash` property is different from that of its parent block. The reason is that certificates or aggregate commits are only required to be generated for blocks that authenticate a change of [BFT parameters][lip-0058], see Section "Chain of Trust" for details. For more recent blocks we want to create and gossip single commits as soon as possible so we store and gossip them for all blocks.
-- For blocks of height at most `bftModule.getBFTHeights().maxHeightCertified` we do not need to store any single commits, as an aggregate commit has been already generated for the height `bftModule.getBFTHeights().maxHeightCertified`.
+- For the `COMMIT_RANGE_STORED+1` most recent blocks of height at most `getBFTHeights().maxHeightPrecommitted` ([getBFTHeights][lip-0058#getbftheights] is defined in LIP 0058) we store and gossip all single commits, while for older blocks we only store single commits for blocks for which the `validatorsHash` property is different from that of its parent block. The reason is that certificates or aggregate commits are only required to be generated for blocks that authenticate a change of [BFT parameters][lip-0058], see Section "Chain of Trust" for details. For more recent blocks we want to create and gossip single commits as soon as possible so we store and gossip them for all blocks.
+- For blocks of height at most `getBFTHeights().maxHeightCertified` we do not need to store any single commits, as an aggregate commit has been already generated for the height `getBFTHeights().maxHeightCertified`.
 - We gossip single commits every `BLOCK_TIME/2` seconds. This means single commits are shared at a higher frequency than blocks so that ideally after a block is finalized, an aggregate commit for that block is included in the chain only one or two blocks later.
 - An aggregate commit requires single commits by a certain subset of the active validators, depending on the value of the certificate threshold described in the next section. One P2P message can contain up to `2*numActiveValidators` single commits, where `numActiveValidators` is the number of active validators at that height. Such a message can therefore contain enough single commits to create two aggregate commits. Together with the gossiping frequency of `BLOCK_TIME/2` seconds this allows to share single commits four times faster than blocks are created, allowing for a significant buffer.
 - In normal operation, aggregate commits for a block will be generated and included in the chain shortly after that block is finalized.
-This implies that the value of `bftModule.getBFTHeights().maxHeightCertified` will be only a bit smaller than `bftModule.getBFTHeights().maxHeightPrecommitted`. In particular, the difference between the two values will be at most `COMMIT_RANGE_STORED`. In that case, single commits are only gossiped once and those of largest height are gossiped first so that aggregate commits for the last finalized block can be created as soon as possible. On the other hand, if the difference between `bftModule.getBFTHeights().maxHeightCertified` and `bftModule.getBFTHeights().maxHeightPrecommitted` is larger than `COMMIT_RANGE_STORED`, aggregate commits have not been generated for a significant number of blocks. In this case, single commits of smaller height are prioritized so that the aggregate commits can catch up to the current finalized height.
+This implies that the value of `getBFTHeights().maxHeightCertified` will be only a bit smaller than `getBFTHeights().maxHeightPrecommitted`. In particular, the difference between the two values will be at most `COMMIT_RANGE_STORED`. In that case, single commits are only gossiped once and those of largest height are gossiped first so that aggregate commits for the last finalized block can be created as soon as possible. On the other hand, if the difference between `getBFTHeights().maxHeightCertified` and `getBFTHeights().maxHeightPrecommitted` is larger than `COMMIT_RANGE_STORED`, aggregate commits have not been generated for a significant number of blocks. In this case, single commits of smaller height are prioritized so that the aggregate commits can catch up to the current finalized height.
 
 ### Certificate Threshold
 
@@ -77,7 +77,7 @@ During the commit phase an additional threshold is used, called **certificate th
 * Commit messages are aggregated to aggregate commits, which are then included in blocks. The sum of BFT weights of the validators signing an aggregate commit has to be at least the certificate threshold value. Here the validators are those that are active at the height of the certificate and the BFT weights are the corresponding weights at that height.
 * When submitting a certificate via a cross-chain update transaction, the weights of all signers have to be above the certificate threshold value that is currently known to the other chain, see [LIP 0053][lip-0053] for details.
 
-The certificate threshold is stored as part of the BFT Parameters substore of the BFT module, see [LIP 0058][lip-0058] for details. The value of this parameters is set by the DPoS or PoA module via the `setBFTParameters` functions. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
+The certificate threshold is stored as part of the BFT store in the consensus domain, see [LIP 0058][lip-0058] for details. The value of this parameters is set by the DPoS or PoA module via the [setValidatorParams][lip-0044#setValidatorParams] of the Validators module and then forwarded to the consensus domain. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
 
 In general, for a height `h`, the certificate threshold could be chosen within the following range:
 
@@ -106,9 +106,9 @@ Intuitively, the chain of trust property means that for any validator change a s
 
 _Figure 1: Example of a sequence of three certificates satisfying the chain of trust._
 
-For maintaining interoperability via certification, it is therefore crucial that the chain of trust is always maintained. Every block and also any certificate derived from a block has a `validatorsHash` property. This property is computed from the BLS keys of the active validators, their BFT weights and the certificate threshold after the block is applied, see the [BFT module][lip-0058] for details. As the active validators are the same within one round, only blocks which are the last block of a round may have a different `validatorsHash` property than their parent block. This means that the chain of trust property is satisfied if the certificate generation mechanism ensures that a certificate is generated for all blocks for which the `validatorsHash` property is distinct from the `validatorsHash` property of the parent block. This way there is a certificate authenticating any validator transition that happened in the chain.
+For maintaining interoperability via certification, it is therefore crucial that the chain of trust is always maintained. Every block and also any certificate derived from a block has a `validatorsHash` property. This property is computed from the BLS keys of the active validators, their BFT weights and the certificate threshold after the block is applied, see the function [computeValidatorsHash][lip-0058#computevalidatorshash] in LIP 0058 for details. As the active validators are the same within one round, only blocks which are the last block of a round may have a different `validatorsHash` property than their parent block. This means that the chain of trust property is satisfied if the certificate generation mechanism ensures that a certificate is generated for all blocks for which the `validatorsHash` property is distinct from the `validatorsHash` property of the parent block. This way there is a certificate authenticating any validator transition that happened in the chain.
 
-The certificate generation specified in this LIP therefore generates an aggregate commit for any block at height `h` for which  `bftModule.existBFTParameters(h+1)` returns `True`. This means that at height `h+1` the [BFT module][lip-0058] stores new and possibly different BFT parameters that need to be authenticated by the block at height `h`. Note that the [DPoS module][lip-0057] and [PoA module][lip-0047] only set new BFT parameters for the height of the first block of a round, if the BFT parameters are different from the previous round. This implies that for DPoS or PoA an aggregate commit for the last block of a round is only required, if the next round uses different BFT parameters than the current round. As already mentioned, from the on-chain data, i.e., the aggregate commit and referenced block header, the corresponding certificates can be computed. Hence, the mechanism specified in this LIP guarantees that the generated certificates satisfy the chain of trust property.
+The certificate generation specified in this LIP therefore generates an aggregate commit for any block at height `h` for which  `existBFTParameters(h+1)` returns `True`, where [existBFTParameters][lip-0058#existbftparameters] is defined in LIP 0058. This means that at height `h+1` the [BFT store][lip-0058#bft-parameters] contains new and possibly different BFT parameters that need to be authenticated by the block at height `h`. As already mentioned, from the on-chain data, i.e., the aggregate commit and referenced block header, the corresponding certificates can be computed. Hence, the mechanism specified in this LIP guarantees that the generated certificates satisfy the chain of trust property.
 
 Note that if possible, also aggregate commits for blocks that are not at the end of the round are created and added to blocks so that a certificate is created as soon as a block is finalized and it is not required to wait for a change of BFT parameters.
 
@@ -116,7 +116,12 @@ Note that if possible, also aggregate commits for blocks that are not at the end
 
 ### Notation
 
-In this LIP, we write `bftModule.fct` for a call to the function `fct` defined in the [BFT module][lip-0058] and analogously `validatorsModule.fct` for a call to the function `fct` defined in the [Validators module][lip-0044].
+In this LIP, we will frequently use the following functions specified in LIP 0058 without reference to the function definition:
+
+- [existBFTParameters][lip-0058#existbftparameters]
+- [getBFTHeights][lip-0058#getbftheights]
+- [getBFTParameters][lip-0058#getbftparameters]
+- [getNextHeightBFTParameters][lip-0058#getnextheightbftparameters]
 
 ### Constants
 
@@ -124,7 +129,16 @@ In this LIP, we write `bftModule.fct` for a call to the function `fct` defined i
 |----------------------------|------------------------|---------------------------------------------------|
 | `BLOCK_TIME`               | configurable per chain, <br> default: 10 seconds | Length of a block slot. |
 | `MESSAGE_TAG_CERTIFICATE`  | `"LSK_CE_"`            | Message tag prepended when signing a certificate object, see [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md). |
-| `COMMIT_RANGE_STORED`      | 100                    | The commit messages at heights `{bftModule.getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., bftModule.getBFTHeights().maxHeightPrecommitted}` are always stored. For smaller heights only the single commits for blocks authenticating a change of BFT parameters are stored. |
+| `COMMIT_RANGE_STORED`      | 100                    | The commit messages at heights `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` are always stored. For smaller heights only the single commits for blocks authenticating a change of BFT parameters are stored. |
+
+### Type Definition
+
+| Name               | Type   | Validation | Description |
+|--------------------|--------|------------|-------------|
+| `BlockHeader`      | object | Must follow `blockHeaderSchema` schema defined in [LIP 0055][lip-0055]. | An object representing a block header. |
+| `Certificate`      | object | Must follow `certificateSchema` schema. | An object representing a certificate. |
+| `SingleCommit`     | object | Must follow `singleCommitSchema` schema. | An object representing a single commit. |
+| `AggregateCommit`  | object | Must follow `aggregateCommitSchema` schema. | An object representing an aggregate commit. |
 
 ### Certificate
 
@@ -140,7 +154,9 @@ certificateSchema = {
         "height",
         "timestamp",
         "stateRoot",
-        "validatorsHash"
+        "validatorsHash",
+        "aggregationBits",
+        "signature"
     ],
     "properties": {
         "blockID": {
@@ -180,17 +196,19 @@ certificateSchema = {
 A certificate is always created from a finalized block in the current chain. A certificate `c` is computed from a block header `blockHeader` in the following canonical way:
 
 ```python
-computeCertificateFromBlockHeader(blockHeader):
-    c = certificate object following certificateSchema
+computeCertificateFromBlockHeader(blockHeader: BlockHeader) -> Certificate:
+    c = object following unsignedCertificateSchema
     c.blockID = block ID of blockHeader
     c.height = blockHeader.height
     c.timestamp = blockHeader.timestamp
     c.stateRoot = blockHeader.stateRoot
     c.validatorsHash = blockHeader.validatorsHash
+    c.aggregationBits = empty bytes
+    c.signature = empty bytes
     return c
 ```
 
-Note that the two properties `aggregationBits` and `signature` are not required in the schema and are not set in the above function because these properties are removed when signing certificates (see section below).
+Note that as all certificate properties are required, we initialize `aggregationBits` and `signature` with the default value (empty bytes).
 
 #### Signature Computation and Validation
 
@@ -203,8 +221,8 @@ The following function computes a certificate signature.
 ###### Parameters
 
 * `sk` is the BLS secret key for signing,
-* `networkIdentifier` is the network identifier of the chain that the certificate corresponds to,
-* `c` is a certificate object following the schema `certificateSchema` defined above.
+* `chainID` is the chain ID of the chain that the certificate corresponds to,
+* `c` is a certificate object.
 
 ###### Returns
 
@@ -213,11 +231,12 @@ The certificate signature as byte array.
 ###### Execution
 
 ```python
-signCertificate(sk, networkIdentifier, c):
-    remove the aggregationBits and signature property from c
+signCertificate(sk: bytes, chainID: bytes, c: Certificate) -> bytes:
+    c.aggregationBits = empty bytes
+    c.signature = empty bytes
     message = serialization of c according to LIP 0027
     tag = MESSAGE_TAG_CERTIFICATE
-    return signBLS(sk, tag, networkIdentifier, message)
+    return signBLS(sk, tag, chainID, message)
 ```
 
 ##### verifySingleCertificateSignature
@@ -228,8 +247,8 @@ The following function verifies that the BLS signature provided as input is a va
 
 * `pk` is the BLS public key used for validating the signature,
 * `sig` is the BLS signature,
-* `networkIdentifier` is the network identifier of the chain that the certificate corresponds to,
-* `c` is a certificate object following the schema `certificateSchema` defined above.
+* `chainID` is the chain ID of the chain that the certificate corresponds to,
+* `c` is a certificate object.
 
 ###### Returns
 
@@ -238,11 +257,12 @@ The functions returns `True` if and only if the certificate signature is valid w
 ###### Execution
 
 ```python
-verifySingleCertificateSignature(pk, sig, networkIdentifier, c):
-    remove the aggregationBits and signature property from c
+verifySingleCertificateSignature(pk: bytes, sig: bytes, chainID: bytes, c: Certificate) -> bool:
+    c.aggregationBits = empty bytes
+    c.signature = empty bytes
     message = serialization of c according to LIP 0027
     tag = MESSAGE_TAG_CERTIFICATE
-    return verifyBLS(pk, tag, networkIdentifier, message, sig) == VALID
+    return verifyBLS(pk, tag, chainID, message, sig)
 ```
 
 ##### verifyAggregateCertificateSignature
@@ -252,10 +272,10 @@ The following function verifies the aggregate BLS signature which is provided as
 ###### Parameters
 
 * `keysList` is an array of BLS public keys,
-* `weights` is an array of weights corresponding to the BLS public keys, i.e., `weights[i]` is the BFT weight of the validator with public key `keysList[i]`,
+* `bftWeights` is an array of weights corresponding to the BLS public keys, i.e., `bftWeights[i]` is the BFT weight of the validator with public key `keysList[i]`,
 * `threshold` is the required threshold value for the signatures,
-* `networkIdentifier` is the network identifier of the chain that the certificate corresponds to,
-* `c` is a certificate object following the schema `certificateSchema` defined above.
+* `chainID` is the chain ID of the chain that the certificate corresponds to,
+* `c` is a certificate object.
 
 ###### Returns
 
@@ -264,13 +284,14 @@ The functions returns `True` if and only if the aggregate certificate signature 
 ###### Execution
 
 ```python
-verifyAggregateCertificateSignature(keysList, weights, threshold, networkIdentifier, c):
+verifyAggregateCertificateSignature(keysList: list[bytes], bftWeights: list[uint64], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
     aggregateSignature = c.signature
     aggregationBits = c.aggregationBits
-    remove the aggregationBits and signature property from c
+    c.aggregationBits = empty bytes
+    c.signature = empty bytes
     message = serialization of c according to LIP 0027
     tag = MESSAGE_TAG_CERTIFICATE
-    return verifyWeightedAggSig(keysList, aggregationBits, aggregateSignature, tag, networkIdentifier, weights, threshold, message) == VALID
+    return verifyWeightedAggSig(keysList, aggregationBits, aggregateSignature, tag, chainID, bftWeights, threshold, message)
 ```
 
 ### Single Commits
@@ -316,23 +337,24 @@ The following function creates a single commit by a validator for a block.
 ##### Parameters
 
 * `blockHeader`: is a block header object,
-* `validatorInfo`: is a object containing properties `address`, `blsPublicKey` and `blsSecretKey` of a registered validator,
-* `networkIdentifier`: is the network identifier of the chain that the block corresponds to.
+* `validatorAddress`: address of the validator,
+* `sk` is the BLS secret key of the validator for signing,
+* `chainID` is the chain ID of the chain that the block corresponds to.
 
 ##### Returns
 
-A single commit object following `singleCommitSchema` or the block corresponding to `blockHeader` signed by the validator corresponding to `validatorInfo`.
+A single commit object of the block corresponding to `blockHeader` signed by the validator with the given BLS secret key `sk` and address `validatorAddress`.
 
 ##### Execution
 
 ```python
-createSingleCommit(blockHeader, validatorInfo, networkIdentifier):
+createSingleCommit(blockHeader: BlockHeader, validatorAddress: bytes, sk: bytes, chainID: bytes) -> SingleCommit:
     m = single commit object following singleCommitSchema
     m.blockID = block ID of blockHeader
     m.height = b.header.height
-    m.validatorAddress = validatorInfo.address
+    m.validatorAddress = validatorAddress
     c = computeCertificateFromBlockHeader(blockHeader)
-    m.certificateSignature = signCertificate(validatorInfo.blsSecretKey, networkIdentifier, c)
+    m.certificateSignature = signCertificate(sk, chainID, c)
     return m
 ```
 
@@ -342,26 +364,26 @@ To reduce the storage requirements, single commits that are no longer needed are
 
 ##### Returns
 
-The height up to which single commits can be removed as `uint32`.
+The height up to which single commits can be removed.
 
 ##### Execution
 
 ```python
-getMaxRemovalHeight():
+getMaxRemovalHeight() -> uint32:
     b = block at height maxHeightFinalized
     return b.header.aggregateCommit.height
 ```
 
 #### Initial Single Commit Creation
 
-If a validator node starts for the first time or loses all previously created single commits due to a restart, the node should automatically re-create all recent single commits, which may be essential for the network to create aggregate commits. Let `h1 = getMaxRemovalHeight()` and `h2 = bftModule.getBFTHeights().maxHeightPrecommitted`. Then the single commits are created as described in the next section [Creation After Block Processing](#creation-after-block-processing) for these values of `h1` and `h2`.
+If a validator node starts for the first time or loses all previously created single commits due to a restart, the node should automatically re-create all recent single commits, which may be essential for the network to create aggregate commits. Let `h1 = getMaxRemovalHeight()` and `h2 = getBFTHeights().maxHeightPrecommitted`. Then the single commits are created as described in the next section [Creation After Block Processing](#creation-after-block-processing) for these values of `h1` and `h2`.
 
 #### Creation After Block Processing
 
-If for a validator `v`, after applying a block the value returned by the function `bftModule.getBFTHeights().maxHeightPrecommitted` increases from `h1` to `h2`, then the following commit messages are created by the validator `v` and gossiped as described further below:
+If for a validator `v`, after applying a block the value returned by the function `getBFTHeights().maxHeightPrecommitted` increases from `h1` to `h2`, then the following commit messages are created by the validator `v` and gossiped as described further below:
 
-* For every height `h` in `{h1+1, h1+2, ..., h2}` such that `bftModule.existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters), validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
-* If `bftModule.existBFTParameters(h2+1)` returns `False` (i.e., `h2` is not the height of a block authenticating a change of BFT parameters), `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
+* For every height `h` in `{h1+1, h1+2, ..., h2}` such that `existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters), validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
+* If `existBFTParameters(h2+1)` returns `False` (i.e., `h2` is not the height of a block authenticating a change of BFT parameters), `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
 
 #### Single Commit P2P Gossip
 
@@ -376,10 +398,10 @@ Every new incoming single commit message `m` is validated as follows:
 
 1. Discard `m` if it is already contained in `nonGossipedCommits` or `gossipedCommits`, i.e., if there is a message `m2` in `nonGossipedCommits` or `gossipedCommits` with `m2.validatorAddress = m.validatorAddress` and `m2.blockID = m.blockID`.
 2. Discard `m` if `m.height <= getMaxRemovalHeight()`.
-3. Discard `m` if `m.height` is not in `{bftModule.getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., bftModule.getBFTHeights().maxHeightPrecommitted}` and `bftModule.existBFTParameters(m.height+1)` returns `False` (i.e., `m.height` is not the height of a block authenticating a change of BFT parameters).
+3. Discard `m` if `m.height` is not in `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` and `existBFTParameters(m.height+1)` returns `False` (i.e., `m.height` is not the height of a block authenticating a change of BFT parameters).
 4. Discard `m` if `m.blockID` is not the ID of the block `b` in the current chain at height `m.height`.
-5. Discard `m` if the validator given by `m.validatorAddress` is not active at height `m.height`. The active validators at height `m.height` can be obtained via `bftModule.getBFTParameters(m.height).validators`.
-6. Let `b` be the block in the current chain at height `m.height`, `c = computeCertificateFromBlockHeader(b)`, `pk = validatorsModule.getValidatorAccount(m.validatorAddress).blsKey` be the BLS public key of the validator given by `m.validatorAddress` and `networkIdentifier` be the network identifier of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, networkIdentifier, c)` returns `True`.
+5. Discard `m` if the validator given by `m.validatorAddress` is not active at height `m.height`. The active validators at height `m.height` can be obtained via `getBFTParameters(m.height).validators`.
+6. Let `b` be the block in the current chain at height `m.height`, `c = computeCertificateFromBlockHeader(b)`, `pk = validatorsModule.getValidatorAccount(m.validatorAddress).blsKey` be the BLS public key of the validator given by `m.validatorAddress` and `chainID` be the chain ID of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, chainID, c)` returns `True`.
 7. If all validations above pass, `m` is added to `nonGossipedCommits`. If steps 1 through 4 above pass, but step 5 or 6 fail, the corresponding peer receives a ban score of 100 (see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md)).
 
 Let `h` be the height of the current tip of the chain. Commit messages in `nonGossipedCommits` are gossiped every `BLOCK_TIME/2` seconds as follows:
@@ -387,10 +409,10 @@ Let `h` be the height of the current tip of the chain. Commit messages in `nonGo
 1. Cleanup the data structures `nonGossipedCommits` and `gossipedCommits`:
    1. Remove any single commit message `m` from `nonGossipedCommits` and `gossipedCommits` with `m.height <=  getMaxRemovalHeight()`.
    2. For every commit message `m` in `nonGossipedCommits` or `gossipedCommits` one of the following two conditions has to hold, otherwise it is discarded.
-      * The value of `m.height` is in `{bftModule.getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, …, bftModule.getBFTHeights().maxHeightPrecommitted}`.
-      * The function `bftModule.existBFTParameters(m.height+1)` returns `True`, which means that `m.height` is the height of a block authenticating a change of BFT parameters.
-2. Let `numActiveValidators` be the length of the array returned by `bftModule.getBFTParameters(h).validators`. Choose up to `2*numActiveValidators` commit messages as follows:
-   1. Select any message in `nonGossipedCommits` or `gossipedCommits` with `m.height < bftModule.getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED` choosing messages with smaller height first.
+      * The value of `m.height` is in `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, …, getBFTHeights().maxHeightPrecommitted}`.
+      * The function `existBFTParameters(m.height+1)` returns `True`, which means that `m.height` is the height of a block authenticating a change of BFT parameters.
+2. Let `numActiveValidators` be the length of the array returned by `getBFTParameters(h).validators`. Choose up to `2*numActiveValidators` commit messages as follows:
+   1. Select any message in `nonGossipedCommits` or `gossipedCommits` with `m.height < getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED` choosing messages with smaller height first.
    2. Select all newly created commit messages in `nonGossipedCommits` (created by a block generator node itself) choosing the ones with the largest height first.
    3. Select among the received commit messages in `nonGossipedCommits` (created by other nodes) the ones with the largest height first.
 3. Gossip an array of up to `2*numActiveValidators` commit messages to 16 randomly chosen connected peers with at least 8 of them being outgoing peers (same parameters as block propagation).
@@ -444,7 +466,7 @@ The function then returns an object following the schema `aggregateCommitSchema`
 ```python
 aggregateSingleCommits(singleCommits):
     h = m.height for first single commit in singleCommits
-    validatorAddresses = addresses of active validators obtained via bftModule.getBFTParameters(h).validators
+    validatorAddresses = addresses of active validators obtained via getBFTParameters(h).validators
     addressToBlsKey = []
     for address in validatorAddresses:
         addressToBlsKey[address] = validatorsModule.getValidatorAccount(address).blsKey
@@ -474,16 +496,16 @@ An object following the schema `aggregateCommitSchema`, which can be added the n
 ```python
 selectAggregateCommit():
     # Note that the BFT parameters at height maxHeightCertified+1 are already authenticated by the previous certificate
-    heightNextBFTParameters = bftModule.getNextHeightBFTParameters(bftModule.getBFTHeights().maxHeightCertified + 1)
+    heightNextBFTParameters = getNextHeightBFTParameters(getBFTHeights().maxHeightCertified + 1)
     if previous function call returns valid height:
-        nextHeight = min(heightNextBFTParameters-1, bftModule.getBFTHeights().maxHeightPrecommitted)
+        nextHeight = min(heightNextBFTParameters-1, getBFTHeights().maxHeightPrecommitted)
     elif previous function call returns Not Found error:
-        nextHeight = bftModule.getBFTHeights().maxHeightPrecommitted
+        nextHeight = getBFTHeights().maxHeightPrecommitted
 
-    while nextHeight > bftModule.getBFTHeights().maxHeightCertified:
+    while nextHeight > getBFTHeights().maxHeightCertified:
         singleCommits = commits in nonGossipedCommits or gossipedCommits with height equal to nextHeight
         nextValidators = set of validator addresses appearing in the single commit messages in singleCommits
-        bftParams = bftModule.getBFTParameters(nextHeight)
+        bftParams = getBFTParameters(nextHeight)
         aggregateBFTWeight = 0
         for v in nextValidators:
             aggregateBFTWeight += BFT weight of object in bftParams.validators with address equal to v
@@ -493,7 +515,7 @@ selectAggregateCommit():
             nextHeight -= 1
     # Return default aggregate commit object
     aggregateCommit = object following aggregateCommitSchema
-    aggregateCommit.height =  bftModule.getBFTHeights().maxHeightCertified
+    aggregateCommit.height =  getBFTHeights().maxHeightCertified
     aggregateCommit.aggregationBits =  empty bytes
     aggregateCommit.certificateSignature =  empty bytes
     return aggregateCommit
@@ -508,23 +530,23 @@ verifyAggregateCommit(aggregateCommit):
     # Check if the aggregate commit object is the default object with empty signature
     if aggregateCommit.aggregationBits == empty bytes
        and aggregateCommit.certificateSignature == empty bytes
-       and aggregateCommit.height == bftModule.getBFTHeights().maxHeightCertified:
+       and aggregateCommit.height == getBFTHeights().maxHeightCertified:
         return True
     if aggregateCommit.aggregationBits == empty bytes or aggregateCommit.certificateSignature == empty bytes:
         return False
     # The heights of aggregate commits must be strictly increasing
-    if aggregateCommit.height <= bftModule.getBFTHeights().maxHeightCertified:
+    if aggregateCommit.height <= getBFTHeights().maxHeightCertified:
         return False
     # Check that the height of the aggregate commit is at most the value of
     # maxHeightPrecommitted before processing b
-    if aggregateCommit.height > bftModule.getBFTHeights().maxHeightPrecommitted:
+    if aggregateCommit.height > getBFTHeights().maxHeightPrecommitted:
         return False
     # If there are new BFT parameters for a height h, then the chain needs to include
     # an aggregate commit for the block at height h-1. This block and the corresponding
     # certificate authenticate the BFT parameters via the validators hash property.
     # Note that the BFT parameters at height maxHeightCertified+1 are already authenticated
     # by the previous certificate.
-    heightNextBFTParameters = bftModule.getNextHeightBFTParameters(bftModule.getBFTHeights().maxHeightCertified+1)
+    heightNextBFTParameters = getNextHeightBFTParameters(getBFTHeights().maxHeightCertified+1)
     if previous function call returns valid height and aggregateCommit.height > heightNextBFTParameters-1:
         return False
 
@@ -534,15 +556,15 @@ verifyAggregateCommit(aggregateCommit):
     c = computeCertificateFromBlockHeader(blockHeader1)
     c.aggregationBits = aggregateCommit.aggregationBits
     c.signature = aggregateCommit.certificateSignature
-    networkIdentifier = network identifier of the chain
-    bftParams = bftModule.getBFTParameters(aggregateCommit.height)
+    chainID = chain ID of the current chain
+    bftParams = getBFTParameters(aggregateCommit.height)
     validatorKeys = list of BLS public keys of validators in bftParams.validators obtained via
                     validatorsModule.getValidatorAccount
     sort validatorKeys lexicographically
     weights = array of validator BFT weights obtained from bftParams.validators such that
               weights[i] is the BFT weight of the validator with the BLS key validatorKeys[i]
     threshold = bftParams.certificationThreshold
-    return verifyAggregateCertificateSignature(validatorKeys, weights, threshold, networkIdentifier, c)
+    return verifyAggregateCertificateSignature(validatorKeys, weights, threshold, chainID, c)
 ```
 
 If the validation above fails, the block is discarded and the peer sending the respective block receives a ban score of 100, see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md).
@@ -630,7 +652,7 @@ getNextCertificateFromAggregateCommits(lastCertifiedHeight):
     for validator in lastCertifiedValidators:
         blsKeyToBFTWeight[validator.blsKey] = validator.bftWeight
 
-    h = bftModule.getBFTHeights().maxHeightCertified
+    h = getBFTHeights().maxHeightCertified
     while h > lastCertifiedHeight:
         if h in aggregateCommits:
             # Verify whether the chain of trust is maintained, i.e., the certificate corresponding to
@@ -700,7 +722,7 @@ getNextCertificateFromSingleCommits(lastCertifiedHeight):
         validatorAddress = validatorsModule.getAddressFromBLSKey(validator.blsKey)
         addressToBFTWeight[validatorAddress] = validator.bftWeight
 
-    h = bftModule.getBFTHeights().maxHeightCertified
+    h = getBFTHeights().maxHeightCertified
     while h > lastCertifiedHeight:
         if h in singleCommits:
             # Obtain the subset of single commits from singleCommits[h] that are signed by a validator known to blockchain B.
@@ -730,10 +752,16 @@ computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singl
 ```
 
 [lip-0044]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md
+[lip-0044#setValidatorParams]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#setValidatorParams
 [lip-0047]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0047.md
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
 [lip-0057]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md
 [lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md
+[lip-0058#bft-parameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#bft-parameters
+[lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash
+[lip-0058#existbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#existbftparameters
+[lip-0058#getbftheights]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getbftheights
+[lip-0058#getnextheightbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getnextheightbftparameters
 [lip-0059]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0059.md

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -77,7 +77,7 @@ During the commit phase an additional threshold is used, called **certificate th
 * Commit messages are aggregated to aggregate commits, which are then included in blocks. The sum of BFT weights of the validators signing an aggregate commit has to be at least the certificate threshold value. Here the validators are those that are active at the height of the certificate and the BFT weights are the corresponding weights at that height.
 * When submitting a certificate via a cross-chain update transaction, the weights of all signers have to be above the certificate threshold value that is currently known to the other chain, see [LIP 0053][lip-0053] for details.
 
-The certificate threshold is stored as part of the BFT store in the consensus domain, see [LIP 0058][lip-0058] for details. The value of this parameters is set by the DPoS or PoA module via the [`setValidatorParams`][lip-0044#setValidatorParams] of the Validators module and then forwarded to the consensus domain. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
+The certificate threshold is stored as part of the BFT store in the consensus domain, see [LIP 0058][lip-0058] for details. The value of this parameter is set by the DPoS or PoA module via the [`setValidatorParams`][lip-0044#setValidatorParams] function of the Validators module and then forwarded to the consensus domain. Both for [Lisk DPoS][lip-0057] and [Lisk PoA][lip-0047], we propose to use the same values for the certificate threshold as for the precommit threshold. This means that the same threshold is required for finality as for cross-chain certification.
 
 In general, for a height `h`, the certificate threshold could be chosen within the following range:
 
@@ -248,7 +248,7 @@ def computeUnsignedCertificateFromBlockHeader(blockHeader: BlockHeader) -> Unsig
 
 #### Signature Computation and Validation
 
-In this section we describe how a signature of a certificate is computed and how single and aggregate signatures of certificates are validated. The functions `signBLS()`, `verifyBLS()` and `verifyWeightedAggSig()` are as defined in the [LIP 0038](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0038.md).
+In this section we describe how a signature of a certificate is computed and how single and aggregate signatures of certificates are validated. The functions `signBLS()`, `verifyBLS()` and `verifyWeightedAggSig()` are as defined in the [LIP 0062][lip-0062].
 
 ##### signCertificate
 
@@ -720,8 +720,7 @@ In this section, we describe how to compute the certificate of largest height th
 
 - All block headers of blockchain *A* with height at least `lastCertifiedHeight`.
 - The single commits collected by the node running blockchain *A* with height at least `lastCertifiedHeight`. For the specifications here, we assume that there is a key-value map `singleCommits` storing the single commits shared via the P2P network of blockchain *A* and collected by the node. That is `singleCommits[h]` for a height `h` is an array of valid single commit object, i.e., single commit objects that passed the validation steps 1 - 7 described in the section [Single Commit P2P Gossip](#single-commit-p2p-gossip), each with height property equal to `h` and with distinct `validatorAddress` properties. There is no key-value entry in `singleCommits` if no single commits for that height were collected.
-- The validators with BFT weight and BLS key and the certificate thresholds used for the computation of the `validatorsHash` property of the blocks from height `lastCertifiedHeight` onwards. For the specifications, we assume that there is a key-value store `validatorsHashPreimage` such that for a validators hash `validatorsHash`, `validatorsHashPreimage[validatorsHash]` is an object following `validatorsHashInputSchema` which yields the value of `validatorsHash` given as input.
-- A function to obtain the address of a validator in blockchain *A* from its BLS key. We assume that that this functionality is provided by the function `getAddressFromBLSKey` of the [Validators module][lip-0044].
+- In Step 7 of the ["before application processing" stage][lip-0058#before-application-processing-1] defined in LIP 0058, no longer needed entries in the [BFT Parameters substore][lip-0058#bft-parameters] are deleted. However, for the approach described here, we may need BFT parameters that would be deleted in this stage. Hence, the implementation should be able to provide past BFT parameters such that it is always possible to obtain them via `getBFTParameters(lastCertifiedHeight + 1)`. For this is is sufficient if from a height `h` onwards, where `h` is the largest integer such that `h <= lastCertifiedHeight + 1`, all BFT parameters in the BFT parameters substore are maintained. In particular, the implementation could allow to maintain all past BFT parameters for nodes that allow to obtain certificates with the approach described here.
 
 The function `getNextCertificateFromSingleCommits` which computes the certificate from the data described above is specified in the next section.
 
@@ -743,13 +742,10 @@ For readability, we describe the logic using two functions, the main function `g
 
 ```python
 def getNextCertificateFromSingleCommits(lastCertifiedHeight: uint32) -> Certificate:
-    lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
-    lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
-    lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold
-
-    addressToBFTWeight = {}
     # Obtain the BFT Parameters that were certified by the last certificate.
     bftParams = getBFTParameters(lastCertifiedHeight + 1)
+
+    addressToBFTWeight = {}
     for validator in bftParams.validators:
         addressToBFTWeight[validator.address] = validator.bftWeight
 
@@ -759,7 +755,7 @@ def getNextCertificateFromSingleCommits(lastCertifiedHeight: uint32) -> Certific
             # Obtain the subset of single commits from singleCommits[h] that are signed by a validator known to blockchain B.
             # Note that the following function returns [] if the sum of BFT weights of these single commits does not reach
             # the certificate threshold.
-            eligibleSingleCommits = computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singleCommits[h])
+            eligibleSingleCommits = computeEligibleSingleCommits(addressToBFTWeight, bftParams.certificateThreshold, singleCommits[h])
             if eligibleSingleCommits != []:
                 aggregateCommit = aggregateSingleCommits(eligibleSingleCommits)
                 return getCertificateFromAggregateCommit(aggregateCommit)
@@ -800,4 +796,5 @@ def computeEligibleSingleCommits(addressToBFTWeight: dict[bytes, uint64], lastCe
 [lip-0058#getnextheightbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getnextheightbftparameters
 [lip-0058#header-initialization]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#header-initialization
 [lip-0059]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0059.md
+[lip-0062]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0062.md
 [lip-0064]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0064.md

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -130,6 +130,7 @@ In this LIP, we will frequently use the following functions specified in LIP 005
 | `BLOCK_TIME`               | configurable per chain, <br> default: 10 seconds | Length of a block slot. |
 | `MESSAGE_TAG_CERTIFICATE`  | `"LSK_CE_"`            | Message tag prepended when signing a certificate object, see [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md). |
 | `COMMIT_RANGE_STORED`      | 100                    | The commit messages at heights `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` are always stored. For smaller heights only the single commits for blocks authenticating a change of BFT parameters are stored. |
+| `EMPTY_BYTES`              |  ""                    | The empty byte string.                            |
 
 ### Type Definition
 
@@ -196,15 +197,15 @@ certificateSchema = {
 A certificate is always created from a finalized block in the current chain. A certificate `c` is computed from a block header `blockHeader` in the following canonical way:
 
 ```python
-computeCertificateFromBlockHeader(blockHeader: BlockHeader) -> Certificate:
+def computeCertificateFromBlockHeader(blockHeader: BlockHeader) -> Certificate:
     c = object following unsignedCertificateSchema
     c.blockID = block ID of blockHeader
     c.height = blockHeader.height
     c.timestamp = blockHeader.timestamp
     c.stateRoot = blockHeader.stateRoot
     c.validatorsHash = blockHeader.validatorsHash
-    c.aggregationBits = empty bytes
-    c.signature = empty bytes
+    c.aggregationBits = EMPTY_BYTES
+    c.signature = EMPTY_BYTES
     return c
 ```
 
@@ -231,10 +232,10 @@ The certificate signature as byte array.
 ###### Execution
 
 ```python
-signCertificate(sk: bytes, chainID: bytes, c: Certificate) -> bytes:
-    c.aggregationBits = empty bytes
-    c.signature = empty bytes
-    message = serialization of c according to LIP 0027
+def signCertificate(sk: bytes, chainID: bytes, c: Certificate) -> bytes:
+    c.aggregationBits = EMPTY_BYTES
+    c.signature = EMPTY_BYTES
+    message = encode(certificateSchema, c)
     tag = MESSAGE_TAG_CERTIFICATE
     return signBLS(sk, tag, chainID, message)
 ```
@@ -257,10 +258,10 @@ The functions returns `True` if and only if the certificate signature is valid w
 ###### Execution
 
 ```python
-verifySingleCertificateSignature(pk: bytes, sig: bytes, chainID: bytes, c: Certificate) -> bool:
-    c.aggregationBits = empty bytes
-    c.signature = empty bytes
-    message = serialization of c according to LIP 0027
+def verifySingleCertificateSignature(pk: bytes, sig: bytes, chainID: bytes, c: Certificate) -> bool:
+    c.aggregationBits = EMPTY_BYTES
+    c.signature = EMPTY_BYTES
+    message = encode(certificateSchema, c)
     tag = MESSAGE_TAG_CERTIFICATE
     return verifyBLS(pk, tag, chainID, message, sig)
 ```
@@ -272,7 +273,7 @@ The following function verifies the aggregate BLS signature which is provided as
 ###### Parameters
 
 * `keysList` is an array of BLS public keys,
-* `bftWeights` is an array of weights corresponding to the BLS public keys, i.e., `bftWeights[i]` is the BFT weight of the validator with public key `keysList[i]`,
+* `bftWeights` is an array of BFT weights corresponding to the BLS public keys, i.e., `bftWeights[i]` is the BFT weight of the validator with public key `keysList[i]`,
 * `threshold` is the required threshold value for the signatures,
 * `chainID` is the chain ID of the chain that the certificate corresponds to,
 * `c` is a certificate object.
@@ -284,12 +285,12 @@ The functions returns `True` if and only if the aggregate certificate signature 
 ###### Execution
 
 ```python
-verifyAggregateCertificateSignature(keysList: list[bytes], bftWeights: list[uint64], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
+def verifyAggregateCertificateSignature(keysList: list[bytes], bftWeights: list[uint64], threshold: uint64, chainID: bytes, c: Certificate) -> bool:
     aggregateSignature = c.signature
     aggregationBits = c.aggregationBits
-    c.aggregationBits = empty bytes
-    c.signature = empty bytes
-    message = serialization of c according to LIP 0027
+    c.aggregationBits = EMPTY_BYTES
+    c.signature = EMPTY_BYTES
+    message = encode(certificateSchema, c)
     tag = MESSAGE_TAG_CERTIFICATE
     return verifyWeightedAggSig(keysList, aggregationBits, aggregateSignature, tag, chainID, bftWeights, threshold, message)
 ```
@@ -348,7 +349,7 @@ A single commit object of the block corresponding to `blockHeader` signed by the
 ##### Execution
 
 ```python
-createSingleCommit(blockHeader: BlockHeader, validatorAddress: bytes, sk: bytes, chainID: bytes) -> SingleCommit:
+def createSingleCommit(blockHeader: BlockHeader, validatorAddress: bytes, sk: bytes, chainID: bytes) -> SingleCommit:
     m = single commit object following singleCommitSchema
     m.blockID = block ID of blockHeader
     m.height = b.header.height
@@ -369,7 +370,7 @@ The height up to which single commits can be removed.
 ##### Execution
 
 ```python
-getMaxRemovalHeight() -> uint32:
+def getMaxRemovalHeight() -> uint32:
     b = block at height maxHeightFinalized
     return b.header.aggregateCommit.height
 ```
@@ -401,7 +402,7 @@ Every new incoming single commit message `m` is validated as follows:
 3. Discard `m` if `m.height` is not in `{getBFTHeights().maxHeightPrecommitted - COMMIT_RANGE_STORED, ..., getBFTHeights().maxHeightPrecommitted}` and `existBFTParameters(m.height+1)` returns `False` (i.e., `m.height` is not the height of a block authenticating a change of BFT parameters).
 4. Discard `m` if `m.blockID` is not the ID of the block `b` in the current chain at height `m.height`.
 5. Discard `m` if the validator given by `m.validatorAddress` is not active at height `m.height`. The active validators at height `m.height` can be obtained via `getBFTParameters(m.height).validators`.
-6. Let `b` be the block in the current chain at height `m.height`, `c = computeCertificateFromBlockHeader(b)`, `pk = validatorsModule.getValidatorAccount(m.validatorAddress).blsKey` be the BLS public key of the validator given by `m.validatorAddress` and `chainID` be the chain ID of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, chainID, c)` returns `True`.
+6. Let `b` be the block in the current chain at height `m.height`, `c = computeCertificateFromBlockHeader(b)`, `pk` be the BLS public key of the validator given by `m.validatorAddress` (obtained using `getBFTParameters(m.height).validators` and checking for BLS key in the array entry with the corresponding address) and `chainID` be the chain ID of the current chain. Check that `verifySingleCertificateSignature(pk, m.certificateSignature, chainID, c)` returns `True`.
 7. If all validations above pass, `m` is added to `nonGossipedCommits`. If steps 1 through 4 above pass, but step 5 or 6 fail, the corresponding peer receives a ban score of 100 (see [LIP 0004](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0004.md)).
 
 Let `h` be the height of the current tip of the chain. Commit messages in `nonGossipedCommits` are gossiped every `BLOCK_TIME/2` seconds as follows:
@@ -445,34 +446,34 @@ aggregateCommitSchema = {
 }
 ```
 
-#### Block Creation
+### Block Creation
 
-In this section, we define two functions that help validators compute an appropriate aggregate commit that can be added to the block.
+In this section, we define two functions that help validators compute an appropriate aggregate commit that can be added to the block. The function `selectAggregateCommit` defined below is used in the header initialization phase of the block creation as described in [LIP 0058][lip-0058#header-initialization].
 
-##### aggregateSingleCommits
+#### aggregateSingleCommits
 
 The function `aggregateSingleCommits` creates an aggregate commit from the provided single commits.
 
-###### Parameters
+##### Parameters
 
-* `singleCommits`: This is a set of single commit messages, all for the same block. We assume that each single commit passed the validation steps 1 - 7 in the section [Single Commit P2P Gossip](#single-commit-p2p-gossip).
+* `singleCommits`: This is a list of single commit messages, all for the same block. We assume that each single commit passed the validation steps 1 - 7 in the section [Single Commit P2P Gossip](#single-commit-p2p-gossip).
 
-###### Returns
+##### Returns
 
 The function then returns an object following the schema `aggregateCommitSchema`.
 
-###### Execution
+##### Execution
 
 ```python
-aggregateSingleCommits(singleCommits):
+def aggregateSingleCommits(singleCommits: list[SingleCommit]) -> AggregateCommit:
     h = m.height for first single commit in singleCommits
-    validatorAddresses = addresses of active validators obtained via getBFTParameters(h).validators
-    addressToBlsKey = []
-    for address in validatorAddresses:
-        addressToBlsKey[address] = validatorsModule.getValidatorAccount(address).blsKey
+    validatorList = getBFTParameters(h).validators
+    addressToBlsKey = {}
+    for validator in validatorList:
+        addressToBlsKey[validator.address] = validator.blsKey
     validatorKeys = addressToBlsKey.values() sorted lexicographically
     pubKeySignaturePairs = []
-    for all m in singleCommits:
+    for m in singleCommits:
         pk = addressToBlsKey(m.validatorAddress)
         add (pk, m.certificateSignature) to pubKeySignaturePairs
     (bitmap, aggSig) = createAggSig(validatorKeys, pubKeySignaturePairs)
@@ -483,18 +484,18 @@ aggregateSingleCommits(singleCommits):
     return aggregateCommit
 ```
 
-##### selectAggregateCommit
+#### selectAggregateCommit
 
 When creating a block, the validator node creating it uses the following function to select an aggregate commit to add to the block.
 
-###### Returns
+##### Returns
 
 An object following the schema `aggregateCommitSchema`, which can be added the next block.
 
-###### Execution
+##### Execution
 
 ```python
-selectAggregateCommit():
+def selectAggregateCommit() -> AggregateCommit:
     # Note that the BFT parameters at height maxHeightCertified+1 are already authenticated by the previous certificate
     heightNextBFTParameters = getNextHeightBFTParameters(getBFTHeights().maxHeightCertified + 1)
     if previous function call returns valid height:
@@ -516,23 +517,23 @@ selectAggregateCommit():
     # Return default aggregate commit object
     aggregateCommit = object following aggregateCommitSchema
     aggregateCommit.height =  getBFTHeights().maxHeightCertified
-    aggregateCommit.aggregationBits =  empty bytes
-    aggregateCommit.certificateSignature =  empty bytes
+    aggregateCommit.aggregationBits =  EMPTY_BYTES
+    aggregateCommit.certificateSignature =  EMPTY_BYTES
     return aggregateCommit
 ```
 
-#### Block Verification
+### Block Verification
 
 As part of the verification of a block header `blockHeader` as described in [LIP 0055][lip-0055], the property `aggregateCommit` has to be verified, i.e., the following function has to return `True`.
 
 ```python
-verifyAggregateCommit(aggregateCommit):
+def verifyAggregateCommit(aggregateCommit):
     # Check if the aggregate commit object is the default object with empty signature
-    if aggregateCommit.aggregationBits == empty bytes
-       and aggregateCommit.certificateSignature == empty bytes
+    if aggregateCommit.aggregationBits == EMPTY_BYTES
+       and aggregateCommit.certificateSignature == EMPTY_BYTES
        and aggregateCommit.height == getBFTHeights().maxHeightCertified:
         return True
-    if aggregateCommit.aggregationBits == empty bytes or aggregateCommit.certificateSignature == empty bytes:
+    if aggregateCommit.aggregationBits == EMPTY_BYTES or aggregateCommit.certificateSignature == EMPTY_BYTES:
         return False
     # The heights of aggregate commits must be strictly increasing
     if aggregateCommit.height <= getBFTHeights().maxHeightCertified:
@@ -608,7 +609,7 @@ The certificate object corresponding to the aggregate commit object given as inp
 ###### Execution
 
 ```python
-getCertificateFromAggregateCommit(aggregateCommit):
+def getCertificateFromAggregateCommit(aggregateCommit):
     blockHeader = block header at height aggregateCommit.height
     certificate = computeCertificateFromBlockHeader(blockHeader)
     certificate.aggregationBits = aggregateCommit.aggregationBits
@@ -643,7 +644,7 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromAggregateCommits` and the auxiliary function `checkChainOfTrust`.
 
 ```python
-getNextCertificateFromAggregateCommits(lastCertifiedHeight):
+def getNextCertificateFromAggregateCommits(lastCertifiedHeight):
     lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
     lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
     lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold
@@ -664,7 +665,7 @@ getNextCertificateFromAggregateCommits(lastCertifiedHeight):
 ```
 
 ```python
-checkChainOfTrust(lastValidatorsHash, blsKeyToBFTWeight, lastCertificateThreshold, aggregateCommit):
+def checkChainOfTrust(lastValidatorsHash, blsKeyToBFTWeight, lastCertificateThreshold, aggregateCommit):
     blockHeader = block header at height aggregateCommit.height - 1
     # Certificate signers and certificate threshold for aggregateCommit are those authenticated by the last certificate
     if lastValidatorsHash == blockHeader.validatorsHash:
@@ -712,7 +713,7 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromSingleCommits` and the auxiliary function `computeEligibleSingleCommits`.
 
 ```python
-getNextCertificateFromSingleCommits(lastCertifiedHeight):
+def getNextCertificateFromSingleCommits(lastCertifiedHeight):
     lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
     lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
     lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold
@@ -737,7 +738,7 @@ getNextCertificateFromSingleCommits(lastCertifiedHeight):
 ```
 
 ```python
-computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singleCommitsArray):
+def computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singleCommitsArray):
     eligibleSingleCommits = []
     aggregateBFTWeight = 0
     for singleCommit in singleCommitsArray:
@@ -763,5 +764,7 @@ computeEligibleSingleCommits(addressToBFTWeight, lastCertificateThreshold, singl
 [lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash
 [lip-0058#existbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#existbftparameters
 [lip-0058#getbftheights]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getbftheights
+[lip-0058#getbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getbftparameters
 [lip-0058#getnextheightbftparameters]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#getnextheightbftparameters
+[lip-0058#header-initialization]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#header-initialization
 [lip-0059]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0059.md

--- a/proposals/lip-0069.md
+++ b/proposals/lip-0069.md
@@ -8,6 +8,7 @@ Type: Informational
 Created: 2022-05-09
 Updated: 2022-09-01
 ```
+
 ## Abstract
 
 The purpose of this LIP is to describe the updated Lisk SDK architecture including the block lifecycle and hooks with related new terminologies.


### PR DESCRIPTION
In this PR makes the following changes:

- Any reference to the BFT module in LIP 0061 is removed (note that due to the application-engine separation, there is no BFT module any more). Previous function calls `bftModule.fct` are changed to `fct`. A list of all functions from [LIP 0058](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md) that are used in the specifications is given at the beginning of the specification section. 
- Any call to the Validator module is removed. Instead, the necessary information regarding validators is obtained from the BFT store via functions defined in [LIP 0058](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md) . This is possible as the BFT store now also stores validator keys.
- The network identifier is removed from LIP 0061 and replaced with the chain ID, see [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md) for background on chain identfiers.
- There is now two types of objects for certificates, a unsigned certificate (without properties `aggregationBits` and `signature`) and a signed certificate. All properties in both associated schema are required in accordance with [LIP 0064](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0064.md). All functions are updated with the respective return types.
- The block-level logic is defined more clearly, adjusting for the update of [LIP 0055](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md) and [LIP 0058](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md) and the new stages "Before Application Processing" and "After Application Processing". In particular, it is made more clear at what step in the block creation the function `selectAggregateCommit` should be called and at what step in the block processing the function `verifyAggregateCommit` should be called. For this, some additional clarity is also added to logic executed in "Before Application Processing" and "After Application Processing" in LIP 0058.
- Approach 2 for computing certificates from single commits is updated and now relies on past BFT parameters instead of calls to the Validators module.
- Type hinting and the appropriate types are introduced and some syntax is simplified.