### PR TITLE
Fix incorrect checking of bits in LIP38 and LIP62

### DIFF
--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bls-signatures/282
 Status: Draft
 Type: Informational
 Created: 2021-04-13
-Updated: 2023-02-22
+Updated: 2023-03-06
 ```
 
 ## Abstract

--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -104,7 +104,7 @@ def verifyAggSig(keysList: list[bytes], aggregationBits: bytes, signature: bytes
     keys = []
     for i in range(8 * len(aggregationBits)):
         # if i-th bit of aggregationBits == 1
-        if aggregationBits[i // 8] & (1 << (i % 8)) == 1:
+        if (aggregationBits[i // 8] >> (i % 8)) & 1:
             keys.append(keysList[i])
     return FastAggregateVerify(keys, taggedMessage, signature) == VALID
 ```
@@ -119,7 +119,7 @@ def verifyWeightedAggSig(keysList: list[bytes], aggregationBits: bytes, signatur
     weightSum = 0
     for i in range(8 * len(aggregationBits)):
         # if i-th bit of aggregationBits == 1
-        if aggregationBits[i // 8] & (1 << (i % 8)) == 1:
+        if (aggregationBits[i // 8] >> (i % 8)) & 1:
             keys.append(keysList[i])
             weightSum += weights[i]
     if weightSum < threshold:

--- a/proposals/lip-0062.md
+++ b/proposals/lip-0062.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/use-pre-hashing-for-signatures/329
 Status: Draft
 Type: Standards Track
 Created: 2022-02-11
-Updated: 2022-09-01
+Updated: 2023-03-06
 Requires: 0037
 ```
 

--- a/proposals/lip-0062.md
+++ b/proposals/lip-0062.md
@@ -81,7 +81,7 @@ def verifyAggSig(keysList: list[bytes], aggregationBits: bytes, signature: bytes
     keys = []
     for i in range(8 * len(aggregationBits)):
         # if i-th bit of aggregationBits == 1
-        if aggregationBits[i // 8] & (1 << (i % 8)) == 1:
+        if (aggregationBits[i // 8] >> (i % 8)) & 1:
             keys.append(keysList[i])
     return FastAggregateVerify(keys, hashedMessage, signature) == VALID
 ```
@@ -94,7 +94,7 @@ def verifyWeightedAggSig(keysList: list[bytes], aggregationBits: bytes, signatur
     weightSum = 0
     for i in range(8 * len(aggregationBits)):
         # if i-th bit of aggregationBits == 1
-        if aggregationBits[i // 8] & (1 << (i % 8)) == 1:
+        if (aggregationBits[i // 8] >> (i % 8)) & 1:
             keys.append(keysList[i])
             weightSum += weights[i]
     if weightSum < threshold:


### PR DESCRIPTION
Fixing incorrect checking of bits in `VerifyAggSig` and `VerifyWeightedAggSig` functions. 
Replaced-
`if aggregationBits[i // 8] & (1 << (i % 8)) == 1`
with:
`if (aggregationBits[i // 8] >> (i % 8)) & 1 `

closes #276