### PR TITLE
LIP0053: apply minor fixes and verify update of validators hash

### DIFF
--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -137,6 +137,13 @@ def verifyCertificate(ccu: Transaction) -> None:
     timestamp = timestamp of the block including ccu
     if certificate.timestamp >= timestamp:
         raise Exception("Certificate timestamp is not smaller than timestamp of the block including the CCU.")
+    
+    # If the certified validators hash differ from the one stored in the chain account,
+    # the CCU must contain a validators update (which can be then verified).
+    if certificate.validatorsHash != chainAccount(ccu.params.sendingChainID).lastCertificate.validatorsHash:
+        validatorsUpdate = ccu.params.activeValidatorsUpdate
+        if len(validatorsUpdate.blsKeysUpdate) == 0 and len(validatorsUpdate.bftWeightsUpdate) == 0 and validatorsUpdate.bftWeightsUpdateBitmap == EMPTY_BYTES and ccu.params.certificateThreshold == validators(ccu.params.sendingChainID).certificateThreshold:
+            raise Exception("Certifying an update to the validators hash requires an active validators update.")
 ```
 
 #### verifyCertificateSignature

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -138,7 +138,7 @@ def verifyCertificate(ccu: Transaction) -> None:
     if certificate.timestamp >= timestamp:
         raise Exception("Certificate timestamp is not smaller than timestamp of the block including the CCU.")
     
-    # If the certified validators hash differ from the one stored in the chain account,
+    # If the certified validators hash differs from the one stored in the chain account,
     # the CCU must contain a validators update (which is verified in verifyValidatorsUpdate).
     if certificate.validatorsHash != chainAccount(ccu.params.sendingChainID).lastCertificate.validatorsHash:
         validatorsUpdate = ccu.params.activeValidatorsUpdate

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -89,7 +89,7 @@ These points guarantee that the CCMs are always forwarded to the correct chains 
 
 ### Cross-chain Command Processing Stages
 
-The execution of cross-chain commands as part of the processing of a cross-chain update is done in several stages, in a way analogous to the execution of a transaction as part of the [processing of a block][lip-0055#block-processing-stages]:
+The [execution of cross-chain messages][lip-0049#apply] as part of the processing of a cross-chain update is done in several stages, in a way analogous to the execution of a transaction as part of the [processing of a block][lip-0055#block-processing-stages]:
 
 1. **Cross-chain message verification**: Each module can define protocol logic that verifies a CCM, possibly by accessing the state store. If an error occurs, the channel with the CCU sending chain is terminated and the CCU execution stops.
 2. **Cross-chain command verification**: The cross-chain command corresponding to the CCM `module`-`crossChainCommand` combination is verified. If an error occurs, the channel with the CCM sending chain is terminated and the CCM execution stops.
@@ -139,7 +139,7 @@ def verifyCertificate(ccu: Transaction) -> None:
         raise Exception("Certificate timestamp is not smaller than timestamp of the block including the CCU.")
     
     # If the certified validators hash differ from the one stored in the chain account,
-    # the CCU must contain a validators update (which can be then verified).
+    # the CCU must contain a validators update (which is verified in verifyValidatorsUpdate).
     if certificate.validatorsHash != chainAccount(ccu.params.sendingChainID).lastCertificate.validatorsHash:
         validatorsUpdate = ccu.params.activeValidatorsUpdate
         if len(validatorsUpdate.blsKeysUpdate) == 0 and len(validatorsUpdate.bftWeightsUpdate) == 0 and validatorsUpdate.bftWeightsUpdateBitmap == EMPTY_BYTES and ccu.params.certificateThreshold == validators(ccu.params.sendingChainID).certificateThreshold:

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -272,8 +272,6 @@ def verifyPartnerChainOutboxRoot(ccu: Transaction) -> None:
     
     # Verification for non-empty certificates.
     if len(ccu.params.certificate) > 0:
-        if outboxRootWitness is empty:
-            raise Exception("The outbox root witness must be non-empty to authenticate the new partnerChainOutboxRoot.")
         outboxKey = MODULE_NAME_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(partnerchainID)
         proof = {
             siblingHashes: outboxRootWitness.siblingHashes,

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -759,7 +759,7 @@ Setup to gather the required mainchain information:
 Create a cross-chain update transaction for a given height `h1`:
 
 * Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for a height (say `h2`) higher or equal to `h1`. This will be used as the `certificate` property of the transaction.
-* The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h1` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
+* The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h2` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
 * Select from the list of stored inclusion proofs the one for height `h2`. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
 * Compute the required update to the active validators stored in the chain account and the validators that were used to create `certificate.validatorsHash`. This update can be obtained by following the logic of `getActiveValidatorsUpdate` as detailed in the [Appendix](#appendix).
 * Set the value of the `certificateThreshold` property to the `certificateThreshold` used to create `certificate.validatorsHash`.

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -758,9 +758,9 @@ Setup to gather the required mainchain information:
 
 Create a cross-chain update transaction for a given height `h1`:
 
-* Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for height `h1`. This will be used as the `certificate` property of the transaction.
+* Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for a height (say `h2`) higher or equal to `h1`. This will be used as the `certificate` property of the transaction.
 * The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h1` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
-* Select from the list of stored inclusion proofs the one for height `h1`. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
+* Select from the list of stored inclusion proofs the one for height `h2`. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
 * Compute the required update to the active validators stored in the chain account and the validators that were used to create `certificate.validatorsHash`. This update can be obtained by following the logic of `getActiveValidatorsUpdate` as detailed in the [Appendix](#appendix).
 * Set the value of the `certificateThreshold` property to the `certificateThreshold` used to create `certificate.validatorsHash`.
 * Post the cross-chain update transaction on the sidechain.

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -200,7 +200,7 @@ def verifyValidatorsUpdate(ccu: Transaction) -> None:
             digit = (int.from_bytes(bftWeightsUpdateBitmap, 'big') >> idx) & 1
             if digit != 1:
                 raise Exception("New validators must have a BFT weight update.")
-            if bftWeightsUpdate[idx].bftWeight == 0:
+            if bftWeightsUpdate[idx] == 0:
                 raise Exception("New validators must have a positive BFT weight.")
 
     # Update validator list.
@@ -255,8 +255,22 @@ def verifyPartnerChainOutboxRoot(ccu: Transaction) -> None:
     # because all messages have been included in the CCU.
     newInboxRoot = calculateRootFromRightWitness(inboxTree.size, inboxTree.appendPath, ccu.params.inboxUpdate.messageWitnessHashes)
 
-    # Verification for non-empty certificates.
+    
     outboxRootWitness = ccu.params.inboxUpdate.outboxRootWitness
+    # The outbox root witness properties must be set either both to their default values
+    # or both to a non-default value.
+    if outboxRootWitness.bitmap == EMPTY_BYTES and len(outboxRootWitness.siblingHashes) > 0:
+        raise Exception("The bitmap in the outbox root witness must be non-mepty if the sibling hashes are non-empty.")
+    if outboxRootWitness.bitmap != EMPTY_BYTES and len(outboxRootWitness.siblingHashes) == 0:
+        raise Exception("The sibling hashes in the outbox root witness must be non-mepty if the bitmap is non-empty.")
+
+    # The outbox root witness is empty if and only if the certificate is empty
+    if outboxRootWitness.bitmap == EMPTY_BYTES and len(ccu.params.certificate) > 0:
+        raise Exception("The outbox root witness must be non-empty to authenticate the new partnerChainOutboxRoot.")
+    if outboxRootWitness.bitmap != EMPTY_BYTES  and len(ccu.params.certificate) == 0:
+        raise Exception("The outbox root witness can be non-empty only if the certificate is non-empty.")
+    
+    # Verification for non-empty certificates.
     if len(ccu.params.certificate) > 0:
         if outboxRootWitness is empty:
             raise Exception("The outbox root witness must be non-empty to authenticate the new partnerChainOutboxRoot.")
@@ -277,8 +291,6 @@ def verifyPartnerChainOutboxRoot(ccu: Transaction) -> None:
 
     # Verification for empty certificates.
     else:
-        if outboxRootWitness is non-empty:
-            raise Exception("The outbox root witness can be non-empty only if the certificate is non-empty.")
         if newInboxRoot != channel(partnerchainID).partnerChainOutboxRoot:
             raise Exception("Inbox root does not match partner chain outbox root.")
 ```

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -761,7 +761,7 @@ Create a cross-chain update transaction for a given height `h1`:
 * Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for a height (say `h2`) higher or equal to `h1`. This will be used as the `certificate` property of the transaction.
 * The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h2` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
 * Select from the list of stored inclusion proofs the one for height `h2`. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
-* Compute the required update to the active validators stored in the chain account and the validators that were used to create `certificate.validatorsHash`. This update can be obtained by following the logic of `getActiveValidatorsUpdate` as detailed in the [Appendix](#appendix).
+* Compute the required update to the active validators stored in the chain account and the validators that were used to create `certificate.validatorsHash`. This update can be obtained by following the logic of `getActiveValidatorsUpdate` as detailed in section ["Computing the Validators Update"](#computing-the-validators-update).
 * Set the value of the `certificateThreshold` property to the `certificateThreshold` used to create `certificate.validatorsHash`.
 * Post the cross-chain update transaction on the sidechain.
 
@@ -785,7 +785,7 @@ A cross-chain update transaction may have been created with validly signed infor
 
 If a CCM is invalid, then the sending chain is [terminated][lip-0045#termination]. The CCU processing then continues and CCMs from other chains are applied. All CCMs from terminated chains have no effect, they are neither applied nor forwarded.
 
-#### First Cross-chain Update from a Sidechain
+#### First Cross-chain Message from a Sidechain
 
 The first cross-chain update containing messages from a given chain has a special function. It will change the sending chain status from `CHAIN_STATUS_REGISTERED` to `CHAIN_STATUS_ACTIVE`. This change means that the receiving chain is now available to receive cross-chain messages and can interact with the sending chain. Additionally, once active, sidechains must follow the liveness condition and regularly post cross-chain updates with non-empty certificates on the mainchain (at least once every 30 days). If the sidechain fails to follow the liveness condition, it is terminated on the mainchain.
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-01-18
+Updated: 2023-01-23
 Requires: 0045, 0049, 0058, 0061
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -138,8 +138,8 @@ def verifyCertificate(ccu: Transaction) -> None:
     if certificate.timestamp >= timestamp:
         raise Exception("Certificate timestamp is not smaller than timestamp of the block including the CCU.")
     
-    # If the certified validators hash differs from the one stored in the chain account,
-    # the CCU must contain a validators update (which can be then verified).
+    # If the certified validators hash differ from the one stored in the chain account,
+    # the CCU must contain a validators update (which is verified in verifyValidatorsUpdate).
     if certificate.validatorsHash != chainAccount(ccu.params.sendingChainID).lastCertificate.validatorsHash:
         validatorsUpdate = ccu.params.activeValidatorsUpdate
         if len(validatorsUpdate.blsKeysUpdate) == 0 and len(validatorsUpdate.bftWeightsUpdate) == 0 and validatorsUpdate.bftWeightsUpdateBitmap == EMPTY_BYTES and ccu.params.certificateThreshold == validators(ccu.params.sendingChainID).certificateThreshold:

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -87,9 +87,9 @@ As the roles of both mainchain and sidechain are quite different, so are the tra
 
 These points guarantee that the CCMs are always forwarded to the correct chains and that the receiving chain can be confident that the chain specified in `ccm.sendingChainID` was truly the chain issuing the CCM.
 
-### Cross-chain Update Command Processing Stages
+### Cross-chain Command Processing Stages
 
-The execution of cross-chain updates is done in several stages, in a way analogous to the [processing stage of a block][lip-0055#block-processing-stages]:
+The execution of cross-chain commands as part of the processing of a cross-chain update is done in several stages, in a way analogous to the execution of a transaction as part of the [processing of a block][lip-0055#block-processing-stages]:
 
 1. **Cross-chain message verification**: Each module can define protocol logic that verifies a CCM, possibly by accessing the state store. If an error occurs, the channel with the CCU sending chain is terminated and the CCU execution stops.
 2. **Cross-chain command verification**: The cross-chain command corresponding to the CCM `module`-`crossChainCommand` combination is verified. If an error occurs, the channel with the CCM sending chain is terminated and the CCM execution stops.
@@ -146,8 +146,6 @@ def verifyCertificateSignature(ccu: Transaction) -> None:
     # Certificate signature must be a valid aggregate signature for the sdechain validators.
     certificate = decode(certificateSchema, ccu.params.certificate)
     partnerchainID = ccu.params.sendingChainID
-    validatorKeys = [validator.blsKey for validator in validators(partnerchainID).activeValidators]
-    validatorWeights = [validator.bftWeight for validator in validators(partnerchainID).activeValidators]
     if not verifyAggregateCertificateSignature(
         validators(partnerchainID).activeValidators,
         validators(partnerchainID).certificateThreshold,
@@ -246,7 +244,7 @@ def verifyPartnerChainOutboxRoot(ccu: Transaction) -> None:
         inboxTree.append(sha256(ccmBytes))
 
     # calculateRootFromRightWitness is specified in LIP 0031.
-    # Notice that if len(ccu.params.inboxUpdate.messageWitnessHashes) == 0, this function returns the same value as inbox.root,
+    # Notice that if len(ccu.params.inboxUpdate.messageWitnessHashes) == 0, this function returns the same value as inboxTree.root,
     # because all messages have been included in the CCU.
     newInboxRoot = calculateRootFromRightWitness(inboxTree.size, inboxTree.appendPath, ccu.params.inboxUpdate.messageWitnessHashes)
 
@@ -471,7 +469,7 @@ def verify(ccu: Transaction) -> None:
 
 <img src="lip-0053/mainchainCCUexec.png" width="80%">
 
-_Figure 1: A schematic of the steps of a mainchain CCU execution. Some details are omitted for clarity. Blue boredered boxes indicate the emission of an event._
+_Figure 1: A schematic of the steps of a mainchain CCU execution. Some details are omitted for clarity. Blue bordered boxes indicate the emission of an event._
 
 ```python
 def execute(ccu: Transaction) -> None:
@@ -624,7 +622,7 @@ def verify(ccu: Transaction) -> None:
 
 <img src="lip-0053/sidechainCCUexec.png" width="80%">
 
-_Figure 2: A schematic of the steps of a sidechain CCU execution. Some details are omitted for clarity. Blue boredered boxes indicate the emission of an event._
+_Figure 2: A schematic of the steps of a sidechain CCU execution. Some details are omitted for clarity. Blue bordered boxes indicate the emission of an event._
 
 ```python
 def execute(ccu: Transaction) -> None:
@@ -738,14 +736,14 @@ The Lisk consensus mechanism is designed to create and publish certificates regu
 Setup to gather the required mainchain information:
 
 * Have access to the Interoperability module endpoints exposed by a mainchain node.
-* Maintain a list of all CCMs included in the sidechain outbox. For each height where a CCM was included in the outbox, also save the inclusion witness of the outbox root with respect to the state root. All CCMs and witnesses for heights that have been certified on the sidechain can be discarded.
-* Maintain a history of all validator changes on the mainchain for rounds that have not yet been certified on the sidechain.
+* Maintain a list of all CCMs included in the sidechain outbox. For each height where a CCM was included in the outbox, also save the inclusion witness of the outbox root with respect to the state root. CCMs can be discarded once they are included via a CCU in a final block of the sidechain. All witnesses corresponding to outbox root values older than the latest `partnerChainOutboxRoot` in the final part of the sidechain can be discarded as well.
+* Maintain a history of all validator changes on the mainchain for rounds that have not yet been certified by a certificate that is included in the the final part of the sidechain.
 
 Create a cross-chain update transaction for a given height `h1`:
 
-* Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for a height (say `h2`) higher or equal to `h1`. This will be used as the `certificate` property of the transaction.
-* The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h2` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
-* Compute the inclusion proof for the outbox root of the sidechain account with respect to the mainchain state root. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
+* Find a [signed certificate][lip-0061#select-certificate] in the mainchain block headers for height `h1`. This will be used as the `certificate` property of the transaction.
+* The property `inboxUpdate.crossChainMessages` lists a subset of the CCMs that have been included in the sidechain outbox up to `h1` (and which have not been included on the sidechain yet). If all CCMs are included, the `messageWitnessHashes` will be empty.
+* Select from the list of stored inclusion proofs the one for height `h1`. This proof is then used to compute `inboxUpdate.outboxRootWitness`.
 * Compute the required update to the active validators stored in the chain account and the validators that were used to create `certificate.validatorsHash`. This update can be obtained by following the logic of `getActiveValidatorsUpdate` as detailed in the [Appendix](#appendix).
 * Set the value of the `certificateThreshold` property to the `certificateThreshold` used to create `certificate.validatorsHash`.
 * Post the cross-chain update transaction on the sidechain.
@@ -766,13 +764,13 @@ Those options for partial cross-chain update transactions are not expected to be
 
 #### Invalid Cross-Chain Messages
 
-A cross-chain update transaction may have been created with validly signed information according to the [validity rules](#parameters-validity) and hence be included in the blockchain. However, the transaction could include invalid CCMs. Those will be detected when trying to process the `inboxUpdate`.
+A cross-chain update transaction may have been created with validly signed information according to the validity rules and hence be included in the blockchain. However, the transaction could include invalid CCMs. Those will be detected when trying to process the `inboxUpdate`.
 
-If a CCM is invalid (as specified in the ["Execute Cross-chain Updates" section](#execute-cross-chain-updates)), then the sending chain is [terminated][lip-0045#termination]. The CCU processing then continues and CCMs from other chains are applied. All CCMs from terminated chains have no effect, they are neither applied nor forwarded.
+If a CCM is invalid, then the sending chain is [terminated][lip-0045#termination]. The CCU processing then continues and CCMs from other chains are applied. All CCMs from terminated chains have no effect, they are neither applied nor forwarded.
 
 #### First Cross-chain Update from a Sidechain
 
-The first cross-chain update containing messages from a given chain has a special function. It will change the sending chain status from `CHAIN_STATUS_REGISTERED` to `CHAIN_STATUS_ACTIVE`. This change means that the receiving chain is now available to receive cross-chain messages and can interact with the sending chain. Additionally, once active, sidechains must follow the liveness condition and regularly post cross-chain updates on the mainchain (at least once every 30 days). If the sidechain fails to follow the liveness condition, it is terminated on the mainchain.
+The first cross-chain update containing messages from a given chain has a special function. It will change the sending chain status from `CHAIN_STATUS_REGISTERED` to `CHAIN_STATUS_ACTIVE`. This change means that the receiving chain is now available to receive cross-chain messages and can interact with the sending chain. Additionally, once active, sidechains must follow the liveness condition and regularly post cross-chain updates with non-empty certificates on the mainchain (at least once every 30 days). If the sidechain fails to follow the liveness condition, it is terminated on the mainchain.
 
 When a sidechain is started and registered, the sidechain developers might decide to not activate the sidechain straight away (maybe to do further testing). It could happen then (intentionally or not) that an old block header (almost 30 days old) is submitted to the mainchain to activate the sidechain. This could result in the sidechain being terminated for liveness failure very soon after the activation (maybe only a few minutes later). To prevent this issue (and without any significant drawbacks) the first cross-chain update to be submitted on mainchain must contain a certificate less than 15 days old. The sidechain has therefore at least 15 days to submit the next cross-chain update to the mainchain and start the regular posting of cross-chain updates.
 


### PR DESCRIPTION
Apply fixes from https://github.com/LiskHQ/lips/issues/216 and internal review. In particular, check that a change in the certified `validatorsHash` is accompanied by an `activeValidatorsUpdate`.