### PR TITLE
Fix usage of pubKeySignaturePairs in createAggSig

### DIFF
--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bls-signatures/282
 Status: Draft
 Type: Informational
 Created: 2021-04-13
-Updated: 2023-01-10
+Updated: 2023-01-23
 ```
 
 ## Abstract

--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -87,8 +87,8 @@ def createAggSig(keysList: list[bytes], pubKeySignaturePairs: list[tuple[bytes, 
     aggregationBits = byte string of length ceil(length(keyList)/8) with all bytes set to 0
     signatures = []
     for pair in pubKeySignaturePairs:
-        signatures.append(pair.sig)
-        index = keysList.index(pair.pubkey)
+        signatures.append(pair[1])
+        index = keysList.index(pair[0])
         # set bit at position index to 1 in aggregationBits
         aggregationBits[index // 8] |= 1 << (index % 8)
     signature = Aggregate(signatures)


### PR DESCRIPTION
It fixes [issue #221](https://github.com/LiskHQ/lips/issues/211) by accessing tuple elements by their index instead of a property name.