### PR TITLE
Add check for address and BLS key uniquess of validators in LIP 0058

### DIFF
--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -490,8 +490,6 @@ def setBFTParameters(precommitThreshold, certificateThreshold, validatorList):
         raise Exception("Given list of validators is larger than the maximum allowed value.")
     if len(validatorList) != len(set([validator.address for validator in validatorList])):
         raise Exception("Duplicate validator address in validator list.")
-    if len(validatorList) != len(set([validator.generatorKey for validator in validatorList])):
-        raise Exception("Duplicate generator key in validator list.")
     if len(validatorList) != len(set([validator.blsKey for validator in validatorList])):
         raise Exception("Duplicate BLS key in validator list.")
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2023-02-13
+Updated: 2023-03-06
 Requires: 0055, 0056, 0061
 ```
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -491,10 +491,10 @@ def setBFTParameters(precommitThreshold, certificateThreshold, validatorList):
     if len(validatorList) != len(set([validator.address for validator in validatorList])):
         raise Exception("Duplicate validator address in validator list.")
     if len(validatorList) != len(set([validator.generatorKey for validator in validatorList])):
-        raise Exception("Duplicate generator key  in validator list.")
+        raise Exception("Duplicate generator key in validator list.")
     if len(validatorList) != len(set([validator.blsKey for validator in validatorList])):
         raise Exception("Duplicate BLS key in validator list.")
-        
+
     aggregateBFTWeight = 0
     for validator in validatorList:
         aggregateBFTWeight += validator.bftWeight

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -488,6 +488,13 @@ The function is called in the after application processing stage of the genesis 
 def setBFTParameters(precommitThreshold, certificateThreshold, validatorList):
     if length(validatorList) > LSK_BFT_BATCH_SIZE:
         raise Exception("Given list of validators is larger than the maximum allowed value.")
+    if len(validatorList) != len(set([validator.address for validator in validatorList])):
+        raise Exception("Duplicate validator address in validator list.")
+    if len(validatorList) != len(set([validator.generatorKey for validator in validatorList])):
+        raise Exception("Duplicate generator key  in validator list.")
+    if len(validatorList) != len(set([validator.blsKey for validator in validatorList])):
+        raise Exception("Duplicate BLS key in validator list.")
+        
     aggregateBFTWeight = 0
     for validator in validatorList:
         aggregateBFTWeight += validator.bftWeight


### PR DESCRIPTION
This PR add the following checks to the function `setBFTParameters` in LIP 0058:

- Check that addresses of provided validators are unique.
- Check that BLS keys of provided validators are unique.

Resolves https://github.com/LiskHQ/lips/issues/279