### PR TITLE
Fix inclusion proof for outbox root in LIP0053

### DIFF
--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -284,7 +284,7 @@ def verifyPartnerChainOutboxRoot(ccu: CCU) -> None:
             siblingHashes: outboxRootWitness.siblingHashes,
             queries: [{
                 key: outboxKey,
-                value: encode(outboxRootSchema, newInboxRoot),
+                value: sha256(encode(outboxRootSchema, newInboxRoot)),
                 bitmap: outboxRootWitness.bitmap
             }],
         }

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-06
+Updated: 2023-03-09
 Requires: 0045, 0049, 0058, 0061
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -279,7 +279,7 @@ def verifyPartnerChainOutboxRoot(ccu: CCU) -> None:
 
     # Verification for non-empty certificates.
     if len(ccu.params.certificate) > 0:
-        outboxKey = MODULE_NAME_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(partnerchainID)
+        outboxKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(OWN_CHAIN_ID)
         proof = {
             siblingHashes: outboxRootWitness.siblingHashes,
             queries: [{


### PR DESCRIPTION
This PR changes the following in the `verifyPartnerChainOutboxRoot()` function:

1. `outboxKey = MODULE_NAME_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(partnerchainID)` with `outboxKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(OWN_CHAIN_ID)`

2. `value: encode(outboxRootSchema, newInboxRoot)`  with `value: sha256(encode(outboxRootSchema, newInboxRoot))`

Resolves #291 