### PR TITLE
Update LIP 0070 - fix constant name

### DIFF
--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -123,7 +123,6 @@ For the rest of this proposal we define the following constants:
 | `MIN_WEIGHT` | uint64 | `1000*(10^8)` | The minimum validator weight required to be selected as a block generator. |
 | `NUMBER_ACTIVE_VALIDATORS` | uint32 | `101` | The number of active validators.To be compatible with the interoperability module, the value should be at most `MAX_NUM_VALIDATORS` ( constant defined in [LIP 0045][lip-0045#constants]), due to the fact that BLS keys of all active validators should fit into a [Cross-Chain Update Transaction (CCU)][lip-0053]. |
 | `NUMBER_STANDBY_VALIDATORS` | uint32 | `2` | The number of standby validators. This LIP is specified for the number of standby validators being 0, 1 or 2. |
-| `ROUND_LENGTH` | uint32 | `103` | The round length. Is equal to `NUMBER_ACTIVE_VALIDATORS` + `NUMBER_STANDBY_VALIDATORS` |
 | `VALIDATOR_REGISTRATION_FEE` | uint64 | `10*(10^8)` | The extra command fee of the validator registration. |
 | `WEIGHT_SCALE_FACTOR` | uint32 | `1000 * (10)^8` | It determines the factor by which BFT weights are divided. |
 | `MAX_BFT_WEIGHT_CAP` | uint32 | `500` | It determines the maximum BFT weight percentage for a single validator. The percentage is obtained by dividing this value by 100, i.e., a value of 500 corresponds to 5%. |

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -123,6 +123,7 @@ For the rest of this proposal we define the following constants:
 | `MIN_WEIGHT` | uint64 | `1000*(10^8)` | The minimum validator weight required to be selected as a block generator. |
 | `NUMBER_ACTIVE_VALIDATORS` | uint32 | `101` | The number of active validators.To be compatible with the interoperability module, the value should be at most `MAX_NUM_VALIDATORS` ( constant defined in [LIP 0045][lip-0045#constants]), due to the fact that BLS keys of all active validators should fit into a [Cross-Chain Update Transaction (CCU)][lip-0053]. |
 | `NUMBER_STANDBY_VALIDATORS` | uint32 | `2` | The number of standby validators. This LIP is specified for the number of standby validators being 0, 1 or 2. |
+| `ROUND_LENGTH` | uint32 | `103` | The round length. Is equal to `NUMBER_ACTIVE_VALIDATORS` + `NUMBER_STANDBY_VALIDATORS` |
 | `VALIDATOR_REGISTRATION_FEE` | uint64 | `10*(10^8)` | The extra command fee of the validator registration. |
 | `WEIGHT_SCALE_FACTOR` | uint32 | `1000 * (10)^8` | It determines the factor by which BFT weights are divided. |
 | `MAX_BFT_WEIGHT_CAP` | uint32 | `500` | It determines the maximum BFT weight percentage for a single validator. The percentage is obtained by dividing this value by 100, i.e., a value of 500 corresponds to 5%. |

--- a/proposals/lip-0070.md
+++ b/proposals/lip-0070.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-reward-sharing-mechanism/3
 Status: Draft
 Type: Standards Track
 Created: 2022-10-26
-Updated: 2023-01-17
+Updated: 2023-01-30
 Required: 0022, 0023, 0057
 ```
 

--- a/proposals/lip-0070.md
+++ b/proposals/lip-0070.md
@@ -432,7 +432,7 @@ Validators can change their commission using a change commission transaction. Th
 
 To avoid such cases and provide guarantees to stakers on their expected rewards, we introduce two constraints on the increase of the validator commission:
 
-* The increase of the commission rate should be at most `MAX_COMMISSION_INCREASE`. For the mainchain this is set to 5%.
+* The increase of the commission should be at most `MAX_COMMISSION_INCREASE`. For the mainchain this is set to 5%.
 * After increasing the commission, a validator can not increase it again for the next  `COMMISSION_INCREASE_PERIOD` blocks. For the mainchain, this is set to 260000 blocks (roughly 30 days).
 
 Those two constraints provide the guarantee to the stakers that if they check the changes in validators' commissions reasonably often (e.g., once a month for the mainchain), then the potential loses in expected rewards of the stakers are quite limited.  

--- a/proposals/lip-0070.md
+++ b/proposals/lip-0070.md
@@ -47,7 +47,7 @@ Here we define the constants related to reward sharing. All other PoS module con
 | `MAX_NUM_BYTES_Q96` | uint32 | 24 | The maximal number of bytes of a serialized fractional number in Q96 format. |
 | **Configurable Constants** | | **Mainchain Value** | |
 | `COMMISSION_INCREASE_PERIOD` | uint32 | 260000 | Determines how frequently (after how many blocks) a validator can increase their commission. |
-| `MAX_COMMISSION_INCREASE_RATE`| uint32 | 500 | Determines the maximum allowed increase on the commission per transaction. |
+| `MAX_COMMISSION_INCREASE`| uint32 | 500 | Determines the maximum allowed increase on the commission per transaction. |
 
 ### Types
 
@@ -136,8 +136,8 @@ def verify(trs: Transaction) -> None:
        h - validatorStore(senderAddress).lastCommissionIncreaseHeight < COMMISSION_INCREASE_PERIOD:
         raise Exception('Can only increase the commission again COMMISSION_INCREASE_PERIOD blocks after the last commission increase.')
 
-    if (trs.params.newCommission - oldCommission) > MAX_COMMISSION_INCREASE_RATE:
-        raise Exception('Invalid argument: Commission increase larger than MAX_COMMISSION_INCREASE_RATE.')
+    if (trs.params.newCommission - oldCommission) > MAX_COMMISSION_INCREASE:
+        raise Exception('Invalid argument: Commission increase larger than MAX_COMMISSION_INCREASE.')
 ```
 
 ##### Execution
@@ -432,7 +432,7 @@ Validators can change their commission using a change commission transaction. Th
 
 To avoid such cases and provide guarantees to stakers on their expected rewards, we introduce two constraints on the increase of the validator commission:
 
-* The increase of the commission rate should be at most `MAX_COMMISSION_INCREASE_RATE`. For the mainchain this is set to 5%.
+* The increase of the commission rate should be at most `MAX_COMMISSION_INCREASE`. For the mainchain this is set to 5%.
 * After increasing the commission, a validator can not increase it again for the next  `COMMISSION_INCREASE_PERIOD` blocks. For the mainchain, this is set to 260000 blocks (roughly 30 days).
 
 Those two constraints provide the guarantee to the stakers that if they check the changes in validators' commissions reasonably often (e.g., once a month for the mainchain), then the potential loses in expected rewards of the stakers are quite limited.  


### PR DESCRIPTION
This PR changes the name of the constant `MAX_COMMISSION_INCREASE_RATE` to `MAX_COMMISSION_INCREASE`, for extra clarity on the meaning of this constant. 