### PR TITLE
Fix issues in LIP-0044

### DIFF
--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -533,7 +533,7 @@ def getValidatorParams() -> ValidatorParams:
 
 #### getGeneratorsBetweenTimestamps
 
-This function returns the addresses of the generators active between the two input timestamps and the number of block slots assigned to them. The slots corresponding to the input timestamps are NOT counted, only the slots in between. Notice that for all counted slots, the current value of `validatorParamsStore.validators` must be the used generator list. Otherwise, the behaviour is undefined. It’s the calling module’s responsibility to ensure that.
+This function returns the addresses of the generators active between the two input timestamps and the number of block slots assigned to them. The slots corresponding to the input timestamps are NOT counted, only the slots in between. Notice that the input timestamps must be recent enough sucht that the active validator set for the counted slots is the one stored `validatorParamsStore.validators`. If the input timestamps are older, the result will most likely be incorrect. It’s the calling module’s responsibility to ensure that.
 
 ```python
 def getGeneratorsBetweenTimestamps(startTimestamp: uint32, endTimestamp: uint32) -> dict[Address, uint32]:

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/introduce-validators-module/317
 Status: Draft
 Type: Standards Track
 Created: 2021-08-06
-Updated: 2023-01-30
+Updated: 2023-02-02
 Requires: 0040
 ```
 

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -533,7 +533,7 @@ def getValidatorParams() -> ValidatorParams:
 
 #### getGeneratorsBetweenTimestamps
 
-This function returns the addresses of the generators active between the two input timestamps and the number of block slots assigned to them. The slots corresponding to the input timestamps are NOT counted, only the slots in between. Notice that for all counted slots, the current `generatorList` must be the used generator list. Otherwise, the behaviour is undefined. It’s the calling module’s responsibility to ensure that.
+This function returns the addresses of the generators active between the two input timestamps and the number of block slots assigned to them. The slots corresponding to the input timestamps are NOT counted, only the slots in between. Notice that for all counted slots, the current value of `validatorParamsStore.validators` must be the used generator list. Otherwise, the behaviour is undefined. It’s the calling module’s responsibility to ensure that.
 
 ```python
 def getGeneratorsBetweenTimestamps(startTimestamp: uint32, endTimestamp: uint32) -> dict[Address, uint32]:
@@ -549,6 +549,7 @@ def getGeneratorsBetweenTimestamps(startTimestamp: uint32, endTimestamp: uint32)
         return result
 
     totalSlots = endSlotNumber - startSlotNumber + 1
+    generatorList = [validator.address for validator in validatorParamsStore.validators]
 
     # Quick skip to directly assign many block slots to every generator in the list.
     baseSlots = totalSlots // len(generatorList)

--- a/proposals/lip-0044.md
+++ b/proposals/lip-0044.md
@@ -54,7 +54,6 @@ We define the following constants:
 | `SUBSTORE_PREFIX_VALIDATORS_KEYS` | bytes | 0x0000 | Substore prefix of the validators keys substore. |
 | `SUBSTORE_PREFIX_VALIDATOR_PARAMS` | bytes | 0x4000 | Substore prefix of the validator params substore. |
 | `SUBSTORE_PREFIX_BLS_KEYS` | bytes | 0x8000 | Substore prefix of the registered BLS keys substore. |
-| `SUBSTORE_PREFIX_GENESIS_DATA` | bytes | 0xc000 | Substore prefix of the genesis data substore. |
 | `INVALID_BLS_KEY` | bytes | `BLS_PUBLIC_KEY_LENGTH` bytes all set to 0x00 | An invalid BLS key, used as a placeholder before a valid BLS key is registered. |
 | `BLOCK_TIME` | integer | 10 (value for the Lisk mainchain) | Block time (in seconds) set in the chain configuration. |
 | `EVENT_NAME_GENERATOR_KEY_REGISTRATION` | string | "generatorKeyRegistration" | Name of the generator key registration event. |


### PR DESCRIPTION
This PR fixes the following in LIP 0044:
- Remove the unused constant `SUBSTORE_PREFIX_GENESIS_DATA` from the constants table.
- Define `generatorList` in `getGeneratorsBetweenTimestamps`, as the definition was removed by [PR 177](https://github.com/LiskHQ/lips/pull/177).

It fixes #241 .