### PR TITLE
Update LIP 0048 - small changes (fee pool account, CCC hooks naming)

### DIFF
--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -31,7 +31,11 @@ Each chain can configure the token used to pay fees. On the Lisk mainchain, the 
 
 ### Minimum Fee per Transaction
 
-As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee (which can be zero). The minimum fee is computed from the transaction size. Chains can configure their minimum fee per byte. The minimum part of the fee should be burned, this is to avoid that validators can send transactions in the blocks they generate without cost.
+As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee (which can be zero). The minimum fee is computed from the transaction size. Chains can configure their minimum fee per byte.
+
+The implementation allows the option to transfer minimum fees to the specified pool address `ADDRESS_FEE_POOL`. This could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants.
+
+If `ADDRESS_FEE_POOL` is left undefined, as is the case with the Lisk mainchain, the minimum part of the fee is burned, to avoid that validators can send transactions in the blocks they generate without cost.
 
 ## Specification
 
@@ -39,28 +43,29 @@ As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater 
 
 We define the following constants:
 
-| Name | Type | Value | Description |
-|------|------|-------|-------------|
-| **General Constants** | | | |
-| `MODULE_NAME_FEE` | string | "fee" | Module name of the Fee module. |
-| `EVENT_NAME_GENERATOR_FEE_PROCESSED` | string | "generatorFeeProcessed" | Event name of the GeneratorFeeProcessed event. |
-| `EVENT_NAME_RELAYER_FEE_PROCESSED` | string | "relayerFeeProcessed" | Event name of the RelayerFeeProcessed event. |
-| `EVENT_NAME_INSUFFICIENT_FEE` | string | "insufficientFee" | Event name of the InsufficientFee event. |
-| `LENGTH_ADDRESS` | uint32 | 20 | The length of an address in bytes. |
-| `LENGTH_TOKEN_ID` | uint32 | 8 | The length of a token ID in bytes. |
-| **Configurable Constants** | | **Mainchain Value** | |
-| `MIN_FEE_PER_BYTE` | uint64 | 1000 | Minimum amount of fee per byte required for transaction validity. |
-| `TOKEN_ID_FEE` | bytes | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees. |
+| Name                                 | Type   | Value                                  | Description                                                       |
+| ------------------------------------ | ------ | -------------------------------------- | ----------------------------------------------------------------- |
+| **General Constants**                |        |                                        |                                                                   |
+| `MODULE_NAME_FEE`                    | string | "fee"                                  | Module name of the Fee module.                                    |
+| `EVENT_NAME_GENERATOR_FEE_PROCESSED` | string | "generatorFeeProcessed"                | Event name of the GeneratorFeeProcessed event.                    |
+| `EVENT_NAME_RELAYER_FEE_PROCESSED`   | string | "relayerFeeProcessed"                  | Event name of the RelayerFeeProcessed event.                      |
+| `EVENT_NAME_INSUFFICIENT_FEE`        | string | "insufficientFee"                      | Event name of the InsufficientFee event.                          |
+| `LENGTH_ADDRESS`                     | uint32 | 20                                     | The length of an address in bytes.                                |
+| `LENGTH_TOKEN_ID`                    | uint32 | 8                                      | The length of a token ID in bytes.                                |
+| **Configurable Constants**           |        | **Mainchain Value**                    |                                                                   |
+| `MIN_FEE_PER_BYTE`                   | uint64 | 1000                                   | Minimum amount of fee per byte required for transaction validity. |
+| `TOKEN_ID_FEE`                       | bytes  | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees.           |
+| `ADDRESS_FEE_POOL`                   | bytes  | undefined                              | Address of the fee pool.                                          |
 
 ### Type Definitions
 
 We use the definition of the following types:
 
-| Name | Type | Validation | Description |
-|------|------|------------|-------------|
+| Name          | Type   | Validation                                                                                                                                                                                                                                                                                    | Description                                          |
+| ------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `Transaction` | object | Must follow the `transactionSchema` schema defined in [LIP 0068](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0068.md) with the only difference that `params` property is not serialized and contains the values of parameters of `paramsSchema` for the corresponding transaction. | An object representing a non-serialized transaction. |
-| `CCM` | object | Must follow the `crossChainMessageSchema` schema defined in [LIP 0049][lip-0049#ccmschema]. | The type of cross-chain messages. |
-| `TokenID` | bytes | Must be of length `LENGTH_TOKEN_ID`. | Used for token identifiers. |
+| `CCM`         | object | Must follow the `crossChainMessageSchema` schema defined in [LIP 0049][lip-0049#ccmschema].                                                                                                                                                                                                   | The type of cross-chain messages.                    |
+| `TokenID`     | bytes  | Must be of length `LENGTH_TOKEN_ID`.                                                                                                                                                                                                                                                          | Used for token identifiers.                          |
 
 Furthermore, for the rest of this LIP we indicate with `ctx` the execution context which is passed as extra input to each method call.
 
@@ -238,7 +243,13 @@ def afterCommandExecute(trs: Transaction) -> None:
     senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     # The fee paid to the generator is the difference between the fee paid by the sender and the paid fees.
     Token.unlock(senderAddress, MODULE_NAME_FEE, TOKEN_ID_FEE, trs.fee)
-    Token.burn(senderAddress, TOKEN_ID_FEE, trs.fee - ctx.availableTransactionFee)
+
+    if ADDRESS_FEE_POOL is not None:
+        # Transfer the fees to the pool account address, if it exists.
+        Token.transfer(senderAddress, ADDRESS_FEE_POOL, TOKEN_ID_FEE, trs.fee - ctx.availableTransactionFee)
+    else:
+        Token.burn(senderAddress, TOKEN_ID_FEE, trs.fee - ctx.availableTransactionFee)
+
     Token.transfer(senderAddress, generatorAddress, TOKEN_ID_FEE, ctx.availableTransactionFee)
 
     emitEvent(

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -271,13 +271,13 @@ def afterCommandExecute(trs: Transaction) -> None:
 #### Before Cross-chain Command Execution
 
 ```python
-def beforeCrossChainCommandExecute(trs: Transaction, ccm: CCM) -> None:
+def beforeCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     # The Token module handles checks on the ccm.fee validity
     # with respect to the escrow account of the ccm sending chain.
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
     relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
 
-    # The Token module beforeCrossChainCommandExecute needs to be called first
+    # The Token module beforeCrossChainCommandExecution needs to be called first
     # to ensure that the relayer has enough funds.
     Token.lock(relayerAddress, MODULE_NAME_FEE, messageFeeTokenID, ccm.fee)
     ctx.availableCCMFee = ccm.fee
@@ -286,7 +286,7 @@ def beforeCrossChainCommandExecute(trs: Transaction, ccm: CCM) -> None:
 #### After Cross-chain Command Execution
 
 ```python
-def afterCrossChainCommandExecute(trs: Transaction, ccm: CCM) -> None:
+def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     # The fee paid to the relayer is the difference between the message fee and the paid fees.
     relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-fee-module/318
 Status: Draft
 Type: Standards Track
 Created: 2021-08-09
-Updated: 2023-01-18
+Updated: 2023-01-23
 Requires: 0051
 ```
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -55,7 +55,7 @@ We define the following constants:
 | **Configurable Constants**           |        | **Mainchain Value**                    |                                                                   |
 | `MIN_FEE_PER_BYTE`                   | uint64 | 1000                                   | Minimum amount of fee per byte required for transaction validity. |
 | `TOKEN_ID_FEE`                       | bytes  | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees.           |
-| `ADDRESS_FEE_POOL`                   | bytes  | Undefined                              | Address of the fee pool.                                          |
+| `ADDRESS_FEE_POOL`                   | bytes  | None                                   | Address of the fee pool.                                          |
 
 ### Type Definitions
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -91,7 +91,7 @@ This event has name `name = EVENT_NAME_GENERATOR_FEE_PROCESSED`. The event is em
 ```java
 generatorFeeProcessedEventDataSchema = {
     "type": "object",
-    "required": ["senderAddress", "generatorAddress", "minimalAmount", "generatorAmount"],
+    "required": ["senderAddress", "generatorAddress", "requiredAmount", "generatorAmount"],
     "properties": {
         "senderAddress": {
             "dataType": "bytes",
@@ -103,7 +103,7 @@ generatorFeeProcessedEventDataSchema = {
             "length": LENGTH_ADDRESS,
             "fieldNumber": 2
         },
-        "minimalAmount": {
+        "requiredAmount": {
             "dataType": "uint64",
             "fieldNumber": 3
         },
@@ -128,7 +128,7 @@ This event has name `name = EVENT_NAME_RELAYER_FEE_PROCESSED`. The event is emit
 ```java
 relayerFeeProcessedEventDataSchema = {
     "type": "object",
-    "required": ["ccmID", "relayerAddress", "minimalAmount", "relayerAmount"],
+    "required": ["ccmID", "relayerAddress", "requiredAmount", "relayerAmount"],
     "properties": {
         "ccmID": {
             "dataType": "bytes",
@@ -140,7 +140,7 @@ relayerFeeProcessedEventDataSchema = {
             "length": LENGTH_ADDRESS,
             "fieldNumber": 2
         },
-        "minimalAmount": {
+        "requiredAmount": {
             "dataType": "uint64",
             "fieldNumber": 3
         },
@@ -256,7 +256,7 @@ def afterCommandExecute(trs: Transaction) -> None:
         data = {
             "senderAddress": senderAddress,
             "generatorAddress": generatorAddress,
-            "minimalAmount": trs.fee - ctx.availableTransactionFee,
+            "requiredAmount": trs.fee - ctx.availableTransactionFee,
             "generatorAmount": ctx.availableTransactionFee
         },
         topics = [senderAddress, generatorAddress]
@@ -304,7 +304,7 @@ def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
         data = {
             "ccmID": ccmID,
             "relayerAddress": relayerAddress,
-            "minimalAmount": ccm.fee - ctx.availableCCMFee,
+            "requiredAmount": ccm.fee - ctx.availableCCMFee,
             "relayerAmount": ctx.availableCCMFee
         },
         topics = [relayerAddress]

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -55,7 +55,7 @@ We define the following constants:
 | **Configurable Constants**           |        | **Mainchain Value**                    |                                                                   |
 | `MIN_FEE_PER_BYTE`                   | uint64 | 1000                                   | Minimum amount of fee per byte required for transaction validity. |
 | `TOKEN_ID_FEE`                       | bytes  | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees.           |
-| `ADDRESS_FEE_POOL`                   | bytes  | None                                   | Address of the fee pool.                                          |
+| `ADDRESS_FEE_POOL`                   | bytes  | Undefined                              | Address of the fee pool.                                          |
 
 ### Type Definitions
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -37,6 +37,8 @@ The implementation allows the option to transfer minimum fees to the specified p
 
 If `ADDRESS_FEE_POOL` is left undefined, as is the case with the Lisk mainchain, the minimum part of the fee is burned, to avoid that validators can send transactions in the blocks they generate without cost.
 
+Similarly, chains can define a special account address `ADDRESS_CCM_FEE_POOL` for collecting minimum CCM fees, in the case of cross-chain commands.
+
 ## Specification
 
 ### Notation and Constants
@@ -55,7 +57,8 @@ We define the following constants:
 | **Configurable Constants**           |        | **Mainchain Value**                    |                                                                   |
 | `MIN_FEE_PER_BYTE`                   | uint64 | 1000                                   | Minimum amount of fee per byte required for transaction validity. |
 | `TOKEN_ID_FEE`                       | bytes  | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees.           |
-| `ADDRESS_FEE_POOL`                   | bytes  | undefined                              | Address of the fee pool.                                          |
+| `ADDRESS_FEE_POOL`                   | bytes  | None                                   | Address of the fee pool.                                          |
+| `ADDRESS_CCM_FEE_POOL`               | bytes  | None                                   | Address of the fee pool.                                          |
 
 ### Type Definitions
 
@@ -93,7 +96,7 @@ This event has name `name = EVENT_NAME_GENERATOR_FEE_PROCESSED`. The event is em
 ```java
 generatorFeeProcessedEventDataSchema = {
     "type": "object",
-    "required": ["senderAddress", "generatorAddress", "burntAmount", "generatorAmount"],
+    "required": ["senderAddress", "generatorAddress", "minimalAmount", "generatorAmount"],
     "properties": {
         "senderAddress": {
             "dataType": "bytes",
@@ -105,7 +108,7 @@ generatorFeeProcessedEventDataSchema = {
             "length": LENGTH_ADDRESS,
             "fieldNumber": 2
         },
-        "burntAmount": {
+        "minimalAmount": {
             "dataType": "uint64",
             "fieldNumber": 3
         },
@@ -130,7 +133,7 @@ This event has name `name = EVENT_NAME_RELAYER_FEE_PROCESSED`. The event is emit
 ```java
 relayerFeeProcessedEventDataSchema = {
     "type": "object",
-    "required": ["ccmID", "relayerAddress", "burntAmount", "relayerAmount"],
+    "required": ["ccmID", "relayerAddress", "minimalAmount", "relayerAmount"],
     "properties": {
         "ccmID": {
             "dataType": "bytes",
@@ -142,7 +145,7 @@ relayerFeeProcessedEventDataSchema = {
             "length": LENGTH_ADDRESS,
             "fieldNumber": 2
         },
-        "burntAmount": {
+        "minimalAmount": {
             "dataType": "uint64",
             "fieldNumber": 3
         },
@@ -258,7 +261,7 @@ def afterCommandExecute(trs: Transaction) -> None:
         data = {
             "senderAddress": senderAddress,
             "generatorAddress": generatorAddress,
-            "burntAmount": trs.fee - ctx.availableTransactionFee,
+            "minimalAmount": trs.fee - ctx.availableTransactionFee,
             "generatorAmount": ctx.availableTransactionFee
         },
         topics = [senderAddress, generatorAddress]
@@ -291,8 +294,14 @@ def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
     Token.unlock(relayerAddress, MODULE_NAME_FEE, messageFeeTokenID, ccm.fee)
-    Token.burn(relayerAddress, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
+
+    if ADDRESS_FEE_POOL is not None:
+        # Transfer the fees to the pool account address, if it exists.
+        Token.transfer(relayerAddress, ADDRESS_CCM_FEE_POOL, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
+    else:
+        Token.burn(relayerAddress, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
     # No need to transfer as the remaining fee is already in the relayer account.
+
     ccmID = sha256(encodeCCM(ccm))
     emitEvent(
         module = MODULE_NAME_FEE,
@@ -300,7 +309,7 @@ def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
         data = {
             "ccmID": ccmID,
             "relayerAddress": relayerAddress,
-            "burntAmount": ccm.fee - ctx.availableCCMFee,
+            "minimalAmount": ccm.fee - ctx.availableCCMFee,
             "relayerAmount": ctx.availableCCMFee
         },
         topics = [relayerAddress]

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -33,9 +33,7 @@ Each chain can configure the token used to pay fees. On the Lisk mainchain, the 
 
 As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee (which can be zero). The minimum fee is computed from the transaction size. Chains can configure their minimum fee per byte.
 
-The implementation allows the option to transfer minimum fees to the specified pool address `ADDRESS_FEE_POOL`. This could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants.
-
-If `ADDRESS_FEE_POOL` is left undefined, as is the case with the Lisk mainchain, the minimum part of the fee is burned, to avoid that validators can send transactions in the blocks they generate without cost.
+Chains can choose that this minimum fee gets either burned (to avoid that validators can send transactions in the blocks they generate without cost) or transferred to the specified pool address `ADDRESS_FEE_POOL`. The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants. In the Lisk mainchain, the minimum fee is always burned.
 
 ## Specification
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -37,8 +37,6 @@ The implementation allows the option to transfer minimum fees to the specified p
 
 If `ADDRESS_FEE_POOL` is left undefined, as is the case with the Lisk mainchain, the minimum part of the fee is burned, to avoid that validators can send transactions in the blocks they generate without cost.
 
-Similarly, chains can define a special account address `ADDRESS_CCM_FEE_POOL` for collecting minimum CCM fees, in the case of cross-chain commands.
-
 ## Specification
 
 ### Notation and Constants
@@ -58,7 +56,6 @@ We define the following constants:
 | `MIN_FEE_PER_BYTE`                   | uint64 | 1000                                   | Minimum amount of fee per byte required for transaction validity. |
 | `TOKEN_ID_FEE`                       | bytes  | `OWN_CHAIN_ID[0:1] + '00000000000000'` | Token ID of the token used to pay the transaction fees.           |
 | `ADDRESS_FEE_POOL`                   | bytes  | None                                   | Address of the fee pool.                                          |
-| `ADDRESS_CCM_FEE_POOL`               | bytes  | None                                   | Address of the fee pool.                                          |
 
 ### Type Definitions
 
@@ -297,7 +294,7 @@ def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
 
     if ADDRESS_FEE_POOL is not None:
         # Transfer the fees to the pool account address, if it exists.
-        Token.transfer(relayerAddress, ADDRESS_CCM_FEE_POOL, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
+        Token.transfer(relayerAddress, ADDRESS_FEE_POOL, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
     else:
         Token.burn(relayerAddress, messageFeeTokenID, ccm.fee - ctx.availableCCMFee)
     # No need to transfer as the remaining fee is already in the relayer account.


### PR DESCRIPTION
Small changes to the Fee module LIP, with regards to the following issues:

- [Allow transfering fees to account instead of burning them](https://github.com/LiskHQ/lips/issues/209)
- [LIP 0048 uses some wrong function names for some CCC hooks](https://github.com/LiskHQ/lips/issues/224).