### PR TITLE
Fix issues in LIP 0063

### DIFF
--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-mainnet-configuration-and-mig
 Status: Draft
 Type: Standards Track
 Created: 2022-04-06
-Updated: 2023-01-18
+Updated: 2023-01-20
 Requires: 0060
 ```
 

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -68,9 +68,9 @@ This value will be used for every validator account in the snapshot block.
    </td>
    <td>bytes
    </td>
-   <td><code>0x 00 00 00 00</code>
+   <td><code>0x 00 00 00 00</code> (in Lisk Mainnet)
    </td>
-   <td>The chain ID of the mainchain of Lisk Mainnet, see <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers">LIP 0037</a>.
+   <td>The chain ID of the mainchain of Lisk, see <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers">LIP 0037</a>.
    </td>
   </tr>
   <tr>
@@ -589,7 +589,7 @@ def createGenesisDataObj():
 
 ###### Assets Entry for Interoperability Module
 
-Let `genesisInteroperabilityStoreSchema` be as defined in [LIP 0045](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#genesis-state-initialization). The `assets` entry for the Interoperability module is added by the logic defined in the function `addInteropModuleEntry` in the following pseudo code. The function `getMainchainID` returns the chain ID of the mainchain in the current network, it is defined in [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#mainchain-chain-id).
+Let `genesisInteroperabilityStoreSchema` be as defined in [LIP 0045](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#genesis-state-initialization). The `assets` entry for the Interoperability module is added by the logic defined in the function `addInteropModuleEntry` in the following pseudo code.
 
 ```python
 def addInteropModuleEntry():
@@ -600,7 +600,7 @@ def addInteropModuleEntry():
     InteropObj.chainValidatorsSubstore = []
     ownChainAccount = {
         "name": CHAIN_NAME_MAINCHAIN,
-        "chainId": getMainchainID(),
+        "chainId": CHAIN_ID_MAINCHAIN,
         "nonce": 0
     }
     InteropObj.ownChainDataSubstore = [{
@@ -608,7 +608,7 @@ def addInteropModuleEntry():
         "storeValue": ownChainAccount}]
     InteropObj.terminatedStateSubstore = []
     InteropObj.terminatedOutboxSubstore = []
-    registeredNamesStore = {"chainID": getMainchainID()}
+    registeredNamesStore = {"chainID": CHAIN_ID_MAINCHAIN}
     InteropObj.registeredNamesSubstore = [{
         "storeKey": bytes(CHAIN_NAME_MAINCHAIN, 'utf-8'),
         "storeValue": registeredNamesStore}]

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -423,23 +423,26 @@ def createUserSubstoreArray():
             userObj.lockedBalances = getLockedBalances(account)
             userSubstore.append(userObj)
     # Append the legacy reserve account separately.
-    userSubstore.append(createLegacyReserveAccount())
+    addLegacyReserveAccount(userSubstore)
     sort userSubstore in the lexicographical order of (userObj.address + userObj.tokenID)
     return userSubstore
 
-def createLegacyReserveAccount():
-    legacyReserveAccount = account in accounts with account.address == ADDRESS_LEGACY_RESERVE
-    isEmpty = legacyReserveAmount is empty
-    legacyReserve = {}
-    legacyReserve.address = ADDRESS_LEGACY_RESERVE
-    legacyReserve.tokenID = TOKEN_ID_LSK
-    legacyReserve.availableBalance = isEmpty ? 0 : legacyReserveAccount.token.balance
+def addLegacyReserveAccount(userSubstore):
     legacyReserveAmount = 0
     for every account in legacyAccounts:
         legacyReserveAmount += account.token.balance
-    lockedBalances = isEmpty ? [] : getLockedBalances(legacyReserveAccount)
-    legacyReserve.lockedBalances = lockedBalances.append({"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount})
-    return legacyReserve
+
+    legacyReserveAccount = userEntry in userSubstore with userEntry.address == ADDRESS_LEGACY_RESERVE
+    if legacyReserveAccount is empty:
+        legacyReserveAccount = {}
+        legacyReserveAccount.address = ADDRESS_LEGACY_RESERVE
+        legacyReserveAccount.tokenID = TOKEN_ID_LSK
+        legacyReserveAccount.availableBalance = 0
+        legacyReserveAccount.lockedBalances = [{"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount}]
+        userSubstore.append(legacyReserve)
+    else:
+        legacyReserveAccount.lockedBalances.append({"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount})
+        sort legacyReserve.lockedBalances in the lexicographical order of lockedBalance.module
 
 def getLockedBalances(account):
     amount = 0
@@ -459,9 +462,9 @@ def createSupplySubstoreArray():
         lockedBalances = getLockedBalances(account)
         if lockedBalances is not empty:
             totalLSKSupply += lockedBalances[0].amount
-    legacyReserveAccount = account with account.address == ADDRESS_LEGACY_RESERVE
-    legacyReserveAmount = lockedBalance.amount for lockedBalance in
-        legacyReserveAccount.lockedBalances with lockedBalance.module == MODULE_NAME_LEGACY
+    legacyReserveAmount = 0
+    for every account in legacyAccounts:
+        legacyReserveAmount += account.token.balance
     LSKSupply = {"tokenID": TOKEN_ID_LSK, "totalSupply": totalLSKSupply + legacyReserveAmount}
     return [LSKSupply]
 ```
@@ -517,7 +520,7 @@ def createValidatorsArray():
             validator.generatorKey = INVALID_ED25519_KEY
         validator.lastGeneratedHeight = account.dpos.delegate.lastForgedHeight
         validator.isBanned = True
-        validator.reportMisbehaviorHeights = account.dpos.delegate.reportMisbehaviorHeights
+        validator.reportMisbehaviorHeights = account.dpos.delegate.pomHeights
         validator.consecutiveMissedBlocks = account.dpos.delegate.consecutiveMissedBlocks
         validator.commission = 10000
         validator.lastCommissionIncreaseHeight = HEIGHT_SNAPSHOT

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -363,6 +363,7 @@ def addLegacyModuleEntry():
         userObj.address = account.address
         userObj.balance = account.token.balance
         legacyObj.accounts.append(userObj)
+    sort legacyObj.accounts in the lexicographical order of userObj.address
     data = serialization of legacyObj using genesisLegacyStoreSchema
     append {"module": MODULE_NAME_LEGACY, "data": data} to b.assets
 ```
@@ -412,9 +413,9 @@ def createLegacyReserveAccount():
 
 def getLockedBalances(account):
     amount = 0
-    for stake in account.pos.stakes:
+    for stake in account.dpos.sentVotes:
         amount += stake.amount
-    for unlockingObj in account.pos.unlocking:
+    for unlockingObj in account.dpos.unlocking:
         amount += unlockingObj.amount
     if amount > 0:
         return [{"module": MODULE_NAME_POS, "amount": amount}]
@@ -428,7 +429,10 @@ def createSupplySubstoreArray():
         lockedBalances = getLockedBalances(account)
         if lockedBalances is not empty:
             totalLSKSupply += lockedBalances[0].amount
-    LSKSupply = {"tokenID": TOKEN_ID_LSK, "totalSupply": totalLSKSupply}
+    legacyReserveAccount = account with account.address == ADDRESS_LEGACY_RESERVE
+    legacyReserveAmount = lockedBalance.amount for lockedBalance in
+        legacyReserveAccount.lockedBalances with lockedBalance.module == MODULE_NAME_LEGACY
+    LSKSupply = {"tokenID": TOKEN_ID_LSK, "totalSupply": totalLSKSupply + legacyReserveAmount}
     return [LSKSupply]
 ```
 
@@ -448,6 +452,7 @@ def addAuthModuleEntry():
         authObj.nonce = account.sequence.nonce
         entry = {"address": account.address, "authAccount": authObj}
         authDataSubstore.append(entry)
+    sort authDataSubstore in the lexicographical order of object.address
     data = serialization of authDataSubstore using genesisAuthStoreSchema
     append {"module": MODULE_NAME_AUTH, "data": data} to b.assets
 ```
@@ -469,31 +474,32 @@ def createValidatorsArray():
     validators = []
     validatorKeys = getValidatorKeys()
     for every account in accounts:
-        if account.pos.validator.username == "":
+        if account.dpos.delegate.username == "":
             continue
         validator = {}
         validator.address = account.address
-        validator.name = account.pos.validator.username
+        validator.name = account.dpos.delegate.username
         validator.blsKey = INVALID_BLS_KEY
         validator.proofOfPossession = DUMMY_PROOF_OF_POSSESSION
         if validatorKeys[account.address]:
             validator.generatorKey = validatorKeys[account.address]
         else:
             validator.generatorKey = INVALID_ED25519_KEY
-        validator.lastGeneratedHeight = account.pos.validator.lastForgedHeight
+        validator.lastGeneratedHeight = account.dpos.delegate.lastForgedHeight
         validator.isBanned = True
-        validator.reportMisbehaviorHeights = account.pos.validator.reportMisbehaviorHeights
-        validator.consecutiveMissedBlocks = account.pos.validator.consecutiveMissedBlocks
+        validator.reportMisbehaviorHeights = account.dpos.delegate.reportMisbehaviorHeights
+        validator.consecutiveMissedBlocks = account.dpos.delegate.consecutiveMissedBlocks
         validator.commission = 10000
         validator.lastCommissionIncreaseHeight = HEIGHT_SNAPSHOT
         validator.sharingCoefficients = [
             {"tokenID": TOKEN_ID_LSK, "coefficient": Q96_ZERO}
         ]
         validators.append(validator)
+    sort validators in the lexicographical order of validator.address
     return validators
 
 # This functions gets the public keys of the registered validators,
-# i.e., the accounts for which account.pos.validator.username is not
+# i.e., the accounts for which account.dpos.delegate.username is not
 # the empty string, from the history of Lisk Core v3 blocks and transactions.
 def getValidatorKeys():
     let keys be an empty dictionary
@@ -507,7 +513,7 @@ def getValidatorKeys():
     return keys
 
 def getStakes(account):
-    stakes = account.pos.stakes
+    stakes = account.dpos.sentVotes
     for every stake in stakes:
         stake.sharingCoefficients = [
             {"tokenID": TOKEN_ID_LSK, "coefficient": Q96_ZERO}
@@ -517,13 +523,14 @@ def getStakes(account):
 def createStakersArray():
     stakers = []
     for every account in accounts:
-        if account.pos.stakes == [] and account.pos.unlocking == []:
+        if account.dpos.sentVotes == [] and account.dpos.unlocking == []:
             continue
         staker = {}
         staker.address = account.address
         staker.stakes = getStakes(account)
-        staker.pendingUnlocks = account.pos.unlocking
+        staker.pendingUnlocks = account.dpos.unlocking
         stakers.append(staker)
+    sort stakers in the lexicographical order of staker.address
     return stakers
 
 def createGenesisDataObj():
@@ -592,4 +599,3 @@ This LIP describes the protocol and process for conducting a hardfork on the Lis
 ## Reference Implementation
 
 TBD
-

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -53,6 +53,15 @@ The following table defines some constants that will be used in the remainder of
 <p>
 This value will be used for every validator account in the snapshot block.
    </td>
+   <tr>
+    <td><code>EMPTY_BYTES</code>
+    </td>
+    <td>bytes
+    </td>
+    <td>empty byte string
+    </td>
+    <td> Empty array of bytes.
+    </td>
   </tr>
   <tr>
    <td><code><a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#constants-and-notations">TOKEN_ID_LSK</a></code>
@@ -102,6 +111,26 @@ This value will be used for every validator account in the snapshot block.
    <td>"legacy"
    </td>
    <td>Module name of the <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0050.md">Legacy Module</a>.
+   </td>
+  </tr>
+  <tr>
+   <td><code>MODULE_NAME_INTEROPERABILITY</code>
+   </td>
+   <td>string
+   </td>
+   <td>"interoperability"
+   </td>
+   <td>Module name of the <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md">Interoperability Module</a>.
+   </td>
+  </tr>
+  <tr>
+   <td><code>CHAIN_NAME_MAINCHAIN</code>
+   </td>
+   <td>string
+   </td>
+   <td>"lisk_mainchain"
+   </td>
+   <td>Name of the Lisk mainchain, as defined in the <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md">Interoperability Module</a>.
    </td>
   </tr>
   <tr>
@@ -345,6 +374,7 @@ From the [registered modules](#modules), the following ones add an entry to `b.a
 - Token module
 - Auth module
 - PoS module
+- Interoperability module
 
 How these modules construct their entry for the `assets` property is defined in the next subsections. The verification of their entries is defined in the _Genesis Block Processing_ sections of the respective module LIPs. Note that once all modules add their entries to `b.assets`, this array [must be sorted by lexicographical order of the `module` property](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0060.md#validation-1).
 
@@ -352,7 +382,7 @@ In the following, let `accountsState` be the key-value store of the accounts sta
 
 ###### Assets Entry for Legacy Module
 
-Let `genesisLegacyStoreSchema` be as defined in [LIP 0050](https://github.com/LiskHQ/lips/blob/aebeecc40447e4229f14fc641fb11527270dfbb5/proposals/lip-0050.md#genesis-state-initialization). The `assets` entry for the legacy module is added by the logic defined in the function `addLegacyModuleEntry` in the following pseudo code:
+Let `genesisLegacyStoreSchema` be as defined in [LIP 0050](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0050.md#genesis-state-initialization). The `assets` entry for the legacy module is added by the logic defined in the function `addLegacyModuleEntry` in the following pseudo code:
 
 ```python
 def addLegacyModuleEntry():
@@ -370,7 +400,7 @@ def addLegacyModuleEntry():
 
 ###### Assets Entry for Token Module
 
-Let `genesisTokenStoreSchema` be as defined in [LIP 0051](https://github.com/LiskHQ/lips/blob/aebeecc40447e4229f14fc641fb11527270dfbb5/proposals/lip-0051.md#genesis-assets-schema). The `assets` entry for the token module is added by the logic defined in the function `addTokenModuleEntry` in the following pseudo code:
+Let `genesisTokenStoreSchema` be as defined in [LIP 0051](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#genesis-assets-schema). The `assets` entry for the token module is added by the logic defined in the function `addTokenModuleEntry` in the following pseudo code:
 
 ```python
 def addTokenModuleEntry():
@@ -438,7 +468,7 @@ def createSupplySubstoreArray():
 
 ###### Assets Entry for Auth Module
 
-Let `genesisAuthStoreSchema` be as defined in [LIP 0041](https://github.com/LiskHQ/lips/blob/aebeecc40447e4229f14fc641fb11527270dfbb5/proposals/lip-0041.md#genesis-state-initialization). The `assets` entry for the auth module is added by the logic defined in the function `addAuthModuleEntry` in the following pseudo code:
+Let `genesisAuthStoreSchema` be as defined in [LIP 0041](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0041.md#genesis-state-initialization). The `assets` entry for the auth module is added by the logic defined in the function `addAuthModuleEntry` in the following pseudo code:
 
 ```python
 def addAuthModuleEntry():
@@ -459,7 +489,7 @@ def addAuthModuleEntry():
 
 ###### Assets Entry for PoS Module
 
-Let `genesisPoSStoreSchema` be as defined in [LIP 0057](https://github.com/LiskHQ/lips/blob/aebeecc40447e4229f14fc641fb11527270dfbb5/proposals/lip-0057.md#genesis-assets-schema). The `assets` entry for the PoS module is added by the logic defined in the function `addPoSModuleEntry` in the following pseudo code:
+Let `genesisPoSStoreSchema` be as defined in [LIP 0057](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#genesis-assets-schema). The `assets` entry for the PoS module is added by the logic defined in the function `addPoSModuleEntry` in the following pseudo code:
 
 ```python
 def addPoSModuleEntry():
@@ -542,6 +572,35 @@ def createGenesisDataObj():
     sort initValidators in lexicographical order
     genesisDataObj.initValidators = initValidators
     return genesisDataObj
+```
+
+###### Assets Entry for Interoperability Module
+
+Let `genesisInteroperabilityStoreSchema` be as defined in [LIP 0045](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#genesis-state-initialization). The `assets` entry for the Interoperability module is added by the logic defined in the function `addInteropModuleEntry` in the following pseudo code. The function `getMainchainID` returns the chain ID of the mainchain in the current network, it is defined in [LIP 0037](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#mainchain-chain-id).
+
+```python
+def addInteropModuleEntry():
+    InteropObj = {}
+    InteropObj.outboxRootSubstore = []
+    InteropObj.chainDataSubstore = []
+    InteropObj.channelDataSubstore = []
+    InteropObj.chainValidatorsSubstore = []
+    ownChainAccount = {
+        "name": CHAIN_NAME_MAINCHAIN,
+        "chainId": getMainchainID(),
+        "nonce": 0
+    }
+    InteropObj.ownChainDataSubstore = [{
+        "storeKey": EMPTY_BYTES,
+        "storeValue": ownChainAccount}]
+    InteropObj.terminatedStateSubstore = []
+    InteropObj.terminatedOutboxSubstore = []
+    registeredNamesStore = {"chainID": getMainchainID()}
+    InteropObj.registeredNamesSubstore = [{
+        "storeKey": bytes(CHAIN_NAME_MAINCHAIN, 'utf-8'),
+        "storeValue": registeredNamesStore}]
+    data = serialization of InteropObj using genesisInteroperabilityStoreSchema
+    append {"module": MODULE_NAME_INTEROPERABILITY, "data": data} to b.assets
 ```
 
 ## Rationale

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -435,26 +435,24 @@ def createUserSubstoreArray():
             userObj.lockedBalances = getLockedBalances(account)
             userSubstore.append(userObj)
     # Append the legacy reserve account separately.
-    addLegacyReserveAccount(userSubstore)
+    userSubstore.append(createLegacyReserveAccount())
     sort userSubstore in the lexicographical order of (userObj.address + userObj.tokenID)
     return userSubstore
 
-def addLegacyReserveAccount(userSubstore):
+def createLegacyReserveAccount():
+    legacyReserveAccount = account in accounts with account.address == ADDRESS_LEGACY_RESERVE
+    isEmpty = legacyReserveAccount is empty
+    legacyReserve = {}
+    legacyReserve.address = ADDRESS_LEGACY_RESERVE
+    legacyReserve.tokenID = TOKEN_ID_LSK
+    legacyReserve.availableBalance = isEmpty ? 0 : legacyReserveAccount.token.balance
     legacyReserveAmount = 0
     for every account in legacyAccounts:
         legacyReserveAmount += account.token.balance
-
-    legacyReserveAccount = userEntry in userSubstore with userEntry.address == ADDRESS_LEGACY_RESERVE
-    if legacyReserveAccount is empty:
-        legacyReserveAccount = {}
-        legacyReserveAccount.address = ADDRESS_LEGACY_RESERVE
-        legacyReserveAccount.tokenID = TOKEN_ID_LSK
-        legacyReserveAccount.availableBalance = 0
-        legacyReserveAccount.lockedBalances = [{"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount}]
-        userSubstore.append(legacyReserve)
-    else:
-        legacyReserveAccount.lockedBalances.append({"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount})
-        sort legacyReserve.lockedBalances in the lexicographical order of lockedBalance.module
+    lockedBalances = isEmpty ? [] : getLockedBalances(legacyReserveAccount)
+    legacyReserve.lockedBalances = lockedBalances.append({"module": MODULE_NAME_LEGACY, "amount": legacyReserveAmount})
+    sort legacyReserve.lockedBalances in the lexicographical order of lockedBalance.module
+    return legacyReserve
 
 def getLockedBalances(account):
     amount = 0


### PR DESCRIPTION
The issues identified by the Service team and addressed in the PR:

- Total LSK supply did not account for legacy accounts.
- Many arrays used to generate the snapshot block were not explicitly sorted by the address.
- Version 3 account DPoS-related properties were erroneously renamed during DPoS -> PoS terminology change.

I have also addressed https://github.com/LiskHQ/lips/issues/221 in this PR by adding Interoperability genesis asset to the snapshot block.