### PR TITLE
Improve Interoperability LIPs

### DIFF
--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -237,7 +237,7 @@ def verify(trs: Transaction) -> None:
         raise Exception("Invalid extra command fee.")
     # Sender must have enough balance to pay for extra command fee.
     senderAddress = sha256(trs.senderPublicKey)[:ADDRESS_LENGTH]
-    if Token.getAvailableBalance(senderAddress, TOKEN_ID_LSK_MAINCHAIN) < REGISTRATION_FEE:
+    if Token.getAvailableBalance(senderAddress, TOKEN_ID_LSK) < REGISTRATION_FEE:
         raise Exception("Sender does not have enough balance.")
 ```
 
@@ -277,7 +277,7 @@ def execute(trs: Transaction) -> None:
             "root": EMPTY_HASH
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
-        "messageFeeTokenID": TOKEN_ID_LSK_MAINCHAIN
+        "messageFeeTokenID": TOKEN_ID_LSK
     }
     create an entry in the channel data substore with
         storeKey = chainID
@@ -303,7 +303,7 @@ def execute(trs: Transaction) -> None:
         storeValue = encode(chainIDSchema, {"chainID": chainID})
 
     # Burn the registration fee.
-    Token.burn(senderAddress, TOKEN_ID_LSK_MAINCHAIN, REGISTRATION_FEE)
+    Token.burn(senderAddress, TOKEN_ID_LSK, REGISTRATION_FEE)
 
     # Emit chain account updated event.
     emitEvent(
@@ -535,7 +535,7 @@ def execute(trs: Transaction) -> None:
             "root": EMPTY_HASH
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
-        "messageFeeTokenID": TOKEN_ID_LSK_MAINCHAIN
+        "messageFeeTokenID": TOKEN_ID_LSK
     }
     create an entry in the channel data substore with
         storeKey = CHAIN_ID_MAINCHAIN

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -318,6 +318,7 @@ def execute(trs: Transaction) -> None:
     # the receiving chain is not active yet.
     registrationCCMParams = {
         "name": trs.params.name,
+        "chainID": trs.params.chainID,
         "messageFeeTokenID": sidechainChannel.messageFeeTokenID
     }
 
@@ -577,6 +578,7 @@ def execute(trs: Transaction) -> None:
     # has not been activated yet.
     registrationCCMParams = {
         "name": CHAIN_NAME_MAINCHAIN,
+        "chainID": CHAIN_ID_MAINCHAIN,
         "messageFeeTokenID": mainchainChannel.messageFeeTokenID
     }
 

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/chain-registration
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2022-10-23
+Updated: 2022-11-11
 Requires: 0038, 0045, 0049, 0056
 ```
 
@@ -69,11 +69,6 @@ This property defines the set of eligible [BLS public keys][lip-0038] with their
 
 The `certificateThreshold` property is an integer setting the required cumulative weight needed for a certificate signature from the sidechain to be valid.
 
-##### sidechainRegistrationFee
-
-The `sidechainRegistrationFee` property accounts for the extra fee required to register the sidechain. It should be set to the value of the `REGISTRATION_FEE` constant.
-
-
 ### Mainchain Registration on a Sidechain
 
 Once the sidechain has been registered on the mainchain, a similar registration process should happen in the sidechain before the interoperable channel is opened between the two chains. This is done by submitting a transaction with the mainchain registration command in the sidechain, which implies the creation of a _mainchain account_ in the sidechain state associated with the Lisk mainchain and other structures needed for interoperability. This mainchain account has a similar structure as the one depicted in Figure 1. By protocol, the chain ID of the mainchain is a constant equal to `CHAIN_ID_MAINCHAIN` in the ecosystem.
@@ -132,8 +127,7 @@ sidechainRegParams = {
         "name",
         "chainID",
         "initValidators",
-        "certificateThreshold",
-        "sidechainRegistrationFee"
+        "certificateThreshold"
     ],
     "properties": {
         "name": {
@@ -169,10 +163,6 @@ sidechainRegParams = {
         "certificateThreshold": {
             "dataType": "uint64",
             "fieldNumber": 4
-        },
-        "sidechainRegistrationFee": {
-            "type": "uint64",
-            "fieldNumber": 5
         }
     }
 }
@@ -232,13 +222,9 @@ def verify(trs: Transaction) -> None:
     if trs.params.certificateThreshold > totalWeight:
         raise Exception("Certificate threshold is too large.")
 
-    # sidechainRegistrationFee must equal REGISTRATION_FEE.
-    if trs.params.sidechainRegistrationFee != REGISTRATION_FEE:
-        raise Exception("Invalid extra command fee.")
-    # Sender must have enough balance to pay for extra command fee.
-    senderAddress = sha256(trs.senderPublicKey)[:ADDRESS_LENGTH]
-    if Token.getAvailableBalance(senderAddress, TOKEN_ID_LSK) < REGISTRATION_FEE:
-        raise Exception("Sender does not have enough balance.")
+    # Transaction fee has to be greater or equal than the registration fee.
+    if trs.fee < REGISTRATION_FEE:
+        raise Exception("Insufficient transaction fee.")
 ```
 
 #### Execution
@@ -302,8 +288,8 @@ def execute(trs: Transaction) -> None:
         storeKey = trs.params.name
         storeValue = encode(chainIDSchema, {"chainID": chainID})
 
-    # Burn the registration fee.
-    Token.burn(senderAddress, TOKEN_ID_LSK, REGISTRATION_FEE)
+    # Pay the registration fee.
+    Fee.payFee(REGISTRATION_FEE)
 
     # Emit chain account updated event.
     emitEvent(

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -218,7 +218,7 @@ In this section, we specify the substores that are part of the Interoperability 
 | `EMPTY_BYTES` | bytes | "" | The empty byte string. |
 | `EMPTY_FEE_ADDRESS` | bytes | "" | The empty byte string. |
 | `THRESHOLD_MAINCHAIN` | uint32 | `68` | The certificate threshold used for Lisk mainchain. Defined in the DPoS module. |
-| `TOKEN_ID_LSK_MAINCHAIN` | bytes | 0x0000000000000000 | The token ID of the Lisk token. Defined in the Token module. |
+| `TOKEN_ID_LSK` | bytes | 0x0000000000000000 | The token ID of the Lisk token. Defined in the Token module. |
 | `MAINCHAIN_NUMBER_ACTIVE_DELEGATES` 	| uint32 | 101 | The number of active delegates on the Lisk mainchain. Defined in the DPoS module. |
 | `MIN_RETURN_FEE` | uint64 | 1000 | The minimum return fee for a cross-chain message in Beddows. |
 | `MAX_CCM_SIZE` | uint64 | 10240 | The maximum size of a cross-chain message in bytes. |

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -593,7 +593,7 @@ terminatedStateAccountSchema = {
 ##### Properties and Default values
 
 * `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain. If the account is not initialized, it is set to `EMPTY_BYTES` instead.
-* `mainchainStateRoot`: The state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(CHAIN_ID_MAINCHAIN).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_BYTES` instead.
+* `mainchainStateRoot`: The state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(CHAIN_ID_MAINCHAIN).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_HASH` instead.
 * `initialized`: A boolean value, indicating whether the terminated state account has been initialized, i.e. if the `stateRoot` property has been set.
 
 A terminated state account is created as part of the `terminateChain` function, as part of the processing of a sidechain terminated CCM, as part of the processing of a channel terminated CCM, or as part of the processing of a state recovery initialization command.
@@ -979,7 +979,7 @@ def createTerminatedStateAccount(chainID: ChainID, stateRoot: bytes = EMPTY_BYTE
 
         terminatedState = {
             "stateRoot": stateRoot,
-            "mainchainStateRoot": EMPTY_BYTES,
+            "mainchainStateRoot": EMPTY_HASH,
             "initialized": True
         }
 
@@ -1000,7 +1000,7 @@ def createTerminatedStateAccount(chainID: ChainID, stateRoot: bytes = EMPTY_BYTE
             raise Exception('Chain to be terminated is not valid.')
 
         terminatedState = {
-            "stateRoot": EMPTY_BYTES,
+            "stateRoot": EMPTY_HASH,
             "mainchainStateRoot": chainAccount(CHAIN_ID_MAINCHAIN).lastCertificate.stateRoot,
             "initialized": False
         }
@@ -1382,7 +1382,7 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
 * Within each substore, check that all entries have a different `storeKey`.
 * For each entry in the chain data substore there must be a corresponding entry (with the same value of `storeKey`) in the outbox root, channel data, and chain validators substores and viceversa. However, if the chain account has status set to terminated, the entry in the outbox root must *not* be present.
 * For each entry in the terminated outbox substore there must be a corresponding entry (with the same value of `storeKey`) in the terminated state substore.
-* For each entry in the terminated state substore, if the property `initialized` is set to `False`, the corresponding entry in the terminated outbox substore must *not* be present. Furthermore, the `stateRoot` must be set to empty bytes and `mainchainStateRoot` must have length `HASH_LENGTH`. Conversely, if the property `initialized` is set to `True`, the `stateRoot` must have have length `HASH_LENGTH` and `mainchainStateRoot` to empty bytes.
+* For each entry in the terminated state substore, if the property `initialized` is set to `False`, the corresponding entry in the terminated outbox substore must *not* be present. Furthermore, the `stateRoot` must be set to `EMPTY_HASH` and `mainchainStateRoot` must not be set to `EMPTY_HASH`. Conversely, if the property `initialized` is set to `True`, the `stateRoot` must not be set to `EMPTY_HASH` and `mainchainStateRoot` must be set to `EMPTY_HASH`.
 * For each entry `chainValidators` in `interoperabilityAsset.chainValidatorsSubstore`, let `activeValidators = chainValidators.storeValue.activeValidators` and let `certificateThreshold = chainValidators.storeValue.certificateThreshold`:
   * `activeValidators` must have at least 1 element and at most `MAX_NUM_VALIDATORS` elements.
   * `activeValidators` must be ordered lexicographically by `blsKey` property.

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -764,7 +764,7 @@ def sendInternal(sendingAddress: Address,
     receivingChainID: ChainID,
     fee: uint64,
     status: uint32,
-    params: object
+    params: bytes
 ) -> None:
 
     # Not possible to send messages to the own chain.
@@ -826,6 +826,20 @@ def sendInternal(sendingAddress: Address,
         )
         raise Exception('Receiving chain is not live.')
 
+    # Pay message fee.
+    if fee > 0:
+        try:
+            Token.payMessageFee(sendingAddress, fee, ccm.receivingChainID)
+        except Exception as e:
+            ccm.params = EMPTY_BYTES
+            emitPersistentEvent(
+                module = MODULE_NAME_INTEROPERABILITY,
+                name = EVENT_NAME_CCM_SENT_FAILED,
+                data = {"ccm": ccm, "code": CCM_SENT_FAILED_CODE_MESSAGE_FEE_EXCEPTION},
+                topics = []
+            )
+            raise e
+
     # Processing on the mainchain.
     if ownChainAccount.chainID == CHAIN_ID_MAINCHAIN:
         partnerChainID = receivingChainID
@@ -847,20 +861,6 @@ def sendInternal(sendingAddress: Address,
             topics = []
         )
         raise Exception('Channel is not active.')
-
-    # Pay message fee.
-    if fee > 0:
-        try:
-            Token.payMessageFee(sendingAddress, fee, ccm.receivingChainID)
-        except Exception as e:
-            ccm.params = EMPTY_BYTES
-            emitPersistentEvent(
-                module = MODULE_NAME_INTEROPERABILITY,
-                name = EVENT_NAME_CCM_SENT_FAILED,
-                data = {"ccm": ccm, "code": CCM_SENT_FAILED_CODE_MESSAGE_FEE_EXCEPTION},
-                topics = []
-            )
-            raise e
 
     ccmID = sha256(encode(crossChainMessageSchema, ccm))
     addToOutbox(partnerChainID, ccm)
@@ -892,7 +892,7 @@ def terminateChain(chainID: ChainID) -> None:
         chainID,
         0,
         CCM_STATUS_CODE_OK,
-        {}
+        EMPTY_BYTES
     )
 
     createTerminatedStateAccount(chainID)
@@ -935,7 +935,18 @@ def bounce(ccm: CCM, newCCMStatus: uint32, ccmProcessedEventCode: uint32) -> Non
         else:
             ccm.fee -= minimumFee     
 
-        addToOutbox(ccm.receivingChainID, ccm)
+        # Processing on the mainchain.
+        if ownChainAccount.chainID == CHAIN_ID_MAINCHAIN:
+            partnerChainID = receivingChainID
+        # Processing on a sidechain.
+        else:
+            # Check for direct channel.
+            if chainAccount(receivingChainID) does not exist:
+                partnerChainID = CHAIN_ID_MAINCHAIN
+            else:
+                partnerChainID = receivingChainID
+
+        addToOutbox(partnerChainID, ccm)
         newCcmID = sha256(encode(crossChainMessageSchema, ccm))
         emitEvent(
             module = MODULE_NAME_INTEROPERABILITY,
@@ -1246,7 +1257,7 @@ def send(sendingAddress: Address,
     crossChainCommand: CrossChainCommand,
     receivingChainID: ChainID,
     fee: uint64,
-    params: object
+    params: bytes
 ) -> None:
 
     sendInternal(
@@ -1256,7 +1267,7 @@ def send(sendingAddress: Address,
         receivingChainID,
         fee,
         CCM_STATUS_CODE_OK,
-        ccm.params
+        params
     )
 ```
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -381,7 +381,7 @@ def forward(ccu: Transaction, ccm: CCM) -> None:
             ccm.sendingChainID,
             0,
             CCM_STATUS_CODE_OK,
-            stmParams
+            encode(sidechainTerminatedCCMParamsSchema, stmParams)
         )
         return
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-messages/299
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2022-10-23
+Updated: 2022-11-11
 Requires: 0053
 ```
 
@@ -189,13 +189,36 @@ crossChainMessageSchema = {
 
 The `module` and `crossChainCommand` properties can only contain alphanumeric characters.
 
+### Serialization
+
+The serialization of an object of type `CCM` is described in the following pseudocode.
+
+```python
+def encodeCCM(ccm: CCM) -> bytes:
+    paramsSchema = JSON schema corresponding to (ccm.module, ccm.crossChainCommand) pair
+    ccm.params = encode(paramsSchema,ccm.params)
+    return encode(crossChainMessageSchema, ccm)
+```
+
+### Deserialization
+
+Consider a binary message `ccmBytes`, corresponding to a serialized cross-chain message. The deserialization procedure is as follows:
+
+```python
+def decodeCCM(ccmBytes: bytes) -> CCM:
+    ccm = decode(crossChainMessageSchema, ccmBytes)
+    paramsSchema = JSON schema corresponding to (ccm.module, ccm.crossChainCommand) pair
+    ccm.params = decode(paramsSchema, ccm.params)
+    return ccm
+```
+
 ### Cross-chain Message ID
 
 The ID of a cross-chain message `ccm` is computed as `sha256(encode(crossChainMessageSchema, ccm))`.
 
 ### Internal Functions
 
-When processing a cross-chain message `ccm`, the functions below may be called by commands from the Interoperability module. Recall that `chainAccount(chainID)` returns the corresponding entry in the chain data substore, and `ownChainAccount` returns the object stored in the own chain account substore.
+When processing a cross-chain message `ccm`, the functions below may be called by commands from the Interoperability module. Recall that `chainAccount(chainID)` returns the corresponding entry in the chain data substore.
 
 #### validateFormat
 
@@ -213,7 +236,7 @@ def validateFormat(ccm: CCM) -> None:
     if not re.match("^[a-zA-Z0-9]*$", ccm.crossChainCommand):
         raise Exception("Cross-chain message command name must be alphanumeric.")
     # Check ccm size.
-    if ccmBytes > MAX_CCM_SIZE:
+    if len(ccmBytes) > MAX_CCM_SIZE:
         raise Exception(f"Cross-chain message size is larger than {MAX_CCM_SIZE}.")
 ```
 
@@ -366,7 +389,7 @@ def forward(ccu: Transaction, ccm: CCM) -> None:
             data = {"ccmID": ccmID, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE},
             topics = [ccm.sendingChainID, ccm.receivingChainID]
         )
-        
+
         # A sidechain terminated message is returned to the sending chain
         # to inform them that the receiving chain is terminated.
         stmParams = {
@@ -496,10 +519,14 @@ registrationCCMParamsSchema = {
 A registration message is created by the Interoperability module when registering a chain, as specified in [LIP 0043][lip-0043].
 
 ##### Verification
+
 ```python
 def verify(ccu: Transaction, ccm: CCM) -> None:
     if chainAccount(ccm.sendingChainID) does not exist:
         raise Exception("Registration message must be sent from a registered chain.")
+
+    if ccm.sendingChainID != ccu.sendingCHainID:
+            raise Exception("Registration message must be sent from a direct channel.")
     
     if chainAccount(ccm.sendingChainID).status != CHAIN_REGISTERED:
         raise Exception("Registration message must be sent from a chain with status 'registered'.")
@@ -526,10 +553,6 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
     if ownChainAccount.chainID == CHAIN_ID_MAINCHAIN:
         if ccm.nonce != 0:
             raise Exception("Registration message must have nonce 0.")
-    # Processing on a sidechain.
-    else:
-        if chainAccount(ccm.sendingChainID) does not exist:
-            raise Exception("Registration message must be sent from the mainchain.")
 ```
 
 ##### Execution

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -438,8 +438,9 @@ A channel terminated message is created by the Interoperability module when [ter
 
 ```python
 def execute(ccu: Transaction, ccm: CCM) -> None:
-    if isLive(ccm.sendingChainID):
-        createTerminatedStateAccount(ccm.sendingChainID)
+    if terminatedStateAccount(ccm.sendingChainID) exists:
+        return
+    createTerminatedStateAccount(ccm.sendingChainID)
 ```
 
 The function `createTerminatedStateAccount` is defined in [LIP 0045][lip-0045#createTerminatedStateAccount].
@@ -462,23 +463,32 @@ registrationCCMParamsSchema = {
     "type": "object",
     "required" : [
         "name",
+        "chainID",
         "messageFeeTokenID"
     ],
     "properties": {
         "name": {
             "dataType": "string",
+            "minLength": MIN_CHAIN_NAME_LENGTH,
+            "maxLength": MAX_CHAIN_NAME_LENGTH,
             "fieldNumber": 1
+        },
+        "chainID": {
+            "dataType": "bytes",
+            "length": CHAIN_ID_LENGTH,
+            "fieldNumber": 2
         },
         "messageFeeTokenID": {
             "dataType": "bytes",
             "length": TOKEN_ID_LENGTH,
-            "fieldNumber": 2
+            "fieldNumber": 3
         }
     }
 }
 ```
 
 * `name`: name registered on the mainchain.
+* `chainID`: chain ID registered on the mainchain.
 * `messageFeeTokenID`: ID of the token used for cross-chain message fees.
 
 ##### Creation
@@ -488,6 +498,12 @@ A registration message is created by the Interoperability module when registerin
 ##### Verification
 ```python
 def verify(ccu: Transaction, ccm: CCM) -> None:
+    if chainAccount(ccm.sendingChainID) does not exist:
+        raise Exception("Registration message must be sent from a registered chain.")
+    
+    if chainAccount(ccm.sendingChainID).status != CHAIN_REGISTERED:
+        raise Exception("Registration message must be sent from a chain with status 'registered'.")
+
     if channel(ccm.sendingChainID).inbox.size != 0:
         raise Exception("Registration message must be the first message in the inbox.")
 
@@ -496,6 +512,9 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
 
     if ownChainAccount.chainID != ccm.receivingChainID:
         raise Exception("Registration message must be sent to the chain account ID of the chain.")
+    
+    if ownChainAccount.chainID != ccm.params.chainID:
+        raise Exception("Registration message must contain the chain ID of the registered chain.")
 
     if ownChainAccount.name != ccm.params.name:
         raise Exception("Registration message must contain the name of the registered chain.")
@@ -509,7 +528,7 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
             raise Exception("Registration message must have nonce 0.")
     # Processing on a sidechain.
     else:
-        if ccm.sendingChainID != CHAIN_ID_MAINCHAIN:
+        if chainAccount(ccm.sendingChainID) does not exist:
             raise Exception("Registration message must be sent from the mainchain.")
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2022-10-23
+Updated: 2022-11-11
 Requires: 0045, 0049, 0058, 0061
 ```
 
@@ -420,6 +420,15 @@ _Figure 1: A schematic of the steps of a mainchain CCU execution. Some details a
 def execute(ccu: Transaction) -> None:
     # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
     verifyCertificateSignature(ccu)
+
+    if ccu.params.inboxUpdate is not empty:
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
+
     # Process cross-chain messages in inbox update.
     crossChainMessages = ccu.params.inboxUpdate.crossChainMessages
 
@@ -434,7 +443,7 @@ def execute(ccu: Transaction) -> None:
                 raise Exception("CCM is not from the sending chain.")
             # Sending and receiving chains must differ.
             if ccm.receivingChainID == ccm.sendingChainID:
-                raise Exception("Sending and receiving chains must differ.") 
+                raise Exception("Sending and receiving chains must differ.")
             if ccm.status == CCM_STATUS_CODE_CHANNEL_UNAVAILABLE:
                 raise Exception("CCM status channel unavailable can only be set on the mainchain.")
         except:
@@ -450,7 +459,7 @@ def execute(ccu: Transaction) -> None:
             )
             # In this case, we do not even update the chain account with the new certificate.
             return
-    
+
     # Update sidechain validators.
     if len(ccu.params.activeValidatorsUpdate) > 0 or ccu.params.certificateThreshold != validators(ccu.params.sendingChainID).certificateThreshold:
         updateValidators(ccu)
@@ -461,6 +470,9 @@ def execute(ccu: Transaction) -> None:
 
     if ccu.params.inboxUpdate is not empty: # An empty object has all properties set to their default values.
         updatePartnerChainOutboxRoot(ccu)
+
+    # Update the context to indicate that now we start the CCM processing.
+    ctx.ccmProcessing = True
 
     for ccmBytes in crossChainMessages:
         ccmID = sha256(ccmBytes)
@@ -482,6 +494,8 @@ def execute(ccu: Transaction) -> None:
         # it is still possible to recover it (because the channel terminated message
         # would refer to an inbox where the message has not been appended yet).
         appendToInboxTree(ccu.params.sendingChainID, ccmBytes)
+    # Update the context to indicate that now we stop the CCM processing.
+    ctx.ccmProcessing = False
 ```
 
 #### SidechainCrossChainUpdate
@@ -532,6 +546,14 @@ def execute(ccu: Transaction) -> None:
     # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
     verifyCertificateSignature(ccu)
 
+    if ccu.params.inboxUpdate is not empty:
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
+
     # Process cross-chain messages in inbox update.
     crossChainMessages = ccu.params.inboxUpdate.crossChainMessages
 
@@ -560,7 +582,7 @@ def execute(ccu: Transaction) -> None:
             )
             # In this case, we do not even update the chain account with the new certificate.
             return
-    
+
     # Update sidechain validators.
     if len(ccu.params.activeValidatorsUpdate) > 0 or ccu.params.certificateThreshold != validators(ccu.params.sendingChainID).certificateThreshold:
         updateValidators(ccu)
@@ -572,6 +594,8 @@ def execute(ccu: Transaction) -> None:
     if ccu.params.inboxUpdate is not empty: # An empty object has all properties set to their default values.
         updatePartnerChainOutboxRoot(ccu)
 
+    # Update the context to indicate that now we start the CCM processing.
+    ctx.ccmProcessing = True
     for ccmBytes in crossChainMessages:
         ccmID = sha256(ccmBytes)
         # Set ccmID (instead of the transaction ID) as default topic to all events emitted in apply
@@ -579,6 +603,8 @@ def execute(ccu: Transaction) -> None:
         ccm = decode(crossChainMessageSchema, ccmBytes)
         apply(ccu, ccm)
         appendToInboxTree(ccu.params.sendingChainID, ccmBytes)
+    # Update the context to indicate that now we stop the CCM processing.
+    ctx.ccmProcessing = False
 ```
 
 ## Backwards Compatibility

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -98,6 +98,7 @@ All interoperability constants are defined in [LIP 0045][lip-0045#constants].
 ### Auxiliary Functions
 
 The following auxiliary functions are used internally by the Interoperability module to verify and execute cross-chain updates.
+The certificate schema `certificateSchema` is defined in [LIP 0061][lip-0061#certificate-schema].
 
 #### verifyLivenessConditionForRegisteredChains
 
@@ -106,7 +107,7 @@ def verifyLivenessConditionForRegisteredChains(ccu: Transaction) -> None:
     if len(ccu.params.certificate) > 0 and len(ccu.params.inboxUpdate) > 0:
         certificate = decode(certificateSchema, ccu.params.certificate)
         timestamp = timestamp of the block including ccu
-        if len(ccu.params.inboxUpdate) > 0 and timestamp - certificate.timestamp > LIVENESS_LIMIT / 2:
+        if timestamp - certificate.timestamp > LIVENESS_LIMIT / 2:
             raise Exception(f"The first CCU with a non-empty inbox update cannot contain a certificate older than {LIVENESS_LIMIT / 2} seconds.")
 ```
 
@@ -439,6 +440,8 @@ def execute(ccu: Transaction) -> None:
         except:
             terminateChain(ccu.params.sendingChainID)
             ccmID = sha256(ccmBytes)
+            # Set ccmID (instead of the transaction ID) as default topic of this event.
+            defaultEventsTopic = ccmID
             emitEvent(
                 module = MODULE_NAME_INTEROPERABILITY,
                 name = EVENT_NAME_CCM_PROCESSED,
@@ -460,6 +463,10 @@ def execute(ccu: Transaction) -> None:
         updatePartnerChainOutboxRoot(ccu)
 
     for ccmBytes in crossChainMessages:
+        ccmID = sha256(ccmBytes)
+        # Set ccmID (instead of the transaction ID) as default topic to all events emitted in apply and forward
+        defaultEventsTopic = ccmID
+
         ccm = decode(crossChainMessageSchema, ccmBytes)
 
         # If the receiving chain is the mainchain, apply the CCM.
@@ -497,6 +504,9 @@ def verify(ccu: Transaction) -> None:
     # Only the mainchain can send this command.
     if ccu.params.sendingChainID != CHAIN_ID_MAINCHAIN:
          raise Exception("Only the mainchain can send a sidechain cross-chain update.")
+    # The  mainchain account must exist.
+    if chainAccount(ccu.params.sendingChainID) does not exists:
+        raise Exception("The mainchain is not registered.")
     if not isLive(ccu.params.sendingChainID):
         raise Exception("The sending chain is not live.")
 
@@ -540,6 +550,8 @@ def execute(ccu: Transaction) -> None:
         except:
             terminateChain(ccu.params.sendingChainID)
             ccmID = sha256(ccmBytes)
+            # Set ccmID (instead of the transaction ID) as default topic of this event.
+            defaultEventsTopic = ccmID
             emitEvent(
                 module = MODULE_NAME_INTEROPERABILITY,
                 name = EVENT_NAME_CCM_PROCESSED,
@@ -561,6 +573,9 @@ def execute(ccu: Transaction) -> None:
         updatePartnerChainOutboxRoot(ccu)
 
     for ccmBytes in crossChainMessages:
+        ccmID = sha256(ccmBytes)
+        # Set ccmID (instead of the transaction ID) as default topic to all events emitted in apply
+        defaultEventsTopic = ccmID
         ccm = decode(crossChainMessageSchema, ccmBytes)
         apply(ccu, ccm)
         appendToInboxTree(ccu.params.sendingChainID, ccmBytes)

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -368,12 +368,9 @@ def verify(trs: Transaction) -> None:
 
 ```python
 def execute(trs: Transaction) -> None:
-    senderAddress = sha256(trs.senderPublicKey)[:ADDRESS_LENGTH]
-    # Set CCM status to recovered and assign fee to trs sender.
-    crossChainMessages = [decode(crossChainMessageSchema, ccmBytes) for ccmBytes in trs.params.crossChainMessages]
+    
     recoveredCCMs = []
-
-    for ccmBytes in crossChainMessages:
+    for ccmBytes in trs.params.crossChainMessages:
         ccmID = sha256(ccmBytes)
         # Set ccmID as default topic to all events emitted in applyRecovery and forwardRecovery
         # (instead of the transaction ID).
@@ -700,7 +697,7 @@ def execute(trs: Transaction) -> None:
     sidechainAccount = decode(chainAccountSchema, trs.params.sidechainAccount)
     if terminatedStateAccount(trs.params.chainID) exists:
         terminatedStateAccount(trs.params.chainID).stateRoot = sidechainAccount.lastCertificate.stateRoot
-        terminatedStateAccount(trs.params.chainID).mainchainStateRoot = EMPTY_BYTES
+        terminatedStateAccount(trs.params.chainID).mainchainStateRoot = EMPTY_HASH
         terminatedStateAccount(trs.params.chainID).initialized = True
     else:
         createTerminatedStateAccount(trs.params.chainID, sidechainAccount.lastCertificate.stateRoot)


### PR DESCRIPTION
Update Interoperability LIPs to include the following improvements.

### LIP 0043

- Remove `height` in line 447
- Use `getValidatorParams` on line 448/449
- don't use (undefined) constant `THRESHOLD_MAINCHAIN`, but rather add it to the params.
- just check BFT weight > 0 in mainchain reg (maybe not necessary)
- rename `initValidators` to `sidechainValidators`
- remove redundant comment about not using `send` function
- rename `certificateThreshold` to `mainchain/sidechainCertificateThreshold` for extra clarity.
- "every newly registered sidechain can increase the size of every cross-chain update command posted on the mainchain" --> should be "from the mainchain"
- Don't use constant `TOKEN_ID_LSK_MAINCHAIN`, but just `TOKEN_ID_LSK` (also in the table defined in LIP45 and perhaps in other LIPs) 
- arguments of `verifyWeightedAggSig` are in a wrong order
- remove description of sidechain registration fee

### LIP 0045 - Interoperability module

- pass `params` as bytes to `send` function (encoded from the module calling send method) instead of an object instead of encoding it in the `sendInternal` method which is extra work of finding the right module/ccCommand to encode.
- Fix `bounce` to get the correct partnerChainID (correct channel).

### LIP 0049

- channel terminated exection: remove usage of `isLive`.
- registration message should check that status is `CHAIN_REGISTERED` and that chain account exists. Drop requirement that it comes from mainchain only.
- Re-add `chainID` to registration message (important for direct channels). This impacts also LIP0043

### LIP 0053

- `certificateSchema` is used multiple times but not defined in any interop. LIP. Add link to LIP 0061 where it is defined.
- explicitly check chainAccount existence before checking `isLive` (similar to direct channels LIP)
- explicitly set the ccmID as default topic (similar to what is done in LIP 0054)
- remove unnecessary check : `if len(ccu.params.inboxUpdate) > 0 and timestamp - certificate.timestamp > LIVENESS_LIMIT / 2:`

### validators in LIP 0053

- make update active validators more efficient (dont pass the BLS key)
- check that we have at most 200 validators after update

### LIP 0054

- fix typos in message recovery command execution.
- Set initialized terminated state account `mainchainStateRoot` to `EMPTY_HASH` (check also in LIP45).