### PR TITLE
Align PoA module with BFT updates

### DIFF
--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -27,11 +27,11 @@ A PoA blockchain is especially attractive for small projects or blockchain appli
 
 ## Rationale
 
-This LIP specifies the PoA module which defines a complete Proof-of-Authority blockchain. Sidechain developers creating a sidechain with the Lisk SDK will have the out-of-the-box choice between this module or the DPoS module as the mechanism for validator selection in their sidechain.
+This LIP specifies the PoA module which defines a complete Proof-of-Authority blockchain. Sidechain developers creating a sidechain with the Lisk SDK will have the out-of-the-box choice between this module or the PoS module as the mechanism for validator selection in their sidechain.
 
 As mentioned, the Lisk PoA module only sets the mechanism for the selection of the validators, which implies that the underlying algorithm to reach consensus for blocks of the chain is assumed to be given by the [Lisk-BFT consensus algorithm][lip-0014]. The PoA module also assumes the same round system as [currently specified for the Lisk Mainchain][lip-0057#round-number]. That is, the assignment of block forging slots is done in batches of consecutive blocks called rounds.
 
-Typically, PoA systems do not define any reward system. However, sidechain developers may choose to have a reward system in the chain native token to incentivize the authorities. In this case, the Reward module specified in [LIP 0042](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0042.md) can be used to define block rewards for PoA blockchains. Note that the Dynamic block rewards module as defined in [LIP 0071](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0071.md) depends on the DPoS information to properly function and thus can not be implemented on PoA blockchains.
+Typically, PoA systems do not define any reward system. However, sidechain developers may choose to have a reward system in the chain native token to incentivize the authorities. In this case, the Reward module specified in [LIP 0042](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0042.md) can be used to define block rewards for PoA blockchains. Note that the Dynamic block rewards module as defined in [LIP 0071](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0071.md) depends on the PoS information to properly function and thus can not be implemented on PoA blockchains.
 
 Moreover, the banning mechanism (as defined in [LIP 0023][lip-0023#delegate-productivity]) and the punishment of BFT violations (as defined in [LIP 0024][lip-0024] for the Lisk-BFT protocol) are not  necessary for a functional PoA blockchain. Hence, in this LIP they are not included in the specifications.
 
@@ -41,12 +41,12 @@ The current active authorities, i.e., those authorities eligible to forge blocks
 
 This command can set a maximum of `MAX_NUM_VALIDATORS` active authorities which is the maximum number of active validators in any chain built with the Lisk SDK.
 
-### Migration from PoA to DPoS
+### Migration from PoA to PoS
 
-As mentioned before, the sidechain developers using the Lisk SDK may specify their blockchain application to be deployed on a PoA or DPoS chain (assuming they do not develop a custom mechanism). Thus, a sidechain will be either a PoA or a DPoS blockchain and both modules cannot co-exist in the same chain. However, there may be an interest for some projects that started as a PoA chain to migrate to DPoS. If this is the case, the developers and the future network validators have two choices:
+As mentioned before, the sidechain developers using the Lisk SDK may specify their blockchain application to be deployed on a PoA or PoS chain (assuming they do not develop a custom mechanism). Thus, a sidechain will be either a PoA or a PoS blockchain and both modules cannot co-exist in the same chain. However, there may be an interest for some projects that started as a PoA chain to migrate to PoS. If this is the case, the developers and the future network validators have two choices:
 
-1. After launching the project, if there is a need for a more decentralized approach: Hard-fork the chain to include the DPoS module instead of PoA. This can be easened by following a snapshot mechanism similar to the one specified in [LIP 0035][lip-0035].
-2. If during the development phase, it is decided that the application should start on a PoA chain and then run on a DPoS chain for the long term: The sidechain developers can define an arbitrarily long bootstrapping period for the DPoS chain in the genesis block as explained in [LIP 0034][lip-0034]. This bootstrapping period effectively mimics a PoA chain where there is a fixed set of validators given by the public keys in the `initDelegates` property of the block header asset. This will allow it to first have a preparatory phase of the application so it can mature sufficiently before transferring to a DPoS chain.
+1. After launching the project, if there is a need for a more decentralized approach: Hard-fork the chain to include the PoS module instead of PoA. This can be easened by following a snapshot mechanism similar to the one specified in [LIP 0035][lip-0035].
+2. If during the development phase, it is decided that the application should start on a PoA chain and then run on a PoS chain for the long term: The sidechain developers can define an arbitrarily long bootstrapping period for the PoS chain in the genesis block as explained in [LIP 0034][lip-0034]. This bootstrapping period effectively mimics a PoA chain where there is a fixed set of validators given by the public keys in the `initValidators` property of the block header asset. This will allow it to first have a preparatory phase of the application so it can mature sufficiently before transferring to a PoS chain.
 
 ## Specification
 
@@ -271,7 +271,7 @@ authorityUpdateDataSchema = {
 
 #### Register Authority Command
 
-This command is equivalent to the [delegate registration command][lip-0057#delegate-registration] in the DPoS module and has the same schema and similar validity rules. The command name of this transaction is `COMMAND_REGISTER_AUTHORITY`.
+This command is equivalent to the [validator registration command][lip-0057#validator-registration] in the PoS module and has the same schema and similar validity rules. The command name of this transaction is `COMMAND_REGISTER_AUTHORITY`.
 
 ##### Parameters
 
@@ -798,6 +798,6 @@ TBA
 [lip-0046]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0046.md
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#validator-changes
-[lip-0057#delegate-registration]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#delegate-registration
+[lip-0057#validator-registration]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#validator-registration
 [lip-0057#round-number]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#round-number-and-end-of-rounds
 [lip-0060]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0060.md

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -8,7 +8,7 @@ Status: Draft
 Type: Standards Track
 Created: 2021-04-29
 Updated: 2022-11-11
-Requires: 0038, 0040, 0044, 0058
+Requires: 0038, 0040, 0044
 ```
 
 ## Abstract
@@ -325,7 +325,7 @@ def verify(trs: Transaction) -> None:
         raise Exception()
     if name(bytes(trs.params.name, 'utf-8')) is not empty:
         raise Exception()
-    senderAddress = SHA-256(trs.senderPublicKey)[NUM_BYTES_ADDRESS]
+    senderAddress = SHA-256(trs.senderPublicKey)[:NUM_BYTES_ADDRESS]
     if validators(senderAddress) is not empty:
         raise Exception()
     if trs.params.extraCommandFee != REGISTRATION_FEE:
@@ -338,8 +338,8 @@ A transaction with module name `MODULE_NAME_POA` and command name `COMMAND_REGIS
 
 ```python
 def execute(trs: Transaction) ->  None:
-    senderAddress = SHA-256(trs.senderPublicKey)[NUM_BYTES_ADDRESS]
-    Token.burn(senderAddress, TOKEN_ID_REGISTRATION_FEE, REGISTRATION_FEE)
+    senderAddress = SHA-256(trs.senderPublicKey)[:NUM_BYTES_ADDRESS]
+    Fee.payFee(REGISTRATION_FEE)
 
     validatorEntry = {"name": trs.params.name}
     validators(senderAddress) = encode(validatorObjectSchema, validatorEntry)
@@ -379,7 +379,7 @@ A transaction with module name `MODULE_NAME_POA` and command name `COMMAND_UPDAT
 
 ```python
 def verify(trs: Transaction) -> None:
-    senderAddress = SHA-256(trs.senderPublicKey)[NUM_BYTES_ADDRESS]
+    senderAddress = SHA-256(trs.senderPublicKey)[:NUM_BYTES_ADDRESS]
     if validators(senderAddress) is empty:
         raise Exception()
 ```
@@ -390,7 +390,7 @@ A transaction with module name `MODULE_NAME_POA` and command name `COMMAND_UPDAT
 
 ```python
 def execute(trs: Transaction) -> None:
-    senderAddress = SHA-256(trs.senderPublicKey)[NUM_BYTES_ADDRESS]
+    senderAddress = SHA-256(trs.senderPublicKey)[:NUM_BYTES_ADDRESS]
     Validators.setValidatorGeneratorKey(senderAddress, trs.params.generatorKey)
 ```
 
@@ -473,7 +473,7 @@ def verify(trs: Transaction) -> None:
     if totalWeight > MAX_UINT64:
         raise Exception()
 
-    if trs.params.threshold < floor(totalWeight/3) + 1 or trs.params.threshold > totalWeight:
+    if trs.params.threshold < totalWeight // 3 + 1 or trs.params.threshold > totalWeight:
         raise Exception()
 
     if trs.params.validatorsUpdateNonce != chainProperties.validatorsUpdateNonce:
@@ -493,7 +493,7 @@ def execute(trs: Transaction) -> None:
             })
     validatorInfos = []
     for validator in snapshotStore(0).validators:
-        key = Validators.getValidatorAccount(validator.address).blsKey
+        key = Validators.getValidatorKeys(validator.address).blsKey
         validatorInfos.add({"key": key, "weight": validator.weight})
     sort validatorInfos lexicographically by "key"
 
@@ -526,7 +526,7 @@ def execute(trs: Transaction) -> None:
     )
 ```
 
-The function `verifyWeightedAggSig` is specified in [LIP 0038][lip-0038], `getValidatorAccount` is exposed by the [Validators module][lip-0044]. The schema `validatorSignatureMessageSchema` is:
+The function `verifyWeightedAggSig` is specified in [LIP 0038][lip-0038], `getValidatorKeys` is exposed by the [Validators module][lip-0044]. The schema `validatorSignatureMessageSchema` is:
 
 ```java
 validatorSignatureMessageSchema = {
@@ -727,15 +727,13 @@ Let `genesisBlockAssetBytes` be the bytes included in the `data` property of a d
 ```python
 chainProperties.roundEndHeight = chainProperties.roundEndHeight + length(snapshotStore(0).validators)
 
-# Pass the required information to the BFT module.
+# Pass the required information to the Validators module.
 bftThreshold = snapshotStore(0).threshold
-if setBFTParameters(bftThreshold, bftThreshold, snapshotStore(0).validators) fails:
-    discard block
+Validators.setValidatorParams(bftThreshold, bftThreshold, snapshotStore(0).validators)
 
 # Pass the BLS keys and generator keys to the Validators module.
 for validator in assetPoA.validators:
-    if (registerValidatorKeys(validator.address, validator.proofOfPossession, validator.generatorKey, validator.blsKey) != True):
-        discard block
+    registerValidatorKeys(validator.address, validator.proofOfPossession, validator.generatorKey, validator.blsKey)
 
 # Pass the list of validators to the Validators module.
 addresses = []
@@ -747,7 +745,7 @@ setGeneratorList(addresses)
 where:
 
 * `registerValidatorKeys` is defined in the [Validators module][lip-0044#register-validator-keys].
-* `setBFTParameters` is a function exposed by the [BFT module][lip-0058].
+* `setValidatorParams` is a function exposed by the [Validators module][lip-0044#setvalidatorparams].
 * `setGeneratorList` is a function exposed by the [Validators module][lip-0044].
 
 ### Block Processing
@@ -759,39 +757,29 @@ The following steps are executed as part of the block processing, see the [LIP 0
 ```python
 def afterTransactionsExecute(b: Block) -> None:
     if b.header.height == chainProperties.roundEndHeight:
-        # Get the last stored BFT parameters, and update them if needed.
-        bftThreshold = snapshotStore(0).threshold
-        currentBFTParameters = BFT.getBFTParameters(b.header.height)
-
-        if (currentBFTParameters.validators != snapshotStore(0).validators
-            or currentBFTParameters.precommitThreshold != bftThreshold
-            or currentBFTParameters.certificateThreshold != bftThreshold):
-            # Pass the required information to the BFT module.
-            BFT.setBFTParameters(bftThreshold, bftThreshold, snapshotStore(0).validators)
+        previousLengthValidators = length(snapshotStore(0).validators)
+        # Update the chain information for the next round.
+        snapshotStore(0) = snapshotStore(1)
+        snapshotStore(1) = snapshotStore(2)
 
         # Reshuffle the list of validators and pass it to the Validators module.
-        roundStartHeight = chainProperties.roundEndHeight - length(snapshotStore(0).validators) + 1
-        randomSeed = Random.getRandomBytes(roundStartHeight, length(snapshotStore(0).validators))
+        roundStartHeight = chainProperties.roundEndHeight - previousLengthValidators + 1
+        randomSeed = Random.getRandomBytes(roundStartHeight, previousLengthValidators)
 
         addresses = []
         for i in range(length(snapshotStore(0).validators)):
             addresses[i] =  snapshotStore(0).validators[i].address
 
         nextValidatorAddresses  = shuffleValidatorsList(addresses, randomSeed)
-        Validators.setGeneratorList(nextValidatorAddresses)
+        Validators.setValidatorParams(snapshotStore(0).threshold, snapshotStore(0).threshold, nextValidatorAddresses)
 
-        # Update the chain information for the next round.
-        snapshotStore(0) = snapshotStore(1)
-        snapshotStore(1) = snapshotStore(2)
-        chainProperties.roundEndHeight = chainProperties.roundEndHeight + length(snapshotStore(1).validators)
+        chainProperties.roundEndHeight = chainProperties.roundEndHeight + length(snapshotStore(0).validators)
 ```
 
 where:
 
-* `getBFTParameters` is a function exposed by the [BFT module][lip-0058].
-* `setBFTParameters` is a function exposed by the [BFT module][lip-0058].
 * `getRandomBytes` is a function exposed by the [Random module][lip-0046].
-* `setGeneratorList` is a function exposed by the [Validators module][lip-0044].
+* `setValidatorParams` is a function exposed by the [Validators module][lip-0044#setvalidatorparams].
 
 ## Backwards Compatibility
 
@@ -814,11 +802,11 @@ TBA
 [lip-0038#public-key-registration]: https://github.com/LiskHQ/lips/blob/master/proposals/lip-0038.md#public-key-registration-and-proof-of-possession
 [lip-0038]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0038.md
 [lip-0044#register-validator-keys]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#registervalidatorkeys
+[lip-0044#setvalidatorparams]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#setvalidatorparams
 [lip-0044]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md
 [lip-0046]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0046.md
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#validator-changes
 [lip-0057#delegate-registration]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#delegate-registration
 [lip-0057#round-number]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#round-number-and-end-of-rounds
-[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md
 [lip-0060]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0060.md

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -77,7 +77,6 @@ The LIP uses the following types.
 | `UPDATE_AUTHORITY_SUCCESS` | uint32 | 0 |
 | `UPDATE_AUTHORITY_FAIL_INVALID_SIGNATURE` | uint32 | 1 |
 | `REGISTRATION_FEE` | uint64 | config parameter |
-| `TOKEN_ID_REGISTRATION_FEE` | bytes | config parameter |
 | `MAX_LENGTH_NAME` | uint32 | 20 |
 | `NUM_BYTES_ADDRESS` | uint32 | 20 |
 | `LENGTH_BLS_KEY` | uint32 | 48 |

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-poa-module/288
 Status: Draft
 Type: Standards Track
 Created: 2021-04-29
-Updated: 2022-11-11
+Updated: 2022-12-19
 Requires: 0038, 0040, 0044
 ```
 

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -31,7 +31,7 @@ This LIP specifies the PoA module which defines a complete Proof-of-Authority bl
 
 As mentioned, the Lisk PoA module only sets the mechanism for the selection of the validators, which implies that the underlying algorithm to reach consensus for blocks of the chain is assumed to be given by the [Lisk-BFT consensus algorithm][lip-0014]. The PoA module also assumes the same round system as [currently specified for the Lisk Mainchain][lip-0057#round-number]. That is, the assignment of block forging slots is done in batches of consecutive blocks called rounds.
 
-Typically, PoA systems do not define any reward system. However, sidechain developers may choose to have a reward system in the chain native token to incentivize the authorities. In this case, the Reward module in the Lisk SDK can be used to define block rewards for PoA blockchains in the same way as for DPoS blockchains.
+Typically, PoA systems do not define any reward system. However, sidechain developers may choose to have a reward system in the chain native token to incentivize the authorities. In this case, the Reward module specified in [LIP 0042](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0042.md) can be used to define block rewards for PoA blockchains. Note that the Dynamic block rewards module as defined in [LIP 0071](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0071.md) depends on the DPoS information to properly function and thus can not be implemented on PoA blockchains.
 
 Moreover, the banning mechanism (as defined in [LIP 0023][lip-0023#delegate-productivity]) and the punishment of BFT violations (as defined in [LIP 0024][lip-0024] for the Lisk-BFT protocol) are not  necessary for a functional PoA blockchain. Hence, in this LIP they are not included in the specifications.
 
@@ -733,19 +733,11 @@ Validators.setValidatorParams(bftThreshold, bftThreshold, snapshotStore(0).valid
 # Pass the BLS keys and generator keys to the Validators module.
 for validator in assetPoA.validators:
     registerValidatorKeys(validator.address, validator.proofOfPossession, validator.generatorKey, validator.blsKey)
-
-# Pass the list of validators to the Validators module.
-addresses = []
-for i in range(length(snapshotStore(0).validators)):
-    addresses[i] = snapshotStore(0).validators[i].address
-
-setGeneratorList(addresses)
 ```
 where:
 
 * `registerValidatorKeys` is defined in the [Validators module][lip-0044#register-validator-keys].
 * `setValidatorParams` is a function exposed by the [Validators module][lip-0044#setvalidatorparams].
-* `setGeneratorList` is a function exposed by the [Validators module][lip-0044].
 
 ### Block Processing
 


### PR DESCRIPTION
This PR aligns the PoA module with engine-application separation and removal of BFT module. In particular:

- The BFT parameters are now set using `setValidatorParams` method of Validators module.
- The method name `getValidatorAccount` is renamed to `getValidatorKeys`.
- All references to BFT module removed.
- DPoS terminology is changed to PoS terminology (in particular, DPoS -> PoS, delegate -> validator).

In addition, there are small fixes:

- Replaced float point division with integer division.
- Fixed wrong logic in `afterTransactionsExecute`.