### PR TITLE
Change type CCU to Transaction in several functions

### DIFF
--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-messages/299
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-24
+Updated: 2023-03-06
 Requires: 0053
 ```
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -243,21 +243,21 @@ def validateFormat(ccm: CCM) -> None:
 
 #### apply
 
-The `apply` function applies a cross-chain message, in the context of a cross-chain update `ccu`.
+The `apply` function applies a cross-chain message, in the context of a cross-chain update transaction `trs`.
 
 <img src="lip-0049/apply.png" width="80%">
 
 _Figure 1: A schematic of the steps executed in the `apply` function. Blue bordered boxes indicate the emission of an event. Functions called from other modules during the CCM execution (indicated as `mdl.<FUNCTION_NAME>`) are repeated for each module in the chain for which the function exists._
 
 ```python
-def apply(ccu: CCU, ccm: CCM) -> None:
+def apply(trs: Transaction, ccm: CCM) -> None:
     try:
         if not isLive(ccm.sendingChainID):  
             raise Exception(f"Sending chain {ccm.sendingChainID} is not live.")
         # Modules can verify the CCM.
         # The Token module verifies the escrowed balance in the CCM sending chain for the message fee.
         for each module mdl for which verifyCrossChainMessage exists:
-            mdl.verifyCrossChainMessage(ccu, ccm)
+            mdl.verifyCrossChainMessage(trs, ccm)
     except:    
         terminateChain(ccm.sendingChainID)
         # Notice that, since the sending chain has been terminated,
@@ -279,7 +279,7 @@ def apply(ccu: CCU, ccm: CCM) -> None:
 
     crossChainCommand = cross-chain command associated with (ccm.module, ccm.crossChainCommand)
     try:  
-        crossChainCommand.verify(ccu, ccm)
+        crossChainCommand.verify(trs, ccm)
     except:
         terminateChain(ccm.sendingChainID)
         emitEvent(
@@ -296,7 +296,7 @@ def apply(ccu: CCU, ccm: CCM) -> None:
         # Call the beforeCrossChainCommandExecution functions from other modules.
         # For example, the Token module assigns the message fee to the CCU sender.
         for each module mdl for which beforeCrossChainCommandExecution exists:
-            mdl.beforeCrossChainCommandExecution(ccu, ccm)
+            mdl.beforeCrossChainCommandExecution(trs, ccm)
     except:
         revert state to baseSnapshot
         terminateChain(ccm.sendingChainID)
@@ -315,10 +315,11 @@ def apply(ccu: CCU, ccm: CCM) -> None:
         # Then, ccu.params.sendingChainID == getMainchainID().
         # This is not necessarily a violation of the protocol, since the message
         # could have been sent before the direct channel was opened.
-        if chainAccount(ccm.sendingChainID) exists and ccu.params.sendingChainID != ccm.sendingChainID:
+        ccuParams = decode(crossChainUpdateTransactionParams, trs.params)
+        if chainAccount(ccm.sendingChainID) exists and ccuParams.sendingChainID != ccm.sendingChainID:
             raise Exception("Cannot receive forwarded messages for a direct channel.")
         # Execute the cross-chain command.
-        crossChainCommand.execute(ccu, ccm)
+        crossChainCommand.execute(trs, ccm)
         emitEvent(
             module = MODULE_NAME_INTEROPERABILITY,
             name = EVENT_NAME_CCM_PROCESSED,
@@ -332,7 +333,7 @@ def apply(ccu: CCU, ccm: CCM) -> None:
     try:
         # Call the afterCrossChainCommandExecution functions from other modules.
         for each module mdl for which afterCrossChainCommandExecution exists:
-            mdl.afterCrossChainCommandExecution(ccu, ccm)     
+            mdl.afterCrossChainCommandExecution(trs, ccm)     
     except:
         revert state to baseSnapshot
         terminateChain(ccm.sendingChainID)
@@ -355,14 +356,14 @@ The `forward` function forwards a CCM to the specified receiving chain. This fun
 _Figure 2: A schematic of the steps executed in the `forward` function. Blue bordered boxes indicate the emission of an event. Functions called from other modules during the CCM execution (indicated as `mdl.<FUNCTION_NAME>`) are repeated for each module in the chain for which the function exists._
 
 ```python
-def forward(ccu: CCU, ccm: CCM) -> None:
+def forward(trs: Transaction, ccm: CCM) -> None:
     try:
         if not isLive(ccm.sendingChainID):  
             raise Exception(f"Sending chain {ccm.sendingChainID} is not live.")
         # Modules can verify the CCM.
         # The Token module verifies the escrowed balance in the CCM sending chain for the message fee.
         for each module mdl for which verifyCrossChainMessage exists:
-            mdl.verifyCrossChainMessage(ccu, ccm)
+            mdl.verifyCrossChainMessage(trs, ccm)
     except:    
         terminateChain(ccm.sendingChainID)
         # Notice that, since the sending chain has been terminated,
@@ -420,7 +421,7 @@ def forward(ccu: CCU, ccm: CCM) -> None:
         # Call the beforeCrossChainMessageForwarding functions from other modules.
         # For example, the Token module transfers the fee from escrow to escrow.
         for each module mdl for which beforeCrossChainMessageForwarding exists:
-            mdl.beforeCrossChainMessageForwarding(ccu, ccm)
+            mdl.beforeCrossChainMessageForwarding(trs, ccm)
     except:
         revert state to baseSnapshot
         terminateChain(ccm.sendingChainID)

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -579,11 +579,11 @@ def execute(trs: Transaction) -> None:
         # If the receiving chain is the mainchain, apply the CCM.
         # This function never raises an error.
         if ccm.receivingChainID == getMainchainID():
-            apply(ccu, ccm)
+            apply(trs, ccm)
         # If the receiving chain is not the mainchain, forward the CCM.
         # This function never raises an error.
         elif ccm.receivingChainID != getMainchainID():
-            forward(ccu, ccm)
+            forward(trs, ccm)
         # We append at the very end. This implies that if the message leads to a chain termination,
         # it is still possible to recover it (because the channel terminated message
         # would refer to an inbox where the message has not been appended yet).
@@ -734,7 +734,7 @@ def execute(trs: Transaction) -> None:
         # Set ccmID (instead of the transaction ID) as default topic to all events emitted in apply.
         defaultEventsTopic = ccmID
         ccm = decode(crossChainMessageSchema, ccmBytes)
-        apply(ccu, ccm)
+        apply(trs, ccm)
         # We append at the very end. This implies that if the message leads to a chain termination,
         # it is still possible to recover it (because the channel terminated message
         # would refer to an inbox where the message has not been appended yet).

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-24
+Updated: 2023-03-06
 Requires: 0045, 0049, 0058, 0061
 ```
 


### PR DESCRIPTION
We do the following:

- Fix several function calls in LIP 0049, where an argument of type `Transaction` is expected, but an argument of type `CCU` is provided. This includes the functions 
  - `verifyCrossChainMessage`
  - `crossChainCommand.verify`
  - `crossChainCommand.execute`
  - `beforeCrossChainCommandExecution`
  - `afterCrossChainCommandExecution`.
- Change the type of the first argument of the functions `apply` and `forward` from LIP 0049 from `CCU` to `Transaction`. This implies that we still have to decode the `params` property of the transaction (which is a CCU) in an additional step in the `apply` function. But this is better than encoding the `params` property of an object of type `CCU` in `apply` and `forward` in order to get an object of type `Transaction` which is required for the function listed above.

This fixes #284.