### PR TITLE
Update token module: Remove direct lsk transfers, add messageFeeTokenID to CC Transfer 

### DIFF
--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -613,6 +613,9 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
     tokenChainID = getChainID(tokenID)
     sendingChainID = ccm.sendingChainID
     amount = ccm.params.amount
+    
+    if ccm.status > MAX_RESERVED_ERROR_STATUS:
+        raise Exception("Invalid CCM status code")
 
     if tokenChainID not in [sendingChainID, OWN_CHAIN_ID]:
         raise Exception("Token must be native to either the sending or the receiving chain.")

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -2199,7 +2199,7 @@ def supportTokenID(tokenID: TokenID) -> None:
     )
 ```
 
-#### removeSupportTokenID
+#### removeSupport
 
 This function is called to remove support from a specified token. In case all tokens are supported or all tokens of the token's native chain are supported, this function raises an exception.
 
@@ -2210,7 +2210,7 @@ def removeSupport(tokenID: TokenID) -> None:
         raise Exception('All tokens are supported.')
 
     if tokenID = TOKEN_ID_LSK or chainID == OWN_CHAIN_ID:
-        raise Exception('Can not remove support for LSK token.')
+        raise Exception('Can not remove support for the specified token.')
 
     if supportedTokens(chainID) exists:
         if supportedTokens(chainID).supportedTokenIDs == []: # All tokens from this chain are supported.

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -1472,13 +1472,16 @@ def transferCrossChainInternal(
         crossChainCommand=CROSS_CHAIN_COMMAND_NAME_TRANSFER,
         receivingChainID=receivingChainID,
         fee=messageFee,
-        params={  
+        params= encode(
+            schema = crossChainTransferMessageParamsSchema
+            object = {  
                 "tokenID": tokenID,
                 "amount": amount,
                 "senderAddress": senderAddress,
                 "recipientAddress": recipientAddress,
                 "data": data
             }
+        )
     )
 ```
 

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2022-11-11
+Updated: 2022-12-19
 ```
 
 ## Abstract

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -193,7 +193,8 @@ The following constants are used throughout the document:
 | `MINT_FAIL_TOKEN_NOT_INITIALIZED` | uint32 | 10 | Used when the mint function fails because the token to be minted is not initialized. |
 | `TOKEN_ID_NOT_AVAILABLE` | uint32 | 11 | Used when the specified token ID is not available. |
 | `TOKEN_ID_NOT_NATIVE` | uint32 | 12 | Used when the specified token ID is not native to the chain. |
-| `INSUFFICIENT_ESCROW_BALANCE` | uint32 | 12 | Used when the escrowed account does not have sufficient balance. |
+| `INSUFFICIENT_ESCROW_BALANCE` | uint32 | 13 | Used when the escrowed account does not have sufficient balance. |
+| `INTEROPERABILITY_NOT_REGISTERED` | uint32 | 14 | Used when the a cross-chain operation is called without having registered an interoperability module. |
 
 ### Type Definition
 
@@ -1844,6 +1845,10 @@ def transferCrossChain(
     if len(data) > MAX_DATA_LENGTH:
         emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, DATA_TOO_LONG)
         raise Exception("Data field too long.")
+
+    if Interoperability module is not registered:
+        emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, INTEROPERABILITY_NOT_REGISTERED)
+        raise Exception("Interoperability module is not registered.")
 
     # Balance checks.
     balanceChecks: dict[TokenID, uint64] = {}

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -1476,7 +1476,7 @@ def transferCrossChainInternal(
         receivingChainID=receivingChainID,
         fee=messageFee,
         params= encode(
-            schema = crossChainTransferMessageParamsSchema
+            schema = crossChainTransferMessageParamsSchema,
             object = {  
                 "tokenID": tokenID,
                 "amount": amount,

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -63,8 +63,6 @@ To allow cross-chain transfers of tokens, we define a specific command which mak
 
 These specifications only allow tokens to be transferred to and from their native chain. In particular, this means that a token minted on chain A cannot be transferred directly from chain B to chain C. This is required to allow the native chain to maintain correct escrowed amounts. The alternative would be to allow such transfer and require an additional message to be sent to the native chain to acknowledge the transfer. However the correctness of the escrowed amounts would rely on the processing of this additional information. Network delays could mean that this is only processed much later and that in the meantime users have been tricked into accepting tokens not backed by escrow.
 
-The only exception is the case of LSK token, which can be transferred from sidechain A to sidechain B through the Lisk mainchain: in this case, a [cross-chain message][lip-0049] is sent from sidechain A to the Lisk mainchain; the mainchain then updates the escrowed amounts and forwards the cross-chain message to sidechain B.
-
 ### Protocol Logic for Other Modules
 
 The Token module provides several exposed methods, which are designed to allow a wide range of use cases while avoiding unexpected behaviors (such as unwanted minting or unlocking of tokens). The functions below are the main exposed methods of the Token module.
@@ -441,7 +439,7 @@ Here, the [initializeUserAccountInternal](#initializeuseraccountinternal) functi
 Transactions executing this command have:
 
 * `module = MODULE_NAME_TOKEN`
-* `command  = COMMAND_NAME_CROSS_CHAIN_TRANSFER`
+* `command = COMMAND_NAME_CROSS_CHAIN_TRANSFER`
 
 ##### Parameters
 
@@ -456,7 +454,8 @@ crossChainTransferParamsSchema = {
         "receivingChainID",
         "recipientAddress",
         "data",
-        "messageFee"
+        "messageFee",
+        "messageFeeTokenID"
     ],
     "properties": {
         "tokenID": {
@@ -486,36 +485,40 @@ crossChainTransferParamsSchema = {
         "messageFee": {
             "dataType": "uint64",
             "fieldNumber": 6
+        },
+        "messageFeeTokenID": {
+            "dataType": "bytes",
+            "length": TOKEN_ID_LENGTH,
+            "fieldNumber": 7
         }
     }
 }
 ```
+
 
 ##### Verification
 
 ```python
 def verify(trs: Transaction) -> None:
     senderAddress = SHA256(trs.senderPublicKey)[:ADDRESS_LENGTH]
+    amount = trs.params.amount
     receivingChainID = trs.params.receivingChainID
     tokenID = trs.params.tokenID
-    amount = trs.params.amount
     messageFee = trs.params.messageFee
-    data = trs.params.data
+    messageFeeTokenID = trs.params.messageFeeTokenID
 
-    # Transfer is only possible for tokens native to either sending or receiving chain
-    # and if there is a direct channel, in which case a forward message will be sent.
+    # Transfer is only possible for tokens native to either sending or receiving chain.
     tokenChainID = getChainID(tokenID) # The native chain of the token used for the transaction.
-    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID, MAINCHAIN_ID]:
-        raise Exception("Token must be native to either the sending or the receiving chain or the mainchain.")
+    if tokenChainID not in [OWN_CHAIN_ID, receivingChainID]:
+        raise Exception("Token must be native to either the sending or the receiving chain.")
+
+    if messageFeeTokenID != Interoperability.getMessageFeeTokenID(receivingChainID):
+        raise Exception("Invalid message fee Token ID.")
 
     balanceChecks: dict[TokenID, uint64] = {}
 
-    if tokenID in balanceChecks:
-        balanceChecks[tokenID] += amount
-    else:
-        balanceChecks[tokenID] = amount
+    balanceChecks[tokenID] = amount
 
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(receivingChainID)
     if messageFeeTokenID in balanceChecks:
         balanceChecks[messageFeeTokenID] += messageFee
     else:
@@ -610,8 +613,8 @@ def verify(ccu: Transaction, ccm: CCM) -> None:
     sendingChainID = ccm.sendingChainID
     amount = ccm.params.amount
 
-    if tokenChainID not in [OWN_CHAIN_ID, sendingChainID, MAINCHAIN_ID]:
-        raise Exception("Token must be native to either the sending or the receiving chain or the mainchain.")
+    if tokenChainID not in [sendingChainID, OWN_CHAIN_ID]:
+        raise Exception("Token must be native to either the sending or the receiving chain.")
 
     if tokenChainID == OWN_CHAIN_ID:
         if escrowStore(sendingChainID, tokenID) does not exist or escrowAmount(sendingChainID, tokenID) < amount:
@@ -1205,7 +1208,7 @@ beforeCCCExecutionEventDataSchema = {
 
 #### beforeCCMForwarding
 
-This event has `name = EVENT_NAME_BEFORE_CCM_FORWARDING`. This event is emitted during calls of [beforeCrossChainMessageForwarding](#beforecrosschainmessageforwarding) function.
+This event has `name = EVENT_NAME_BEFORE_CCM_FORWARDING`. This event is emitted during calls of [beforeCrossChainMessageForwarding](#beforecrosschainmessageforwarding) function; since this function is defined only in the mainchain, this event is also defined only in mainchain. 
 
 ##### Topics
 
@@ -2206,7 +2209,7 @@ def removeSupport(tokenID: TokenID) -> None:
     if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
         raise Exception('All tokens are supported.')
 
-    if tokenID = TOKEN_ID_LSK:
+    if tokenID = TOKEN_ID_LSK or chainID == OWN_CHAIN_ID:
         raise Exception('Can not remove support for LSK token.')
 
     if supportedTokens(chainID) exists:
@@ -2490,7 +2493,7 @@ def beforeCrossChainCommandExecution(ccu: Transaction, ccm: CCM) -> None:
                     "ccmID": Interoperability.encodeCCM(ccm),
                     "messageFeeTokenID": messageFeeTokenID,
                     "relayerAddress": relayerAddress,
-                    "result": RESULT_INSUFFICIENT_BALANCE
+                    "result": INSUFFICIENT_ESCROW_BALANCE
                 },
                 topics=[relayerAddress, messageFeeTokenID]
             )
@@ -2505,50 +2508,36 @@ def beforeCrossChainCommandExecution(ccu: Transaction, ccm: CCM) -> None:
 
 #### beforeCrossChainMessageForwarding
 
+This function is defined only in the Lisk mainchain. 
+
 ```python
 def beforeCrossChainMessageForwarding(ccu: Transaction, ccm: CCM) -> None:
     # This should never fail since it is checked in verifyCrossChainMessage.
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID) # Always TOKEN_ID_LSK.
     if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:
-        emitFailedCCMForwardEvent(ccm, RESULT_INSUFFICIENT_BALANCE)
+        emitPersistentEvent(
+            module=MODULE_NAME_TOKEN,
+            name=EVENT_NAME_BEFORE_CCM_FORWARDING,
+            data={
+                "ccmID": Interoperability.encodeCCM(ccm),
+                "messageFeeTokenID": messageFeeTokenID,
+                "result": INSUFFICIENT_ESCROW_BALANCE
+            },
+            topics=[ccm.sendingChainID, ccm.receivingChainID]
+        )   
         raise Exception("Insufficient balance in the sending chain for the message fee.")
 
     # Transfer the fee from escrow to escrow. messageFeeTokenID is always TOKEN_ID_LSK.
     escrowAmount(ccm.sendingChainID, messageFeeTokenID) -= ccm.fee
     escrowAmount(ccm.receivingChainID, messageFeeTokenID) += ccm.fee
 
-    if ccm.module == MODULE_NAME_TOKEN and ccm.crossChainCommand == CROSS_CHAIN_COMMAND_NAME_TRANSFER and getChainID(ccm.params.tokenID) == OWN_CHAIN_ID:
-        if escrowAmount(ccm.sendingChainID, ccm.params.tokenID) < ccm.params.amount:
-            emitFailedCCMForwardEvent(ccm, INSUFFICIENT_ESCROW_BALANCE)
-            raise Exception("Insufficient balance in the sending chain for the transfer.")
-
-        # Transfer the amount from escrow to escrow.
-        escrowAmount(ccm.sendingChainID, ccm.params.tokenID) -= ccm.params.amount
-        escrowAmount(ccm.receivingChainID, ccm.params.tokenID) += ccm.params.amount
-
-        emitEvent(
-            module=MODULE_NAME_TOKEN,
-            name=EVENT_NAME_BEFORE_CCM_FORWARDING,
-            data={
-                "ccmID": Interoperability.encodeCCM(ccm),
-                "messageFeeTokenID": messageFeeTokenID,
-                "result": RESULT_SUCCESSFUL
-            },
-            topics=[ccm.sendingChainID, ccm.receivingChainID]
-        )
-
-def emitFailedCCMForwardEvent(
-    ccm: CCM,
-    result: uint32
-) -> None:
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID)
-    emitPersistentEvent(
+    emitEvent(
         module=MODULE_NAME_TOKEN,
         name=EVENT_NAME_BEFORE_CCM_FORWARDING,
         data={
             "ccmID": Interoperability.encodeCCM(ccm),
             "messageFeeTokenID": messageFeeTokenID,
-            "result": result
+            "result": RESULT_SUCCESSFUL
         },
         topics=[ccm.sendingChainID, ccm.receivingChainID]
     )


### PR DESCRIPTION
This PR aims to perform the following updates in the token module:

 - **Remove the allowance to send LSK tokens between sidechains using a single Cross-Chain token transfer transaction.** (Instead, LSK should be first transferred to mainchain and then a second CC token transfer should be performed from mainchain to receiving chain) 
 - **Add `messageFeeTokenID` to the params of cross-chain token transfer.** The motivation behind this is that once direct sidechain channels get enabled, the  token used for messages fees between chains might change between the time of submitting the transaction until the transaction gets executed (e.g., if a direct channel to the receiving chain gets initialized during that time). Therefore, an additional check will be performed to make sure that the message fee submitted corresponds to the valid token for message fees)
 - Some smaller changes, such as adding an additional check in `removeSupport` function and additional checks before using the interoperability module.  