### PR TITLE
LIP0065: hash events before inserting them into tree

### DIFF
--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -98,7 +98,7 @@ To summarize, we chose sparse Merkle trees because:
 
 | Name | Type | Value | Description |
 |------|------|-------|-------------|
-| `MAX_EVENT_SIZE_BYTES` | integer | `1024` | Maximum size in bytes of a serialized event. |
+| `MAX_EVENT_SIZE_BYTES` | integer | `16*1024` | Maximum size in bytes of a serialized event. |
 | `MIN_MODULE_NAME_LENGTH` | integer | `1` | Minimum length of a module name. |
 | `MAX_MODULE_NAME_LENGTH` | integer | `32` | Maximum length of a module name. |
 | `MIN_EVENT_NAME_LENGTH` | integer | `1` | Minimum length of an event name. |

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -103,7 +103,7 @@ To summarize, we chose sparse Merkle trees because:
 | `MAX_MODULE_NAME_LENGTH` | integer | `32` | Maximum length of a module name. |
 | `MIN_EVENT_NAME_LENGTH` | integer | `1` | Minimum length of an event name. |
 | `MAX_EVENT_NAME_LENGTH` | integer | `32` | Maximum length of an event name. |
-| `EMPTY_HASH` | bytes | `SHA-256("")` | Hash of empty bytes. |
+| `EMPTY_HASH` | bytes | `sha256(b"")` | Hash of empty bytes. |
 | `EVENT_TOPIC_INIT_GENESIS_STATE` | bytes | `0x00` | Default topic for events emitted during genesis state initialization. |
 | `EVENT_TOPIC_FINALIZE_GENESIS_STATE` | bytes | `0x01` | Default topic for events emitted during genesis state finalization. |
 | `EVENT_TOPIC_BEFORE_TRANSACTIONS` | bytes | `0x02` | Default topic for events emitted _before_ transactions execution. |
@@ -122,7 +122,7 @@ The event ID is defined as the hash of the serialize event.
 
 ```python
 def eventID(event: Event) -> bytes:
-    return SHA-256(encode(eventSchema, event))
+    return sha256(encode(eventSchema, event))
 ```
 
 ### Event Data Structure

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -48,7 +48,7 @@ Events have the following properties:
 
 ### Event Tree
 
-Events are emitted during [application domain stages of the block processing][lip-0055#block-processing-stages] and are inserted in a [sparse Merkle tree][lip-0039] as new leaf nodes. The leaf values are set to the serialized events. Leaf keys are given by the concatenation of a generic byte value and an index that identifies the position in which the event was emitted during the block processing. In particular, each event specifies an array of topics (similar to the 'indexed' keyword used in [Solidity](https://docs.soliditylang.org/en/v0.8.11/cheatsheet.html#modifiers)). The same event is inserted multiple times in the sparse Merkle tree, once for each entry in this array. By default, the indexed topics array contains the ID of the transaction that emitted the event or a constant placeholder for events emitted during the processing of the block header. However, events emitted during the [processing of a cross-chain message][lip-0053#ccu-processing] contain the ID of the cross-chain message as default topic instead of the ID of the cross-chain update transaction that contained the cross-chain message.
+Events are emitted during [application domain stages of the block processing][lip-0055#block-processing-stages] and are inserted in a [sparse Merkle tree][lip-0039] as new leaf nodes. The leaf values are set to the hash of the serialized events. Leaf keys are given by the concatenation of a generic byte value and an index that identifies the position in which the event was emitted during the block processing. In particular, each event specifies an array of topics (similar to the 'indexed' keyword used in [Solidity](https://docs.soliditylang.org/en/v0.8.11/cheatsheet.html#modifiers)). The same event is inserted multiple times in the sparse Merkle tree, once for each entry in this array. By default, the indexed topics array contains the ID of the transaction that emitted the event or a constant placeholder for events emitted during the processing of the block header. However, events emitted during the [processing of a cross-chain message][lip-0053#ccu-processing] contain the ID of the cross-chain message as default topic instead of the ID of the cross-chain update transaction that contained the cross-chain message.
 
 This pattern allows efficient (non-)inclusion proofs for a variety of use cases, while at the same time leaving developers of custom modules the freedom to decide how to index custom events.
 
@@ -206,12 +206,12 @@ For events emitted during the command execution, modules specify whether the eve
 
 ### Events Tree
 
-Events are inserted into the events tree once for each entry in the event `topics` array. The leaf key is the concatenation of the hash of the element in the topics array, the event `index` converted to a binary string of length `EVENT_INDEX_LENGTH_BITS` and concatenated with the topic index of `TOPIC_INDEX_LENGTH_BITS` bits (corresponding to the entry in the `topics` array), for a total of `TOTAL_INDEX_LENGTH_BYTES` bytes. The leaf value is the serialization of the event properties using the `eventSchema` given above.
+Events are inserted into the events tree once for each entry in the event `topics` array. The leaf key is the concatenation of the hash of the element in the topics array, the event `index` converted to a binary string of length `EVENT_INDEX_LENGTH_BITS` and concatenated with the topic index of `TOPIC_INDEX_LENGTH_BITS` bits (corresponding to the entry in the `topics` array), for a total of `TOTAL_INDEX_LENGTH_BYTES` bytes. The leaf value is the SHA256 of the serialization of the event properties using the `eventSchema` given above.
 
 In summary, for each event one key-value pair is added to the events tree for each entry `topic` in the associated `topics` array, where:
 
-* `key = SHA-256(topic)[:TOPIC_HASH_LENGTH_BYTES] + ((event index << TOPIC_INDEX_LENGTH_BITS) + topic index).to_bytes(TOTAL_INDEX_LENGTH_BYTES, byteorder="big")`
-* `value` = serialization of event according to `eventSchema`.
+* `key = sha256(topic)[:TOPIC_HASH_LENGTH_BYTES] + ((event index << TOPIC_INDEX_LENGTH_BITS) + topic index).to_bytes(TOTAL_INDEX_LENGTH_BYTES, byteorder="big")`
+* `value = sha256(encode(eventSchema, event))`.
 
 ### Event Root
 

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -206,7 +206,7 @@ For events emitted during the command execution, modules specify whether the eve
 
 ### Events Tree
 
-Events are inserted into the events tree once for each entry in the event `topics` array. The leaf key is the concatenation of the hash of the element in the topics array, the event `index` converted to a binary string of length `EVENT_INDEX_LENGTH_BITS` and concatenated with the topic index of `TOPIC_INDEX_LENGTH_BITS` bits (corresponding to the entry in the `topics` array), for a total of `TOTAL_INDEX_LENGTH_BYTES` bytes. The leaf value is the SHA256 of the serialization of the event properties using the `eventSchema` given above.
+Events are inserted into the events tree once for each entry in the event `topics` array. The leaf key is the concatenation of the hash of the element in the topics array, the event `index` converted to a binary string of length `EVENT_INDEX_LENGTH_BITS` and concatenated with the topic index of `TOPIC_INDEX_LENGTH_BITS` bits (corresponding to the entry in the `topics` array), for a total of `TOTAL_INDEX_LENGTH_BYTES` bytes. The leaf value is the SHA-256 hash of the serialization of the event properties using the `eventSchema` given above.
 
 In summary, for each event one key-value pair is added to the events tree for each entry `topic` in the associated `topics` array, where:
 

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-events-and-add-events-root
 Status: Draft
 Type: Standards Track
 Created: 2022-05-03
-Updated: 2022-11-11
+Updated: 2022-12-19
 Requires: 0039, 0055
 ```
 


### PR DESCRIPTION
Update the specifications of the events tree: set the leaf value to the _hash_ of the serialized event.