### PR TITLE
Update the usage of chainID in lip0066

### DIFF
--- a/proposals/lip-0037.md
+++ b/proposals/lip-0037.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/use-message-tags-and-chain-identifie
 Status: Draft
 Type: Standards Track
 Created: 2021-04-07
-Updated: 2023-01-20
+Updated: 2023-01-30
 Replaces: 0009
 ```
 

--- a/proposals/lip-0037.md
+++ b/proposals/lip-0037.md
@@ -45,7 +45,7 @@ These specifications supersede the specifications given in [LIP 0009][lip-0009].
 
 Chain identifiers are 4-byte values that follow a specific format: the first byte is used to identify the network in which the chain is running (either the mainnet, official testnet, or any other test network). The other 3 bytes identify the chain within the network. We include the network-specific prefix explicitly to ensure that a chain does not use the same chain identifier in the test network as in the mainnet.
 
-The first bit of the chain-identifier prefix is always set to `0`. Thus, we have a total of `128` available network IDs. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation).
+The first bit of the chain-identifier prefix is always set to `0`. Thus, we have a total of `128` available network IDs. This is done to prevent the overflow of the max size of `uint32` for hardened paths for [Ed25519 keys derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation).
 
 Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage that users can easily verify that they are signing a transaction for the correct blockchain. Furthermore, the chain identifier can be directly set by the blockchain creator, which is more convenient than generating a random 32-byte value.
 
@@ -62,7 +62,7 @@ Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage t
 
 | Name | Type | Validation | Description |
 |------|------|------------|-------------|
-| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain.|
+| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain. |
 
 ### Message Tags
 

--- a/proposals/lip-0037.md
+++ b/proposals/lip-0037.md
@@ -43,7 +43,9 @@ Note that any updates to the serialization specification of a message type must 
 Chain identifiers for transaction signatures and block signatures were already introduced in [LIP 0009](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0009.md#specification) and [LIP 0024](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0024.md#update-to-the-block-header-signing-procedure) (as network identifiers) to prevent replay attacks on other chains. Here, we specify how to use a chain identifier for any kind of message to prevent replay attacks on other chains in general.
 These specifications supersede the specifications given in [LIP 0009][lip-0009].
 
-Chain identifiers are 4-byte values that follow a specific format: the first byte is used to identify the network in which the chain is running (either the mainnet, official testnet, or any other test network). The first bit of the first byte is set to `0`. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation). The other 3 bytes identify the chain within the network. We include the network-specific prefix explicitly to ensure that a chain does not use the same chain identifier in the test network as in the mainnet.
+Chain identifiers are 4-byte values that follow a specific format: the first byte is used to identify the network in which the chain is running (either the mainnet, official testnet, or any other test network). The other 3 bytes identify the chain within the network. We include the network-specific prefix explicitly to ensure that a chain does not use the same chain identifier in the test network as in the mainnet.
+
+The first bit of the chain-identifier prefix is always set to `0`. Thus, we have a total of `128` available network IDs. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation).
 
 Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage that users can easily verify that they are signing a transaction for the correct blockchain. Furthermore, the chain identifier can be directly set by the blockchain creator, which is more convenient than generating a random 32-byte value.
 
@@ -60,7 +62,7 @@ Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage t
 
 | Name | Type | Validation | Description |
 |------|------|------------|-------------|
-| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain which is `chainID.to_bytes(4, 'big')` i.e. big endian uint32 serialization of `chainID`.|
+| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain.|
 
 ### Message Tags
 
@@ -96,7 +98,7 @@ has to be used where:
 
 ### Chain Identifiers
 
-Chain identifiers are 4-byte values. The first byte is set to `CHAIN_ID_PREFIX_MAINNET` for chains running in the mainnet network and to `CHAIN_ID_PREFIX_TESTNET` for chains running in the testnet network. The first bit of the chain-identifier prefix is always set to `0`. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation). The other 3 bytes must be chosen uniquely for the respective blockchain, i.e., no other blockchain created with the Lisk SDK should use the same 3 bytes.
+Chain identifiers are 4-byte values. The first byte is set to `CHAIN_ID_PREFIX_MAINNET` for chains running in the mainnet network and to `CHAIN_ID_PREFIX_TESTNET` for chains running in the testnet network. The first bit of the chain-identifier prefix is always set to `0`. The other 3 bytes must be chosen uniquely for the respective blockchain, i.e., no other blockchain created with the Lisk SDK should use the same 3 bytes.
 
 The following table defines the chain-identifiers prefixes currently specified.
 

--- a/proposals/lip-0037.md
+++ b/proposals/lip-0037.md
@@ -43,7 +43,7 @@ Note that any updates to the serialization specification of a message type must 
 Chain identifiers for transaction signatures and block signatures were already introduced in [LIP 0009](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0009.md#specification) and [LIP 0024](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0024.md#update-to-the-block-header-signing-procedure) (as network identifiers) to prevent replay attacks on other chains. Here, we specify how to use a chain identifier for any kind of message to prevent replay attacks on other chains in general.
 These specifications supersede the specifications given in [LIP 0009][lip-0009].
 
-Chain identifiers are 4-byte values that follow a specific format: the first byte is used to identify the network in which the chain is running (either the mainnet, official testnet, or any other test network); the other 3 bytes identify the chain within the network. We include the network-specific prefix explicitly to ensure that a chain does not use the same chain identifier in the test network as in the mainnet.
+Chain identifiers are 4-byte values that follow a specific format: the first byte is used to identify the network in which the chain is running (either the mainnet, official testnet, or any other test network). The first bit of the first byte is set to `0`. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation). The other 3 bytes identify the chain within the network. We include the network-specific prefix explicitly to ensure that a chain does not use the same chain identifier in the test network as in the mainnet.
 
 Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage that users can easily verify that they are signing a transaction for the correct blockchain. Furthermore, the chain identifier can be directly set by the blockchain creator, which is more convenient than generating a random 32-byte value.
 
@@ -96,7 +96,7 @@ has to be used where:
 
 ### Chain Identifiers
 
-Chain identifiers are 4-byte values. The first byte is set to `CHAIN_ID_PREFIX_MAINNET` for chains running in the mainnet network and to `CHAIN_ID_PREFIX_TESTNET` for chains running in the testnet network. The other 3 bytes must be chosen uniquely for the respective blockchain, i.e., no other blockchain created with the Lisk SDK should use the same 3 bytes.
+Chain identifiers are 4-byte values. The first byte is set to `CHAIN_ID_PREFIX_MAINNET` for chains running in the mainnet network and to `CHAIN_ID_PREFIX_TESTNET` for chains running in the testnet network. The first bit of the chain-identifier prefix is always set to `0`. This is done to prevent the overflow of the max size of `uint32` when we hardened the paths for [Ed25519 derivation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0066.md#ed25519-key-derivation). The other 3 bytes must be chosen uniquely for the respective blockchain, i.e., no other blockchain created with the Lisk SDK should use the same 3 bytes.
 
 The following table defines the chain-identifiers prefixes currently specified.
 

--- a/proposals/lip-0037.md
+++ b/proposals/lip-0037.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/use-message-tags-and-chain-identifie
 Status: Draft
 Type: Standards Track
 Created: 2021-04-07
-Updated: 2023-01-18
+Updated: 2023-01-20
 Replaces: 0009
 ```
 
@@ -60,7 +60,7 @@ Using 4 bytes instead of 32 bytes as in [LIP 0009][lip-0009] has the advantage t
 
 | Name | Type | Validation | Description |
 |------|------|------------|-------------|
-| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain. |
+| `ChainID` | `bytes` | Must be of length `CHAIN_ID_LENGTH`. | ID of a chain which is `chainID.to_bytes(4, 'big')` i.e. big endian uint32 serialization of `chainID`.|
 
 ### Message Tags
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -45,14 +45,12 @@ We define the following constants:
 | `PrivateKeyEd25519` | bytes  | Byte sequences of length `ED25519_PRIVATE_KEY_LENGTH`. | An Ed25519 private key. |
 | `PrivateKeyBLS`     | bytes  | Byte sequences of length `BLS_PRIVATE_KEY_LENGTH`. | An BLS private key. |
 
-## bytesToInt Conversion
-For the `chainID` , we use the bytes value. We define the function `bytesToInt` to deserialize bytes to integer value.
+## uint32be Function
+We define the function `uint32be` to convert bytes to unsigned integer values.
 
 ```python
-def bytesToInt(numberBytes: bytes) -> int:
-    if len(numberBytes) > chainID:
-        raise Exception()
-    return big-endian decoding of numberBytes
+def uint32be(chainID: bytes) -> int:
+    return int.from_bytes(chainID, byteorder='big')
 ```
 
 ### Ed25519 Key Derivation
@@ -129,7 +127,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `chainID `is `m/25519'/134'/chainID'/n'.` Here `chainID` is the big-endian decoding of `bytesToInt(chainID)`.
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted` is the return integer value of `uint32be(chainID)`. The hardened derivation `chainIDConverted'` can always be converted to a byte value that fits into 4 bytes because the first bit is set to `0`.
 
 ### BLS Key Derivation
 
@@ -153,7 +151,7 @@ The logic of the functions `derive_master_SK` and `derive_child_SK` are specifie
 
 #### Derivation Path for BLS Keys
 
-Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainID/0` for the BLS key derived for the chain with ID `chainID`. Here `chainID` is the big-endian decoding of `bytesToInt(chainID)`.
+Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainIDConverted/0` for the BLS key derived for the chain with ID `chainID` where `ChainIDConverted` is the return integer value of `uint32be(chainID)`.
 
 In particular, the path used to derive the BLS private key for the Lisk mainchain in the Lisk mainnet is `m/12381/134/0/0`.
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -127,7 +127,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/chainIDConverted'/n'`, where `chainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a chain ID must be 0](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `chainID` is `m/25519'/134'/chainIDConverted'/n'`, where `chainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a chain ID must be 0](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
 
 ### BLS Key Derivation
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -127,7 +127,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a chainID must be 0](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/chainIDConverted'/n'`, where `chainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a chain ID must be 0](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
 
 ### BLS Key Derivation
 
@@ -151,7 +151,7 @@ The logic of the functions `derive_master_SK` and `derive_child_SK` are specifie
 
 #### Derivation Path for BLS Keys
 
-Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainIDConverted/0` for the BLS key derived for the chain with ID `chainID` where `ChainIDConverted = bytesToUint(chainID)`.
+Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainIDConverted/0` for the BLS key derived for the chain with ID `chainID` where `chainIDConverted = bytesToUint(chainID)`.
 
 In particular, the path used to derive the BLS private key for the Lisk mainchain in the Lisk mainnet is `m/12381/134/0/0`.
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -45,11 +45,11 @@ We define the following constants:
 | `PrivateKeyEd25519` | bytes  | Byte sequences of length `ED25519_PRIVATE_KEY_LENGTH`. | An Ed25519 private key. |
 | `PrivateKeyBLS`     | bytes  | Byte sequences of length `BLS_PRIVATE_KEY_LENGTH`. | An BLS private key. |
 
-## uint32be Function
-We define the function `uint32be` to convert bytes to unsigned integer values.
+## bytesToUint Function
+We define the function `bytesToUint` to convert bytes to unsigned integer values.
 
 ```python
-def uint32be(chainID: bytes) -> int:
+def bytesToUint(chainID: bytes) -> uint32:
     return int.from_bytes(chainID, byteorder='big')
 ```
 
@@ -127,7 +127,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted` is the return integer value of `uint32be(chainID)`. The hardened derivation `chainIDConverted'` can always be converted to a byte value that fits into 4 bytes because the first bit is set to `0`.
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a `chainID` must be `0`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
 
 ### BLS Key Derivation
 
@@ -151,7 +151,7 @@ The logic of the functions `derive_master_SK` and `derive_child_SK` are specifie
 
 #### Derivation Path for BLS Keys
 
-Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainIDConverted/0` for the BLS key derived for the chain with ID `chainID` where `ChainIDConverted` is the return integer value of `uint32be(chainID)`.
+Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainIDConverted/0` for the BLS key derived for the chain with ID `chainID` where `ChainIDConverted = bytesToUint(chainID)`.
 
 In particular, the path used to derive the BLS private key for the Lisk mainchain in the Lisk mainnet is `m/12381/134/0/0`.
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -45,7 +45,7 @@ We define the following constants:
 | `PrivateKeyEd25519` | bytes  | Byte sequences of length `ED25519_PRIVATE_KEY_LENGTH`. | An Ed25519 private key. |
 | `PrivateKeyBLS`     | bytes  | Byte sequences of length `BLS_PRIVATE_KEY_LENGTH`. | An BLS private key. |
 
-## bytesToUint Function
+#### bytesToUint Function
 We define the function `bytesToUint` to convert bytes to unsigned integer values.
 
 ```python
@@ -127,7 +127,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a `chainID` must be `0`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `ChainID` is `m/25519'/134'/ChainIDConverted'/n'`, where `ChainIDConverted = bytesToUint(chainID)`. The hardened value `chainIDConverted'` will always be within the range of a `uint32` because [the first bit of a chainID must be 0](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0037.md#chain-identifiers-1).
 
 ### BLS Key Derivation
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-tree-based-key-derivation-
 Status: Draft
 Type: Informational
 Created: 2022-06-02
-Updated: 2023-01-16
+Updated: 2023-01-20
 ```
 
 ## Abstract

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-tree-based-key-derivation-
 Status: Draft
 Type: Informational
 Created: 2022-06-02
-Updated: 2022-07-22
+Updated: 2023-01-16
 ```
 
 ## Abstract
@@ -44,6 +44,16 @@ We define the following constants:
 | `ExtendedKey`       | object | Object with 2 properties, `key` and `chainCode`. Both associated values must be byte sequences of length 32. | Used as an intermediary object during key derivation. |
 | `PrivateKeyEd25519` | bytes  | Byte sequences of length `ED25519_PRIVATE_KEY_LENGTH`. | An Ed25519 private key. |
 | `PrivateKeyBLS`     | bytes  | Byte sequences of length `BLS_PRIVATE_KEY_LENGTH`. | An BLS private key. |
+
+## bytesToInt Conversion
+For the `chainID` , we use the bytes value. We define the function `bytesToInt` to deserialize bytes to integer value.
+
+```python
+def bytesToInt(numberBytes: bytes) -> int:
+    if len(numberBytes) > chainID:
+        raise Exception()
+    return big-endian decoding of numberBytes
+```
 
 ### Ed25519 Key Derivation
 
@@ -119,7 +129,7 @@ def childKeyDerivation(node: ExtendedKey, index: uint32) -> ExtendedKey:
 
 The path for deriving the n-th private key from that phrase is `m/44'/134'/n'`. This follows the specifications of [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Registered_coin_types) and [SLIP 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), assigning 134 to the LSK token.
 
-The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `chainID `is `m/25519'/134'/chainID'/n'.` If `chainID` is not known, use the path `m/25519'/134'/0'/n'` for the n-th generator key derived for chains without known chain ID.
+The path for deriving the private key of the n-th [generator key](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0044.md#generator-key) pair, for the chain with [ID](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0043.md#chain-id) `chainID `is `m/25519'/134'/chainID'/n'.` Here `chainID` is the big-endian decoding of `bytesToInt(chainID)`.
 
 ### BLS Key Derivation
 
@@ -143,11 +153,9 @@ The logic of the functions `derive_master_SK` and `derive_child_SK` are specifie
 
 #### Derivation Path for BLS Keys
 
-Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainID/0` for the BLS key derived for the chain with ID `chainID`.
+Similarly to the specifications of [EIP 2334](https://eips.ethereum.org/EIPS/eip-2334), we use the path `m/12381/134/chainID/0` for the BLS key derived for the chain with ID `chainID`. Here `chainID` is the big-endian decoding of `bytesToInt(chainID)`.
 
-If `chainID` is not known, use the path `m/12381/134/0/n` for the n-th generator key derived for chains without known chain ID.
-
-In particular, the path used to derive the BLS private key for the Lisk mainchain is `m/12381/134/1/0`.
+In particular, the path used to derive the BLS private key for the Lisk mainchain in the Lisk mainnet is `m/12381/134/0/0`.
 
 ### Secret Recovery Phrase
 

--- a/proposals/lip-0066.md
+++ b/proposals/lip-0066.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-tree-based-key-derivation-
 Status: Draft
 Type: Informational
 Created: 2022-06-02
-Updated: 2023-01-20
+Updated: 2023-01-30
 ```
 
 ## Abstract


### PR DESCRIPTION
This PR introduces the following changes:

- Handling the new format of `chainID` which is in bytes. Specifically, we treat the `chainID` as the encoding of a `uint32` value in big endian and insert the corresponding integer value in the derivation path. 
- Case of `chainID` not known does not exist anymore.