### PR TITLE
Fix LIP0054 open issues

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-02-24
+Updated: 2023-03-10
 Requires: 0043, 0049, 0053, 0054
 ```
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -236,6 +236,7 @@ In this section, we specify the substores that are part of the Interoperability 
 | `MAX_CROSS_CHAIN_COMMAND_NAME_LENGTH` | uint32 | 32 | The maximum length of a string specifying the name of a command. |
 | `MIN_CHAIN_NAME_LENGTH` | uint32 | 1 | The minimum length of a string specifying the name of a chain. |
 | `MAX_CHAIN_NAME_LENGTH` | uint32 | 32 | The maximum length of a string specifying the name of a chain. |
+| `SUBSTORE_PREFIX_LENGTH` | uint32 | 2 | Length in bytes of a substore prefix. |
 
 We further use the utility function `getMainchainID` defined in [LIP 0037][lip-0037#getMainchainID] to obtain the chain ID of the mainchain.
 
@@ -618,8 +619,8 @@ terminatedStateAccountSchema = {
 ```
 ##### Properties
 
-* `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain, or to the state root given in the parameters of the sidechain terminated CCM. If the account is not initialized, it is set to `EMPTY_HASH` instead.
-* `mainchainStateRoot`: The last certified state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(getMainchainID()).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_HASH` instead.
+* `stateRoot`: The state root of the terminated chain. If the terminated state account is initialized, this property is set to either `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain, or to the state root given in the parameters of the sidechain terminated CCM. If the account is not initialized, it is set to `EMPTY_HASH` instead.
+* `mainchainStateRoot`: If the terminated state account is *not* initialized, this property is set to the last certified state root of the mainchain at the moment in which the chain was terminated, i.e. to `chainAccount(getMainchainID()).lastCertificate.stateRoot`. If the account is initialized, it is set to `EMPTY_HASH` instead.
 * `initialized`: A boolean value, indicating whether the terminated state account has been initialized, i.e. if the `stateRoot` property has been set.
 
 A terminated state account is created as part of the `terminateChain` function, as part of the processing of a sidechain terminated CCM, as part of the processing of a channel terminated CCM, or as part of the processing of a state recovery initialization command.

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -980,6 +980,14 @@ The `createTerminatedStateAccount` function creates an entry in the terminated s
 def createTerminatedStateAccount(chainID: ChainID, stateRoot: bytes = EMPTY_HASH) -> None:    
     if chainAccount(chainID) exists:
         chainAccount(chainID).status = CHAIN_STATUS_TERMINATED
+        # Emit chain status updated event.
+        emitEvent(
+            module = MODULE_NAME_INTEROPERABILITY,
+            name = EVENT_NAME_CHAIN_ACCOUNT_UPDATED,
+            data = chainAccount(chainID),
+            topics = [chainID]
+        )
+
         remove the entry with storeKey = chainID from the outbox root substore
 
         # If no stateRoot is given as input, get it from the state.
@@ -991,28 +999,27 @@ def createTerminatedStateAccount(chainID: ChainID, stateRoot: bytes = EMPTY_HASH
             "mainchainStateRoot": EMPTY_HASH,
             "initialized": True
         }
-
-        # Emit chain status updated event.
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CHAIN_ACCOUNT_UPDATED,
-            data = chainAccount(chainID),
-            topics = [chainID]
-        )
-
-    # State root is not available, set it to empty hash temporarily.
-    # This should only happen on a sidechain.
+        
     else:
         # Processing on the mainchain.
         if ownChainAccount.chainID == getMainchainID():
             # If the account does not exist on the mainchain, the input chainID is invalid.
             raise Exception('Chain to be terminated is not valid.')
 
-        terminatedState = {
-            "stateRoot": EMPTY_HASH,
-            "mainchainStateRoot": chainAccount(getMainchainID()).lastCertificate.stateRoot,
-            "initialized": False
-        }
+        # If no stateRoot is given as input, the terminated state account is not initialized.
+        # This can only happen on a sidechain.
+        if stateRoot == EMPTY_HASH:
+            terminatedState = {
+                "stateRoot": EMPTY_HASH,
+                "mainchainStateRoot": chainAccount(getMainchainID()).lastCertificate.stateRoot,
+                "initialized": False
+            }
+        else:
+            terminatedState = {
+                "stateRoot": stateRoot,
+                "mainchainStateRoot": EMPTY_HASH,
+                "initialized": True
+            }    
 
     create an entry in the terminated state substore with
         storeKey = chainID

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -618,7 +618,7 @@ terminatedStateAccountSchema = {
 ```
 ##### Properties
 
-* `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain, or to the state root given in the parameters of the sidechain terminated CCM. If the account is not initialized, it is set to `EMPTY_HASH` instead. 
+* `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain, or to the state root given in the parameters of the sidechain terminated CCM. If the account is not initialized, it is set to `EMPTY_HASH` instead.
 * `mainchainStateRoot`: The last certified state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(getMainchainID()).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_HASH` instead.
 * `initialized`: A boolean value, indicating whether the terminated state account has been initialized, i.e. if the `stateRoot` property has been set.
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -618,8 +618,8 @@ terminatedStateAccountSchema = {
 ```
 ##### Properties
 
-* `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain. If the account is not initialized, it is set to `EMPTY_HASH` instead.
-* `mainchainStateRoot`: The state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(getMainchainID()).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_HASH` instead.
+* `stateRoot`: The state root of the terminated chain, initialized to `chainAccount(chainID).lastCertificate.stateRoot`, where `chainID` is the chain ID of the terminated chain, or to the state root given in the parameters of the sidechain terminated CCM. If the account is not initialized, it is set to `EMPTY_HASH` instead. 
+* `mainchainStateRoot`: The last certified state root of the mainchain at the moment in which the chain was terminated, set to `chainAccount(getMainchainID()).lastCertificate.stateRoot` for non-initialized terminated state accounts. If the account is initialized, it is set to `EMPTY_HASH` instead.
 * `initialized`: A boolean value, indicating whether the terminated state account has been initialized, i.e. if the `stateRoot` property has been set.
 
 A terminated state account is created as part of the `terminateChain` function, as part of the processing of a sidechain terminated CCM, as part of the processing of a channel terminated CCM, or as part of the processing of a state recovery initialization command.

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -67,9 +67,9 @@ This command is used to terminate a sidechain that violated the liveness conditi
 
 ### Message Recovery from the Sidechain Channel Outbox
 
-This mechanism allows to recover any CCM pending in the sidechain channel outbox. That is, those CCMs sent from the sidechain that have not been included in the (terminated) receiving chain yet. Specifically, this includes all the CCMs whose indices (the position of these CCMs in the outbox tree) are larger than the index of the last message that the receiving sidechain reported to have included in its inbox. 
+This mechanism allows to recover any CCM pending in the sidechain channel outbox. That is, those CCMs sent from the sending chain that have not been included in the (terminated) receiving chain yet. Specifically, this includes all the CCMs whose indices (the position of these CCMs in the outbox tree) are larger than the index of the last message that the receiving sidechain reported to have included in its inbox. 
 
-Notice that the message recovery mechanism requires that the channel outbox is stored in the chain where the commands are processed. In the SDK 6, sidechain channels can only be stored on the mainchain. This means that the message recovery mechanism would only works on the mainchain.
+Notice that the message recovery mechanism requires that the channel outbox is stored in the chain where the commands are processed. In the SDK 6, sidechain channels can only be stored on the mainchain. This means that the message recovery mechanism would only work on the mainchain.
 
 The message recovery mechanism requires the following conditions:
 
@@ -238,6 +238,11 @@ def verify(trs: Transaction) -> None:
             "bitmap": entry.bitmap
         }
         storeQueries.append(query)
+    
+    # Check that every query keys are pariwise distinct, 
+    # meaning that we are not trying to recover the same entry twice.
+    if len(queryKeys) != len(set(queryKeys)):
+        raise Exception("Recovered store keys are not pairwise distinct.")
 
     proofOfInclusionStores = { siblingHashes: trsParams.siblingHashes, queries : storeQueries }
 
@@ -263,7 +268,7 @@ def execute(trs: Transaction) -> None:
 
         emptyStore = EMPTY_BYTES
         query = {
-            "key": storePrefix + entry.substorePrefix + entry.storeKey,
+            "key": storePrefix + entry.substorePrefix + sha256(entry.storeKey),
             "value": sha256(emptyStore),
             "bitmap": entry.bitmap
         }

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -75,7 +75,7 @@ The message recovery mechanism requires the following conditions:
 
 * There exists an entry in the terminated outbox substore with store key equal to the terminated sidechain chain ID. This entry is created by the [message recovery initialization command](#message-recovery-initialization-command), which can be submitted after the chain account has been terminated.
 * The pending CCMs to be recovered have to be available to the sender of the recovery command.
-* The indices of the pending CCMs to be recovered have to be larger than the value of the `partnerChainInboxSize` property of the terminated outbox account. This implies that these CCMs are still pending or that their  processing has not been certified to the mainchain.
+* The indices of the pending CCMs to be recovered have to be larger than the value of the `partnerChainInboxSize` property of the terminated outbox account. This implies that these CCMs are still pending or that their processing has not been certified to the mainchain.
 * The proof of inclusion for the pending CCMs into the  `outboxRoot` property of the terminated outbox account has to be available. When a message recovery command is processed, the `outboxRoot` property is updated to account for the recovered CCMs (see Figure 1). This implies that the future potential message recovery commands have to include a proof of inclusion into the updated Merkle tree against the new `outboxRoot`.
 
 ![CCM_recovery](lip-0054/ccm_recovery.png)

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -21,7 +21,7 @@ This LIP is licensed under the [Creative Commons Zero 1.0 Universal][creative].
 
 ## Motivation
 
-In the Lisk ecosystem, the ability of a sidechain to interoperate with other chains can be revoked, i.e., terminated, permanently. Specifically, this occurs when the sidechain has been inactive for too long, i.e., not posting a transaction with a [cross-chain update (CCU)][lip-0053] command for more than 30 days, or if it posted one with a malicious CCU command on the mainchain. Once a sidechain is terminated in the ecosystem, the users of said chain cannot have any cross-chain interaction with it. This means they will no longer be able to send or receive any (fungible or non-fungible) token, message or custom information from or to the sidechain. Therefore, it is useful to provide a trustless on-chain mechanism to recover tokens, messages and information from terminated sidechains. This mechanism will noticeably improve the user experience of the Lisk ecosystem without affecting the security guarantees of the general interoperability solution.
+In the Lisk ecosystem, the ability of a sidechain to interoperate with other chains can be revoked, i.e., terminated, permanently. Specifically, this occurs when the sidechain has been inactive for too long, i.e., not posting a transaction with a [cross-chain update (CCU)][lip-0053] command with non-empty certificate for more than 30 days, or if it posted one with a malicious CCU command on the mainchain. Once a sidechain is terminated in the ecosystem, the users of said chain cannot have any cross-chain interaction with it. This means they will no longer be able to send or receive any (fungible or non-fungible) token, message or custom information from or to the sidechain. Therefore, it is useful to provide a trustless on-chain mechanism to recover tokens, messages and information from terminated sidechains. This mechanism will noticeably improve the user experience of the Lisk ecosystem without affecting the security guarantees of the general interoperability solution.
 
 ## Rationale
 
@@ -67,9 +67,13 @@ This command is used to terminate a sidechain that violated the liveness conditi
 
 ### Message Recovery from the Sidechain Channel Outbox
 
-This mechanism allows to recover any CCM pending in the sidechain channel outbox. That is, those CCMs sent from the sidechain that have not been included in the (terminated) receiving chain yet. Specifically, this includes all the CCMs whose indices (the position of these CCMs in the outbox tree) are larger than the index of the last message that the receiving sidechain reported to have included in its inbox. This recovery mechanism requires these conditions to work as follows:
+This mechanism allows to recover any CCM pending in the sidechain channel outbox. That is, those CCMs sent from the sidechain that have not been included in the (terminated) receiving chain yet. Specifically, this includes all the CCMs whose indices (the position of these CCMs in the outbox tree) are larger than the index of the last message that the receiving sidechain reported to have included in its inbox. 
 
-* The sidechain chain account has been terminated on the mainchain, i.e. there exists an entry in the terminated chain substore with store key equal to the sidechain chain ID. This entry is created automatically on the mainchain.
+Notice that the message recovery mechanism requires that the channel outbox is stored in the chain where the commands are processed. In the SDK 6, sidechain channels can only be stored on the mainchain. This means that the message recovery mechanism would only works on the mainchain.
+
+The message recovery mechanism requires the following conditions:
+
+* The sidechain chain account has been terminated on the mainchain, i.e. there exists an entry in the terminated state substore with store key equal to the sidechain chain ID. This entry is created automatically on the mainchain.
 * There exists an entry in the terminated outbox substore with store key equal to the terminated sidechain chain ID. This entry is created by the message recovery initialization command, which can be submitted after the chain account has been terminated.
 * The pending CCMs to be recovered have to be available to the sender of the recovery command.
 * The indices of the pending CCMs to be recovered have to be larger than the value of the `partnerChainInboxSize` property of the terminated outbox account. This implies that these CCMs are still pending or that their processing has not been certified to the mainchain.
@@ -161,7 +165,8 @@ stateRecoveryParams = {
         "siblingHashes": {
             "type": "array",
             "items": {
-                "dataType": "bytes"
+                "dataType": "bytes",
+                "length": HASH_LENGTH
             },
             "fieldNumber": 4
         }
@@ -170,7 +175,7 @@ stateRecoveryParams = {
 ```
 
 * `chainID`: The ID of the terminated sidechain identifying the terminated state account from which assets will be recovered.
-* `module`: The ID of the module store to recover.
+* `module`: The name of the module store to recover.
 * `storeEntries`: An array of store entries to recover. Each store entry is an object with the following properties:
   * `substorePrefix`: The substore prefix of the substore to recover.
   * `storeKey`: The store key of the entry to recover.
@@ -191,13 +196,12 @@ def verify(trs: Transaction) -> None:
     if terminatedStateAccount(trsParams.chainID).initialized == False:
         raise Exception("Terminated state account is not initialized.")
 
-    # Interoperability module cannot be recovered.
-    if trsParams.module == MODULE_NAME_INTEROPERABILITY:
-        raise Exception("Interoperability module cannot be recovered.")
-
     if trsParams.module is not associated with a module registered on the chain:
         raise Exception("Module is not registered on the chain.")
+
     # The module indicated in the transaction params must have a recover function.
+    # For example, this means that modules such as Interoperability or Auth
+    # cannot be recovered.
     recoveryModule = module associated with trsParams.module
     if recoveryModule does not have a recover function:
         raise Exception("Module is not recoverable.")
@@ -211,12 +215,13 @@ def verify(trs: Transaction) -> None:
     storePrefix = module_name_to_store_prefix(trsParams.module)
 
     for entry in trsParams.storeEntries:
-        if entry.value is EMPTY_BYTES:
+        if entry.storeValue is EMPTY_BYTES:
             raise Exception("Recovered store value cannot be empty.")
 
-        queryKeys.append(entry.storeKey)
+        queryKey = storePrefix + entry.substorePrefix + sha256(entry.storeKey)
+        queryKeys.append(queryKey)
         query = {
-            "key": storePrefix + entry.substorePrefix + sha256(entry.storeKey),
+            "key": queryKey,
             "value": sha256(entry.storeValue),
             "bitmap": entry.bitmap
         }
@@ -228,6 +233,8 @@ def verify(trs: Transaction) -> None:
         raise Exception("State recovery proof of inclusion is not valid.")
 ```
 
+The function `module_name_to_store_prefix` is defined in [LIP 0040][lip-0040#module-store-prefix].
+
 #### Execution
 
 ```python
@@ -237,13 +244,14 @@ def execute(trs: Transaction) -> None:
     storeQueries = []
 
     recoveryModule = module associated with trsParams.module
+    storePrefix = module_name_to_store_prefix(trsParams.module)
     for entry in trsParams.storeEntries:
         # The recover function corresponding to trsParams.module applies the recovery logic.
         recoveryModule.recover(trsParams.chainID, entry.substorePrefix, entry.storeKey, entry.storeValue)
 
         emptyStore = EMPTY_BYTES
         query = {
-            "key": trsParams.module + entry.substorePrefix + entry.storeKey,
+            "key": storePrefix + entry.substorePrefix + entry.storeKey,
             "value": sha256(emptyStore),
             "bitmap": entry.bitmap
         }
@@ -331,15 +339,27 @@ def verify(trs: Transaction) -> None:
 
     if terminatedOutboxAccount(trsParams.chainID) does not exist:
         raise Exception("Terminated outbox account does not exist.")
+    
+    # Check that there is at least one cross-chain message to recover.
+    if len(trsParams.crossChainMessages) == 0:
+        raise Exception("No cross-chain messages to recover.")
+    
+    # Check that there is exactly one index per cross-chain message.
+    if len(trsParams.idxs) != len(trsParams.crossChainMessages):
+        raise Exception("Inclusion proof indices and cross-chain messages do not have the same length.")
 
     # Check that the idxs are sorted in ascending order.
     if trsParams.idxs != sorted(trsParams.idxs):
         raise Exception("Cross-chain message indexes are not sorted in ascending order.")
 
-    # Check that the CCMs are still pending.
-    for index in trsParams.idxs:
-        if index < terminatedOutboxAccount(trsParams.chainID).partnerChainInboxSize:
-            raise Exception("Cross-chain message is not pending.")
+    # Check that the idxs are unique.
+    if len(trsParams.idxs) != len(set(trsParams.idxs)):
+        raise Exception("Cross-chain message indexes are not unique.")
+    
+    # Check that the CCMs are still pending. We can check only the first one,
+    # as the idxs are sorted in ascending order.
+    if trsParams.idxs[0] < terminatedOutboxAccount(trsParams.chainID).partnerChainInboxSize:
+        raise Exception("Cross-chain message is not pending.")
 
     # Process basic checks for all CCMs.
     for ccmBytes in crossChainMessages:
@@ -370,6 +390,8 @@ def verify(trs: Transaction) -> None:
         ) == False:
         raise Exception("Message recovery proof of inclusion is not valid.")
 ```
+
+The function `validateFormat` is defined in [LIP 0049][lip-0049#validateFormat].
 
 #### Execution
 
@@ -412,7 +434,6 @@ def execute(trs: Transaction) -> None:
 ```python
 def applyRecovery(trs: Transaction, ccm: CCM) -> None:
     # Calculate CCM ID, used later in events.
-    ccmID = sha256(encode(crossChainMessageSchema, ccm))
     ccm.status = CCM_STATUS_CODE_RECOVERED
     ccm.sendingChainID, ccm.receivingChainID = ccm.receivingChainID, ccm.sendingChainID
 
@@ -511,9 +532,6 @@ def applyRecovery(trs: Transaction, ccm: CCM) -> None:
 
 ```python
 def forwardRecovery(trs: Transaction, ccm: CCM) -> None:
-    # Calculate CCM ID, used later in events.
-    ccmID = sha256(encode(crossChainMessageSchema, ccm))
-
     ccm.status = CCM_STATUS_CODE_RECOVERED
     ccm.sendingChainID, ccm.receivingChainID = ccm.receivingChainID, ccm.sendingChainID
 
@@ -552,11 +570,10 @@ def forwardRecovery(trs: Transaction, ccm: CCM) -> None:
     # Emit CCM forwarded event.
     # Recalculate CCM ID. This differs because of new status, sending, and receiving chains.
     # We use the updated ID as this CCM is appended to the outbox.
-    recoveredCCMID = sha256(encode(crossChainMessageSchema, ccm))
     emitEvent(
         module = MODULE_NAME_INTEROPERABILITY,
         name = EVENT_NAME_CCM_PROCESSED,
-        data = {"ccmID": recoveredCCMID, "result": CCM_PROCESSED_RESULT_FORWARDED, "code": CCM_PROCESSED_CODE_SUCCESS},
+        data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_FORWARDED, "code": CCM_PROCESSED_CODE_SUCCESS},
         topics = [ccm.sendingChainID, ccm.receivingChainID]
     )
 ```
@@ -597,7 +614,7 @@ def verify(trs: Transaction) -> None:
     if chainAccount(trsParams.chainID) does not exist:
         raise Exception("Chain account does not exist.")
 
-    # The commands fails if the sidechain is already terminated.
+    # The command fails if the sidechain is already terminated.
     if chainAccount(trsParams.chainID).status == CHAIN_STATUS_TERMINATED:
         raise Exception("Sidechain is already terminated.")
 
@@ -677,12 +694,12 @@ def verify(trs: Transaction) -> None:
     if trsParams.chainID == getMainchainID() or trsParams.chainID == ownChainAccount.chainID:
         raise Exception("Chain ID is not valid.")
 
-    # The commands fails if the sidechain is already terminated on this chain.
+    # The command fails if the sidechain is already terminated on this chain.
     if terminatedStateAccount(trsParams.chainID) exists and terminatedStateAccount(trsParams.chainID).initialized == True:
         raise Exception("Sidechain is already terminated.")
 
     sidechainAccount = decode(chainDataSchema, trsParams.sidechainAccount)
-    # The commands fails if the sidechain is not terminated and did not violate the liveness requirement.
+    # The command fails if the sidechain is not terminated and did not violate the liveness requirement.
     if sidechainAccount.status != CHAIN_STATUS_TERMINATED
         and chainAccount(getMainchainID()).lastCertificate.timestamp - sidechainAccount.lastCertificate.timestamp <= LIVENESS_LIMIT:
         raise Exception("Sidechain is not terminated.")
@@ -783,15 +800,15 @@ def verify(trs: Transaction) -> None:
     if trsParams.chainID == getMainchainID() or trsParams.chainID == ownChainAccount.chainID:
         raise Exception("Chain ID is not valid.")
 
-    # The commands fails if the chain is not registered.
+    # The command fails if the chain is not registered.
     if chainAccount(trsParams.chainID) does not exist:
         raise Exception("Chain is not registered.")
 
-    # The commands fails if the chain is not terminated.
+    # The command fails if the chain is not terminated.
     if terminatedStateAccount(trsParams.chainID) does not exist or terminatedStateAccount(trsParams.chainID).initialized == False:
-        raise Exception("Chain is not terminated.")
+        raise Exception("Terminated state account not present or not initialized.")
 
-    # The commands fails if there exist already a terminated outbox account.
+    # The command fails if there exist already a terminated outbox account.
     if terminatedOutboxAccount(trsParams.chainID) exists:
         raise Exception("Terminated outbox account already exists.")
 
@@ -838,12 +855,14 @@ TBA
 [lip-0031#proof-of-inclusion]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0031.md#proof-of-inclusion
 [lip-0039]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0039.md
 [lip-0039#proof-construction]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0039.md#proof-construction
+[lip-0040#module-store-prefix]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0040.md#module-store-prefix-1
 [lip-0045]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md
 [lip-0045#specs]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#specification
 [lip-0045#constants]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#notation-and-constants
 [lip-0049]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md
 [lip-0049#schema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#cross-chain-message-schema
 [lip-0049#terminatedMessage]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#sidechain-terminated-message
+[lip-0049#validateFormat]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#validateFormat
 [lip-0051]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md
 [lip-0051#recover]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#recover
 [lip-0052]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0052.md

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-sidechain-recovery-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-22
+Updated: 2023-03-10
 Requires: 0040, 0045, 0049, 0051
 ```
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -73,10 +73,9 @@ Notice that the message recovery mechanism requires that the channel outbox is s
 
 The message recovery mechanism requires the following conditions:
 
-* The sidechain chain account has been terminated on the mainchain, i.e. there exists an entry in the terminated state substore with store key equal to the sidechain chain ID. This entry is created automatically on the mainchain.
-* There exists an entry in the terminated outbox substore with store key equal to the terminated sidechain chain ID. This entry is created by the message recovery initialization command, which can be submitted after the chain account has been terminated.
+* There exists an entry in the terminated outbox substore with store key equal to the terminated sidechain chain ID. This entry is created by the [message recovery initialization command](#message-recovery-initialization-command), which can be submitted after the chain account has been terminated.
 * The pending CCMs to be recovered have to be available to the sender of the recovery command.
-* The indices of the pending CCMs to be recovered have to be larger than the value of the `partnerChainInboxSize` property of the terminated outbox account. This implies that these CCMs are still pending or that their processing has not been certified to the mainchain.
+* The indices of the pending CCMs to be recovered have to be larger than the value of the `partnerChainInboxSize` property of the terminated outbox account. This implies that these CCMs are still pending or that their  processing has not been certified to the mainchain.
 * The proof of inclusion for the pending CCMs into the  `outboxRoot` property of the terminated outbox account has to be available. When a message recovery command is processed, the `outboxRoot` property is updated to account for the recovered CCMs (see Figure 1). This implies that the future potential message recovery commands have to include a proof of inclusion into the updated Merkle tree against the new `outboxRoot`.
 
 ![CCM_recovery](lip-0054/ccm_recovery.png)
@@ -146,6 +145,8 @@ stateRecoveryParams = {
         },
         "module": {
             "dataType": "string",
+            "minLength": MIN_MODULE_NAME_LENGTH,
+            "maxLength": MAX_MODULE_NAME_LENGTH,
             "fieldNumber": 2
         },
         "storeEntries": {
@@ -156,6 +157,8 @@ stateRecoveryParams = {
                 "properties": {
                     "substorePrefix": {
                         "dataType": "bytes",
+                        "minLength": SUBSTORE_PREFIX_LENGTH,
+                        "maxLength": SUBSTORE_PREFIX_LENGTH,
                         "fieldNumber": 1
                     },
                     "storeKey": {
@@ -450,7 +453,6 @@ def execute(trs: Transaction) -> None:
 
 ```python
 def applyRecovery(trs: Transaction, ccm: CCM) -> None:
-    # Calculate CCM ID, used later in events.
     ccm.status = CCM_STATUS_CODE_RECOVERED
     ccm.sendingChainID, ccm.receivingChainID = ccm.receivingChainID, ccm.sendingChainID
 
@@ -765,8 +767,8 @@ def verify(trs: Transaction) -> None:
         raise Exception("Chain is not registered.")
 
     # The command fails if the chain is not terminated.
-    if terminatedStateAccount(trsParams.chainID) does not exist or terminatedStateAccount(trsParams.chainID).initialized == False:
-        raise Exception("Terminated state account not present or not initialized.")
+    if terminatedStateAccount(trsParams.chainID) does not exist:
+        raise Exception("Terminated state account not present.")
 
     # The command fails if there exist already a terminated outbox account.
     if terminatedOutboxAccount(trsParams.chainID) exists:

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -111,6 +111,18 @@ Furthermore, for the rest of this section:
 * Let `SMTVerify` be the `verify` function specified in [LIP 0039][lip-0039].
 * Let `SMTCalculateRoot` be the `calculateRoot` function specified in [LIP 0039][lip-0039].
 
+We also define the following auxiliary function to make the specifications more readable.
+
+```python
+def emitCCMEvent(ccm: CCM, result: uint32, code: uint32) -> None:
+    emitEvent(
+        module = MODULE_NAME_INTEROPERABILITY,
+        name = EVENT_NAME_CCM_PROCESSED,
+        data = {"ccm": ccm, "result": result, "code": code},
+        topics = [ccm.sendingChainID, ccm.receivingChainID]
+    )
+```
+
 ### State Recovery Command
 
 This command is used to recover the state from a terminated chain.
@@ -443,41 +455,21 @@ def applyRecovery(trs: Transaction, ccm: CCM) -> None:
         for each module mdl for which verifyCrossChainMessage exists:
             mdl.verifyCrossChainMessage(trs, ccm)
     except:
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_CCM_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_CCM_EXCEPTION)
         return
 
     if ccm.module is not supported:
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_MODULE_NOT_SUPPORTED},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_MODULE_NOT_SUPPORTED)
         return
     elif crossChainCommand is not supported:
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_CROSS_CHAIN_COMMAND_NOT_SUPPORTED},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_CROSS_CHAIN_COMMAND_NOT_SUPPORTED)
         return
 
     crossChainCommand = cross-chain command associated with (ccm.module, ccm.crossChainCommand)
     try:
         crossChainCommand.verify(trs, ccm)
     except:
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_EXCEPTION)
         return
 
     # Create a state snapshot.
@@ -489,32 +481,17 @@ def applyRecovery(trs: Transaction, ccm: CCM) -> None:
             mdl.beforeCrossChainCommandExecution(trs, ccm)
     except:
         revert state to baseSnapshot
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_BEFORE_CCC_EXECUTION_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_BEFORE_CCC_EXECUTION_EXCEPTION)
         return
     # Create a state snapshot.
     executionSnapshot = snapshot of the current state
     try:
         # Execute the cross-chain command.
         crossChainCommand.execute(trs, ccm)
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_APPLIED, "code": CCM_PROCESSED_CODE_SUCCESS},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_APPLIED, CCM_PROCESSED_CODE_SUCCESS)
     except:
         revert state to executionSnapshot
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_FAILED_CCM},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_FAILED_CCM)
 
     try:
         # Call the afterCrossChainCommandExecution functions from other modules.
@@ -522,12 +499,7 @@ def applyRecovery(trs: Transaction, ccm: CCM) -> None:
             mdl.afterCrossChainCommandExecution(trs, ccm)
     except:
         revert state to baseSnapshot
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_AFTER_CCC_EXECUTION_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_AFTER_CCC_EXECUTION_EXCEPTION)
 ```
 
 ```python
@@ -541,12 +513,7 @@ def forwardRecovery(trs: Transaction, ccm: CCM) -> None:
         for each module mdl for which verifyCrossChainMessage exists:
             mdl.verifyCrossChainMessage(trs, ccm)
     except:
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_CCM_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_VERIFY_CCM_EXCEPTION)
         return
 
     # Create a state snapshot.
@@ -558,24 +525,12 @@ def forwardRecovery(trs: Transaction, ccm: CCM) -> None:
             mdl.beforeCrossChainMessageForwarding(trs, ccm)
     except:
         revert state to baseSnapshot
-        emitEvent(
-            module = MODULE_NAME_INTEROPERABILITY,
-            name = EVENT_NAME_CCM_PROCESSED,
-            data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_DISCARDED, "code": CCM_PROCESSED_CODE_INVALID_CCM_BEFORE_CCC_FORWARDING_EXCEPTION},
-            topics = [ccm.sendingChainID, ccm.receivingChainID]
-        )
+        emitCCMEvent(ccm, CCM_PROCESSED_RESULT_DISCARDED, CCM_PROCESSED_CODE_INVALID_CCM_BEFORE_CCC_FORWARDING_EXCEPTION)
         return
 
     addToOutbox(ccm.receivingChainID, ccm)
     # Emit CCM forwarded event.
-    # Recalculate CCM ID. This differs because of new status, sending, and receiving chains.
-    # We use the updated ID as this CCM is appended to the outbox.
-    emitEvent(
-        module = MODULE_NAME_INTEROPERABILITY,
-        name = EVENT_NAME_CCM_PROCESSED,
-        data = {"ccm": ccm, "result": CCM_PROCESSED_RESULT_FORWARDED, "code": CCM_PROCESSED_CODE_SUCCESS},
-        topics = [ccm.sendingChainID, ccm.receivingChainID]
-    )
+    emitCCMEvent(ccm, CCM_PROCESSED_RESULT_FORWARDED, CCM_PROCESSED_CODE_SUCCESS)
 ```
 
 ### Liveness Termination Command

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -239,7 +239,7 @@ def verify(trs: Transaction) -> None:
         }
         storeQueries.append(query)
     
-    # Check that every query keys are pariwise distinct, 
+    # Check that all query keys are pariwise distinct, 
     # meaning that we are not trying to recover the same entry twice.
     if len(queryKeys) != len(set(queryKeys)):
         raise Exception("Recovered store keys are not pairwise distinct.")

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -216,7 +216,7 @@ def verify(trs: Transaction) -> None:
 
         queryKeys.append(entry.storeKey)
         query = {
-            "key": storePrefix + entry.substorePrefix + entry.storeKey,
+            "key": storePrefix + entry.substorePrefix + sha256(entry.storeKey),
             "value": sha256(entry.storeValue),
             "bitmap": entry.bitmap
         }
@@ -795,7 +795,7 @@ def verify(trs: Transaction) -> None:
     if terminatedOutboxAccount(trsParams.chainID) exists:
         raise Exception("Terminated outbox account already exists.")
 
-    queryKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_CHANNEL_DATA + sha256(getMainchainID())
+    queryKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_CHANNEL_DATA + sha256(OWN_CHAIN_ID)
 
     query = {
         key: queryKey,


### PR DESCRIPTION
Closes https://github.com/LiskHQ/lips/issues/283.

- Address internal review.
- Add some extra checks to the message recovery and state recovery commands.
- Fixes `createTerminatedStateAccount` function to actually make use of the input `stateRoot`