### PR TITLE
Rename verifyBLSKey to validateBLSKey

### DIFF
--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/introduce-validators-module/317
 Status: Draft
 Type: Standards Track
 Created: 2021-08-06
-Updated: 2023-01-18
+Updated: 2023-01-30
 Requires: 0040
 ```
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -611,12 +611,12 @@ setValidatorParams(precommitThreshold: uint64, certificateThreshold: uint64, val
 
 This function works exactly as the function `getValidatorKeys` defined [above](#getValidatorKeys).
 
-#### verifyBLSKey
+#### validateBLSKey
 
 This function checks that the input BLS key `blsKey` has not been registered before in the chain and that the proof of possession `proofOfPossession` for the BLS key is valid.
 
 ```python
-def verifyBLSKey(proofOfPossession: ProofOfPossession, blsKey: PublicKeyBLS) -> bool:
+def validateBLSKey(proofOfPossession: ProofOfPossession, blsKey: PublicKeyBLS) -> bool:
     if there exists an entry in the registered BLS keys substore with storeKey == blsKey:
         return False
 


### PR DESCRIPTION
This fixes the [issue 214](https://github.com/LiskHQ/lips/issues/214) by renaming the endpoint `verifyBLSKey` to `validateBLSKey`.