### PR TITLE
Improve definition of CHAIN_ID_MAINCHAIN and TOKEN_ID_LSK

### DIFF
--- a/proposals/lip-0042.md
+++ b/proposals/lip-0042.md
@@ -50,7 +50,7 @@ In this section, we specify the protocol logic in the lifecycle of a block injec
 | `REWARD_REDUCTION_SEED_REVEAL`  | uint32   | 1                                         |
 | `REWARD_REDUCTION_MAX_PREVOTES` | uint32   | 2                                         |
 | `TOKEN_ID_REWARD`               | bytes    | specified as part of module configuration |
-| `TOKEN_ID_LSK`                  | bytes    | `0x0000000000000000`                      |
+| `TOKEN_ID_LSK`                  | bytes    | as specified in [LIP 0051](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations) |
 | `REWARD_REDUCTION_FACTOR_BFT`   | uint32   | 4                                         |
 
 ### Token for rewards

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -263,7 +263,7 @@ def execute(trs: Transaction) -> None:
             "root": EMPTY_HASH
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
-        "messageFeeTokenID": TOKEN_ID_LSK_MAINCHAIN
+        "messageFeeTokenID": TOKEN_ID_LSK
     }
     create an entry in the channel data substore with
         storeKey = chainID
@@ -520,7 +520,7 @@ def execute(trs: Transaction) -> None:
             "root": EMPTY_HASH
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
-        "messageFeeTokenID": TOKEN_ID_LSK_MAINCHAIN
+        "messageFeeTokenID": TOKEN_ID_LSK
     }
     create an entry in the channel data substore with
         storeKey = CHAIN_ID_MAINCHAIN

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -57,7 +57,6 @@ We define the following constants:
 | `SUBSTORE_PREFIX_GENESIS_DATA` | bytes | 0xc000 | Substore prefix of the genesis data substore. |
 | `INVALID_BLS_KEY` | bytes | `BLS_PUBLIC_KEY_LENGTH` bytes all set to 0x00 | An invalid BLS key, used as a placeholder before a valid BLS key is registered. |
 | `BLOCK_TIME` | integer | 10 (value for the Lisk mainchain) | Block time (in seconds) set in the chain configuration. |
-| `MAINCHAIN_ID` | bytes | Value is specified in [LIP 0045][lip-0045#constants] | The chain ID of the mainchain as part of the interoperability module. |
 | `EVENT_NAME_GENERATOR_KEY_REGISTRATION` | string | "generatorKeyRegistration" | Name of the generator key registration event. |
 | `EVENT_NAME_BLS_KEY_REGISTRATION` | string | "blsKeyRegistration" | Name of the BLS key registration event. |
 | `KEY_REG_RESULT_SUCCESS` | uint32 | 0 | Success result code of key registration events. |

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -135,7 +135,7 @@ In this section, we specify the substores that are part of the Interoperability 
 |------|------|-------|-------------|
 | **Interoperability Constants** | | | |
 | `MODULE_NAME_INTEROPERABILITY` | string | "interoperability" | Name of the Interoperability module. |
-| `CHAIN_ID_MAINCHAIN` | bytes | 0x00000000 | Chain ID of the Lisk mainchain in the mainnet. |
+| `CHAIN_ID_MAINCHAIN` | bytes | `CHAIN_ID_PREFIX` + 0x000000 | Chain ID of the Lisk mainchain as defined in [LIP 0063](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0063.md#constants). Note that `CHAIN_ID_PREFIX` is the network prefix depending on the network as stated in [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1). |
 | `CHAIN_NAME_MAINCHAIN` | string | "lisk-mainchain" | Name of the Lisk mainchain. |
 | **Interoperability Store** | | | |
 | `STORE_PREFIX_INTEROPERABILITY` | bytes | 0x83ed0d25 | Prefix of the interoperability store. |
@@ -218,7 +218,7 @@ In this section, we specify the substores that are part of the Interoperability 
 | `EMPTY_BYTES` | bytes | "" | The empty byte string. |
 | `EMPTY_FEE_ADDRESS` | bytes | "" | The empty byte string. |
 | `THRESHOLD_MAINCHAIN` | uint32 | `68` | The certificate threshold used for Lisk mainchain. Defined in the DPoS module. |
-| `TOKEN_ID_LSK_MAINCHAIN` | bytes | 0x0000000000000000 | The token ID of the Lisk token. Defined in the Token module. |
+| `TOKEN_ID_LSK` | bytes | `CHAIN_ID_MAINCHAIN` +  0x00000000 | The token ID of the Lisk token. Defined in the Token module. |
 | `MAINCHAIN_NUMBER_ACTIVE_DELEGATES` 	| uint32 | 101 | The number of active delegates on the Lisk mainchain. Defined in the DPoS module. |
 | `MIN_RETURN_FEE` | uint64 | 1000 | The minimum return fee for a cross-chain message in Beddows. |
 | `MAX_CCM_SIZE` | uint64 | 10240 | The maximum size of a cross-chain message in bytes. |

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -56,7 +56,7 @@ We define the following constants:
 | `LENGTH_TOKEN_ID`|uint32|8|The length of a token ID in bytes.|
 | **Configurable Constants** | | **Mainchain Value** | |
 | `MIN_FEE_PER_BYTE` | uint64 | 1000 | Minimum amount of fee per byte required for transaction validity. |
-| `TOKEN_ID_FEE` | bytes | `TOKEN_ID_LSK = 0x0000000000000000` | Token ID of the token used to pay the transaction fees. |
+| `TOKEN_ID_FEE` | bytes | `TOKEN_ID_LSK` as defined in [LIP 0051](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations) | Token ID of the token used to pay the transaction fees. |
 | **Type Definitions** | | | |
 | `TokenID` | bytes | Must be of length `LENGTH_TOKEN_ID`. | Used for token identifiers. |
 

--- a/proposals/lip-0050.md
+++ b/proposals/lip-0050.md
@@ -50,7 +50,7 @@ We define the following constants:
 | `EVENT_NAME_ACCOUNT_RECLAIMED` | string | "accountReclaimed" | The name of the account reclaimed event. |
 | `EVENT_NAME_KEYS_REGISTERED` | string | "keysRegistered" | The name of the keys registered event. |
 | `SUBSTORE_PREFIX_LEGACY_ACCOUNTS` | bytes | 0x0000 | Substore prefix of the legacy accounts substore. This contains the addresses and balances of legacy accounts. |
-| `TOKEN_ID_LSK` | bytes | 0x0000000000000000 | Identifier of the LSK token. |
+| `TOKEN_ID_LSK` | bytes | `CHAIN_ID_MAINCHAIN` +  0x00000000 | The token ID of the Lisk token as defined in the [Token module](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations). `CHAIN_ID_MAINCHAIN` is defined in [LIP 0063](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0063.md#constants). |
 | `LENGTH_ADDRESS` | uint32| 20 | The length of an address in bytes. |
 | `LENGTH_LEGACY_ADDRESS` | uint32| 8 | The length of a legacy address in bytes |
 | `LENGTH_BLS_KEY` | uint32| 48 | The length of a BLS key in bytes |

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -123,39 +123,38 @@ As of writing this proposal, other modules exist in the Lisk protocol that make 
 
 The following constants are used throughout the document:
 
-| Name | Type | Value |
-|------|------|-------|
-| **Interoperability Constants** | | |
-| `MAINCHAIN_ID` | bytes | 0x 00 00 00 00 |
-| **Token Module Constants** | | |
-| `MODULE_NAME_TOKEN` | string | "token" |
-| `COMMAND_NAME_TRANSFER` | string | "transfer" |
-| `COMMAND_NAME_CROSS_CHAIN_TRANSFER` | string | "transferCrossChain" |
-| `CROSS_CHAIN_COMMAND_NAME_TRANSFER` | string | TBD |
-| `CCM_STATUS_OK` | uint32 | 0 |
-| `CCM_STATUS_TOKEN_NOT_SUPPORTED` | uint32 | 64 |
-| `CCM_STATUS_PROTOCOL_VIOLATION` | uint32 | 65 |
-| `TOKEN_ID_LSK` | bytes | 0x 00 00 00 00 00 00 00 00 |
-| `ALL_SUPPORTED_TOKENS_KEY` | bytes | `EMPTY_BYTES` |
-| **Token Store Constants** | | |
-| `SUBSTORE_PREFIX_USER` | bytes | 0x 00 00 |
-| `SUBSTORE_PREFIX_SUPPLY` | bytes | 0x 80 00 |
-| `SUBSTORE_PREFIX_ESCROW` | bytes | 0x c0 00 |
-| `SUBSTORE_PREFIX_SUPPORTED_TOKENS` | bytes | 0x e0 00 |
-| **Configurable Constants** | | Mainchain value |
-| `USER_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 |
-| `ESCROW_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 |
-| **General Constants** | | |
-| `OWN_CHAIN_ID` | bytes | `chainID` of the chain. |
-| `ADDRESS_LENGTH` | uint32 | 20 |
-| `MIN_MODULE_NAME_LENGTH` | uint32 | 1 |
-| `MAX_MODULE_NAME_LENGTH` | uint32 | 32 |
-| `TOKEN_ID_LENGTH` | uint32 | 8 |
-| `CHAIN_ID_LENGTH` | uint32 | 4 |
-| `LOCAL_ID_LENGTH` | uint32 | 4 |
-| `HASH_LENGTH` | uint32 | 32|
-| `MAX_DATA_LENGTH` | uint32 | 64 |
-| `EMPTY_BYTES` | bytes | "" |
+| Name | Type | Value | Description |
+|------|------|-------|-------------|
+| **Token Module Constants** | | | |
+| `MODULE_NAME_TOKEN` | string | "token" | |
+| `COMMAND_NAME_TRANSFER` | string | "transfer" | |
+| `COMMAND_NAME_CROSS_CHAIN_TRANSFER` | string | "transferCrossChain" | |
+| `CROSS_CHAIN_COMMAND_NAME_TRANSFER` | string | TBD | |
+| `CCM_STATUS_OK` | uint32 | 0 | |
+| `CCM_STATUS_TOKEN_NOT_SUPPORTED` | uint32 | 64 | |
+| `CCM_STATUS_PROTOCOL_VIOLATION` | uint32 | 65 | |
+| `TOKEN_ID_LSK` | bytes | `CHAIN_ID_MAINCHAIN` +  0x 00 00 00 00 | |
+| `ALL_SUPPORTED_TOKENS_KEY` | bytes | `EMPTY_BYTES` | |
+| **Token Store Constants** | | | |
+| `SUBSTORE_PREFIX_USER` | bytes | 0x 00 00 | |
+| `SUBSTORE_PREFIX_SUPPLY` | bytes | 0x 80 00 | |
+| `SUBSTORE_PREFIX_ESCROW` | bytes | 0x c0 00 | |
+| `SUBSTORE_PREFIX_SUPPORTED_TOKENS` | bytes | 0x e0 00 | |
+| **Configurable Constants** | | Mainchain value | |
+| `USER_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 | |
+| `ESCROW_ACCOUNT_INITIALIZATION_FEE` | uint64 | 5000000 | |
+| **General Constants** | | | |
+| `CHAIN_ID_MAINCHAIN` | bytes | `CHAIN_ID_PREFIX` + 0x 00 00 00 | Chain ID of the Lisk mainchain as defined in [LIP 0063](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0063.md#constants). Note that `CHAIN_ID_PREFIX` is the network prefix depending on the network as stated in [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1). |
+| `OWN_CHAIN_ID` | bytes | `chainID` of the chain. | |
+| `ADDRESS_LENGTH` | uint32 | 20 | |
+| `MIN_MODULE_NAME_LENGTH` | uint32 | 1 | |
+| `MAX_MODULE_NAME_LENGTH` | uint32 | 32 | |
+| `TOKEN_ID_LENGTH` | uint32 | 8 | |
+| `CHAIN_ID_LENGTH` | uint32 | 4 | |
+| `LOCAL_ID_LENGTH` | uint32 | 4 | |
+| `HASH_LENGTH` | uint32 | 32| |
+| `MAX_DATA_LENGTH` | uint32 | 64 | |
+| `EMPTY_BYTES` | bytes | "" | |
 
 ### Event Names and Results
 
@@ -216,7 +215,7 @@ Calling a function `fct` implemented in the [Interoperability module][lip-0045] 
 
 Tokens are identified in the ecosystem by the **token ID**. The token ID is given by the concatenation of the ID of the token native chain and the token local ID: `tokenID = chainID + localID`.
 
-For example, the LSK token is identified by the token ID `0x0000000000000000`, i.e., `chainID = MAINCHAIN_ID = 0x00000000` and `localID = 0x00000000`.
+For example, the LSK token on the mainnet is identified by the token ID `0x0000000000000000`, i.e., `chainID = CHAIN_ID_MAINCHAIN = 0x00000000` and `localID = 0x00000000`.
 
 ### Token Module Store
 
@@ -343,7 +342,7 @@ supportedTokensSchema = {
 }
 ```
 
-If all tokens are supported, then the substore must contain an entry for the key `ALL_SUPPORTED_TOKENS_KEY` and no other entry. If not all tokens are supported, but all tokens from a chain with ID `chainID` are supported, then the substore must contain an entry for the key `chainID` with an empty array as value. For the native tokens and the LSK token which are always supported, no entries in the substore are added. That means, there is no entry with key `OWN_CHAIN_ID` and for entries with key `MAINCHAIN_ID`, the entry `TOKEN_ID_LSK` does not need to be included in the supported tokens array. For all entries in this substore, the properties `supportedTokenIDs` are kept in lexicographical order.
+If all tokens are supported, then the substore must contain an entry for the key `ALL_SUPPORTED_TOKENS_KEY` and no other entry. If not all tokens are supported, but all tokens from a chain with ID `chainID` are supported, then the substore must contain an entry for the key `chainID` with an empty array as value. For the native tokens and the LSK token which are always supported, no entries in the substore are added. That means, there is no entry with key `OWN_CHAIN_ID` and for entries with key `CHAIN_ID_MAINCHAIN`, the entry `TOKEN_ID_LSK` does not need to be included in the supported tokens array. For all entries in this substore, the properties `supportedTokenIDs` are kept in lexicographical order.
 
 #### Store Notation
 
@@ -505,7 +504,7 @@ def verify(trs: Transaction) -> None:
     # Transfer is only possible for tokens native to either sending or receiving chain
     # and if there is a direct channel, in which case a forward message will be sent.
     tokenChainID = getChainID(tokenID) # The native chain of the token used for the transaction.
-    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, MAINCHAIN_ID]:
+    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, CHAIN_ID_MAINCHAIN]:
         raise Exception("Token must be native to either the sending or the receiving chain or the mainchain.")
 
     balanceChecks: dict[TokenID, uint64] = {}
@@ -610,7 +609,7 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
     sendingChainID = ccm.sendingChainID
     amount = ccm.params.amount
 
-    if tokenChainID not in [OWN_CHAIN_ID, sendingChainID, MAINCHAIN_ID]:
+    if tokenChainID not in [OWN_CHAIN_ID, sendingChainID, CHAIN_ID_MAINCHAIN]:
         raise Exception("Token must be native to either the sending or the receiving chain or the mainchain.")
 
     if tokenChainID == OWN_CHAIN_ID:
@@ -1858,7 +1857,7 @@ def transferCrossChain(
             raise Exception("Insufficient sender available balance")
 
     # Transfer is only possible for tokens native to either sending, receiving or mainchain.
-    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, MAINCHAIN_ID]:
+    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, CHAIN_ID_MAINCHAIN]:
         emitFailedCrossChainTransferEvent(senderAddress, tokenID, balanceChecks[tkID], receivingChainID, recipientAddress, INVALID_TOKEN_ID)
         raise Exception("Token must be native to either the sending, the receiving chain or the mainchain.")
 

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -80,6 +80,7 @@ For the rest of this proposal we define the following constants:
 | `ED25519_PUBLIC_KEY_LENGTH` | uint32 | 32 | Length in bytes of type `PublicKeyEd25519`. |
 | `SEED_LENGTH` | uint32 | 16 | Length in bytes of a valid seed revealed. |
 | `OWN_CHAIN_ID` | bytes | | The [chain ID][lip-0037#chain-identifiers] of the chain. |
+| `TOKEN_ID_LSK` | bytes | `CHAIN_ID_MAINCHAIN + 0x 00 00 00 00` | The token ID of the Lisk token as defined in the [Token module](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations). `CHAIN_ID_MAINCHAIN` is defined in [LIP 0063](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0063.md#constants). |
 | **DPoS store constants** | | | |
 | `STORE_PREFIX_VOTER` | bytes | 0x0000 | The store prefix of the voter substore. |
 | `STORE_PREFIX_DELEGATE` | bytes | 0x4000 | The store prefix of the delegate substore. |
@@ -113,9 +114,9 @@ For the rest of this proposal we define the following constants:
 | `NUMBER_ACTIVE_DELEGATES` | uint32 | `101` | The number of active delegates. |
 | `NUMBER_STANDBY_DELEGATES` | uint32 | `2` | The number of standby delegates. This LIP is specified for the number of standby delegates being 0, 1 or 2. |
 | `ROUND_LENGTH` | uint32 | `103` | The round length. Is equal to `NUMBER_ACTIVE_DELEGATES` + `NUMBER_STANDBY_DELEGATES` |
-| `TOKEN_ID_DPOS` | bytes | `TOKEN_ID_LSK = 0x 00 00 00 00 00 00 00 00` | The [token ID][lip-0051#tokenID] of the token used to cast votes. |
-| `TOKEN_ID_FEE` | bytes | `TOKEN_ID_LSK = 0x 00 00 00 00 00 00 00 00` | The [token ID][lip-0051#tokenID] of the token used to pay the transaction fees. Defined in the fee module. |
-| `TOKEN_ID_REWARD` | bytes |`TOKEN_ID_LSK = 0x 00 00 00 00 00 00 00 00`| The [token ID][lip-0051#tokenID] of the token used for block rewards. Specified as part of the [reward module][lip-0042] configuration. |
+| `TOKEN_ID_DPOS` | bytes | `TOKEN_ID_LSK` | The [token ID][lip-0051#tokenID] of the token used to cast votes. |
+| `TOKEN_ID_FEE` | bytes | `TOKEN_ID_LSK` | The [token ID][lip-0051#tokenID] of the token used to pay the transaction fees. Defined in the fee module. |
+| `TOKEN_ID_REWARD` | bytes |`TOKEN_ID_LSK`| The [token ID][lip-0051#tokenID] of the token used for block rewards. Specified as part of the [reward module][lip-0042] configuration. |
 | `DELEGATE_REGISTRATION_FEE` | uint64 | `10*(10^8)` | The extra command fee of the delegate registration. |
 | `INVALID_BLS_KEY ` | bytes | 48 bytes all set to 0x00 | The byte value associated with validators that did not register a BLS key. |
 

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -55,16 +55,6 @@ This value will be used for every delegate account in the snapshot block.
    </td>
   </tr>
   <tr>
-   <td><code><a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations">TOKEN_ID_LSK</a></code>
-   </td>
-   <td>bytes
-   </td>
-   <td><code>0x 00 00 00 00 00 00 00 00</code>
-   </td>
-   <td>Token ID of the LSK token.
-   </td>
-  </tr>
-  <tr>
    <td><code>MODULE_NAME_DPOS</code>
    </td>
    <td>string
@@ -208,6 +198,26 @@ ffffff
    <td>The empty byte string, which represents the zero in Q96 representation.
    </td>
   </tr>
+  <tr>
+   <td><code>CHAIN_ID_MAINCHAIN</code>
+   </td>
+   <td>bytes
+   </td>
+   <td><code>CHAIN_ID_PREFIX + 0x 00 00 00</code>
+   </td>
+   <td>The chain ID of the mainchain. <code>CHAIN_ID_PREFIX</code> is the network prefix depending on the network (mainnet, testnet, alpha, beta, etc.) as stated in <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1">LIP 0037</a>. For example, NETWORK_PREFIX = 0x 00 for the mainnet.
+   </td>
+  </tr>
+  <tr>
+   <td><code>TOKEN_ID_LSK</code>
+   </td>
+   <td>bytes
+   </td>
+   <td><code>CHAIN_ID_MAINCHAIN + 0x 00 00 00 00</code>
+   </td>
+   <td>Token ID of the LSK token. Defined in <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations">LIP 0051</a>.
+   </td>
+  </tr>
 </table>
 
 ### Mainnet Configuration
@@ -265,6 +275,10 @@ Some new LIPs introduced configurable constants. The values for these constants 
 | [Token Module](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations) | `TOKEN_ID_STORE_INITIALIZATION` | `TOKEN_ID_LSK` |
 | [Dynamic Block Reward Module](https://github.com/LiskHQ/lips-staging/blob/main/proposals/lip-add-introduce-dynamic-block-rewards.md#notation-and-constants) | `FACTOR_MINIMUM_REWARD_ACTIVE_DELEGATES` | 1000 |
 | [Dynamic Block Reward Module](https://github.com/LiskHQ/lips-staging/blob/main/proposals/lip-add-introduce-dynamic-block-rewards.md#notation-and-constants) | `TOKEN_ID_DYNAMIC_BLOCK_REWARD` | `TOKEN_ID_LSK` |
+
+#### Chain Identifier
+
+The [chain identifier](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1) of the Lisk Mainchain is set to `CHAIN_ID_MAINCHAIN`.
 
 ### Mainnet Migration
 


### PR DESCRIPTION
This PR improves the definition of the constants `CHAIN_ID_MAINCHAIN` and `TOKEN_ID_LSK` in several LIPs by:
- Defining `CHAIN_ID_MAINCHAIN = CHAIN_ID_PREFIX + 0x 00 00 00` in LIP 0063 (Mainchain migration and configuration) where it is mentioned that `CHAIN_ID_PREFIX` depends on the network.
- Every LIP that uses `CHAIN_ID_MAINCHAIN` uses the same definition and refers to LIP 0063.
- Defining `TOKEN_ID_LSK = CHAIN_ID_MAINCHAIN +  0x 00 00 00 00` in LIP 0051 (Token module).
- Every LIP that uses `TOKEN_ID_LSK` uses the same definition and refers to LIP 0051.
- Unify the constants names and remove alternatives like `MAINCHAIN_ID` or `TOKEN_ID_LSK_MAINCHAIN`.

Note that many LIPs have an individual style to list and define constants. Therefore, the changes are not consistent in order to be as close as possible to the current style of each LIP.