### PR TITLE
Change BFT Parameter removal height

### DIFF
--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -768,7 +768,7 @@ In the before application processing stage of a block `b`, the BFT store is upda
 4. The value of `bftVotes.maxHeightPrevoted` is updated by calling the function `updateMaxHeightPrevoted` specified in [LIP 0056][lip-0056].
 5. The value of `bftVotes.maxHeightPrecommitted` is updated by calling the function `updateMaxHeightPrecommitted` specified in [LIP 0056][lip-0056].
 6. Let `m` be the aggregate commit included in block `b`. If `m.aggregationBits` is empty bytes and `m.signature` is empty bytes, do nothing. Otherwise, set `bftVotes.maxHeightCertified` to `m.height`.
-7. Let `h` be the largest integer such that `h <= min(getMaxRemovalHeight(), bftVotes.blockBFTInfos[-1].height)` and there is an entry in the BFT Parameters store with key `h`. Then remove any key-value pair from BFT Parameters with a key strictly smaller than `h`. Note that that function `getMaxRemovalHeight()` is defined in [LIP 0061](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#single-commit-removal).
+7. Let `h` be the largest integer such that `h <= min(getMaxRemovalHeight(), bftVotes.blockBFTInfos[-1].height)` and there is an entry in the BFT Parameters store with key `h`. Then remove any key-value pair from BFT Parameters with a key strictly smaller than `h`. Note that the function `getMaxRemovalHeight()` is defined in [LIP 0061](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#single-commit-removal).
 
 #### After Application Processing
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -768,7 +768,7 @@ In the before application processing stage of a block `b`, the BFT store is upda
 4. The value of `bftVotes.maxHeightPrevoted` is updated by calling the function `updateMaxHeightPrevoted` specified in [LIP 0056][lip-0056].
 5. The value of `bftVotes.maxHeightPrecommitted` is updated by calling the function `updateMaxHeightPrecommitted` specified in [LIP 0056][lip-0056].
 6. Let `m` be the aggregate commit included in block `b`. If `m.aggregationBits` is empty bytes and `m.signature` is empty bytes, do nothing. Otherwise, set `bftVotes.maxHeightCertified` to `m.height`.
-7. Let `h` be the largest integer such that `h <= min(bftVotes.maxHeightCertified+1, bftVotes.blockBFTInfos[-1].height)` and there is an entry in the BFT Parameters store with key `h`. Then remove any key-value pair from BFT Parameters with a key strictly smaller than `h`.
+7. Let `h` be the largest integer such that `h <= min(getMaxRemovalHeight(), bftVotes.blockBFTInfos[-1].height)` and there is an entry in the BFT Parameters store with key `h`. Then remove any key-value pair from BFT Parameters with a key strictly smaller than `h`. Note that that function `getMaxRemovalHeight()` is defined in [LIP 0061](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#single-commit-removal).
 
 #### After Application Processing
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2023-01-30
+Updated: 2023-02-13
 Requires: 0055, 0056, 0061
 ```
 


### PR DESCRIPTION
This PR changes the height at which old BFT parameters are removed in the engine. For the aggregate commit creation BFT parameters for certain older heights are needed in certain cases, see https://github.com/LiskHQ/lips/issues/245.

Resolves https://github.com/LiskHQ/lips/issues/245

