### PR TITLE
Fix repeated properties in signed/unsigned certificate and block header schemas

### DIFF
--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/update-block-schema-and-block-proces
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-23
+Updated: 2023-02-20
 Requires: 0040, 0061, 0065
 ```
 

--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -262,114 +262,6 @@ The block transactions is an array of transaction objects. The JSON schema and v
 
 ### Block Header
 
-#### Block Header JSON Schema
-
-Block headers are serialized and deserialized accordingly to the following JSON schema.
-
-```java
-blockHeaderSchema = {
-  "type": "object",
-  "required": [
-    "version",
-    "timestamp",
-    "height",
-    "previousBlockID",
-    "generatorAddress",
-    "transactionRoot",
-    "assetRoot",
-    "eventRoot",
-    "stateRoot",
-    "maxHeightPrevoted",
-    "maxHeightGenerated",
-    "impliesMaxPrevotes",
-    "validatorsHash",
-    "aggregateCommit",
-    "signature"
-  ],
-  "properties": {
-    "version": {
-      "dataType": "uint32",
-      "fieldNumber": 1
-    },
-    "timestamp": {
-      "dataType": "uint32",
-      "fieldNumber": 2
-    },
-    "height": {
-      "dataType": "uint32",
-      "fieldNumber": 3
-    },
-    "previousBlockID": {
-      "dataType": "bytes",
-      "fieldNumber": 4
-    },
-    "generatorAddress": {
-      "dataType": "bytes",
-      "fieldNumber": 5
-    },
-    "transactionRoot": {
-      "dataType": "bytes",
-      "fieldNumber": 6
-    },
-    "assetRoot": {
-      "dataType": "bytes",
-      "fieldNumber": 7
-    },
-    "eventRoot": {
-      "dataType": "bytes",
-      "fieldNumber": 8
-    },
-    "stateRoot": {
-      "dataType": "bytes",
-      "fieldNumber": 9
-    },
-    "maxHeightPrevoted": {
-      "dataType": "uint32",
-      "fieldNumber": 10
-    },
-    "maxHeightGenerated": {
-      "dataType": "uint32",
-      "fieldNumber": 11
-    },
-    "impliesMaxPrevotes": {
-      "dataType": "boolean",
-      "fieldNumber": 12
-    },
-    "validatorsHash": {
-      "dataType": "bytes",
-      "fieldNumber": 13
-    },
-    "aggregateCommit": {
-      "type": "object",
-      "fieldNumber": 14,
-      "required": [
-        "height",
-        "aggregationBits",
-        "certificateSignature"
-      ],
-      "properties": {
-        "height": {
-          "dataType": "uint32",
-          "fieldNumber": 1
-        },
-        "aggregationBits": {
-          "dataType": "bytes",
-          "fieldNumber": 2
-        },
-        "certificateSignature": {
-          "dataType": "bytes",
-          "fieldNumber": 3
-        }
-      }
-    },
-    "signature": {
-      "dataType": "bytes",
-      "fieldNumber": 15
-    }
-  }
-}
-```
-
 #### Unsigned Block Header JSON Schema
 
 Unsigned block headers are serialized and deserialized accordingly to the following JSON schema (notice the missing `signature` property).
@@ -472,6 +364,26 @@ unsignedBlockHeaderSchema = {
   }
 }
 ```
+
+#### Block Header JSON Schema
+
+Block headers are serialized and deserialized accordingly to the following JSON schema.
+
+```java
+blockHeaderSchema = {
+  "type": "object",
+  "required": [...unsignedBlockHeaderSchema.required,"signature"],
+  "properties": {
+    ...unsignedBlockHeaderSchema.properties,
+    "signature": {
+      "dataType": "bytes",
+      "fieldNumber": 15
+    }
+  }
+}
+```
+
+Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding schema should be inserted in place, and it is just used for notational convenience.
 
 #### Block Signature Calculation
 

--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -383,7 +383,7 @@ blockHeaderSchema = {
 }
 ```
 
-Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding schema should be inserted in place, and it is just used for notational convenience.
+Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding part of the schema should be inserted in place, and it is just used for notational convenience.
 
 #### Block Signature Calculation
 

--- a/proposals/lip-0055.md
+++ b/proposals/lip-0055.md
@@ -8,7 +8,7 @@ Discussions-To: https://research.lisk.com/t/update-block-schema-and-block-proces
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-20
+Updated: 2023-03-20
 Requires: 0040, 0061, 0065
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -195,39 +195,9 @@ unsignedCertificateSchema = {
 ```java
 certificateSchema = {
     "type": "object",
-    "required": [
-        "blockID",
-        "height",
-        "timestamp",
-        "stateRoot",
-        "validatorsHash",
-        "aggregationBits",
-        "signature"
-    ],
+    "required": [...unsignedCertificateSchema.required, "aggregationBits", "signature"],
     "properties": {
-        "blockID": {
-            "dataType": "bytes",
-            "length": HASH_LENGTH,
-            "fieldNumber": 1
-        },
-        "height": {
-            "dataType": "uint32",
-            "fieldNumber": 2
-        },
-        "timestamp": {
-            "dataType": "uint32",
-            "fieldNumber": 3
-        },
-        "stateRoot": {
-            "dataType": "bytes",
-            "length": HASH_LENGTH,
-            "fieldNumber": 4
-        },
-        "validatorsHash": {
-            "dataType": "bytes",
-            "length": HASH_LENGTH,
-            "fieldNumber": 5
-        },
+        ...unsignedCertificateSchema.properties,
         "aggregationBits": {
             "dataType": "bytes",
             "fieldNumber": 6
@@ -240,6 +210,8 @@ certificateSchema = {
     }
 }
 ```
+
+Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding schema should be inserted in place, and it is just used for notational convenience.
 
 #### Creation
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-certificate-generation-mec
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-10
+Updated: 2023-03-20
 Requires: 0044, 0055, 0058
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -211,7 +211,7 @@ certificateSchema = {
 }
 ```
 
-Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding schema should be inserted in place, and it is just used for notational convenience.
+Here, the `...` notation, borrowed from [JavaScript ES6 data destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), indicates that the corresponding part of the schema should be inserted in place, and it is just used for notational convenience.
 
 #### Creation
 


### PR DESCRIPTION
In this PR following changes are done in LIP 0055 and LIP 0061:

1. In the `certificateSchema`: repeated "required" array field is replaced with a new notation `...unsignedCertificateSchema.required` and the repeated "properties" field is replaced with a new notation `...unsignedCertificateSchema.properties`

2. In the `unsignedBlockHeaderSchema`: repeated "required" array field is replaced with a new notation `...unsignedBlockHeaderSchema.required` and the repeated "properties" field is replaced with a new notation `...unsignedBlockHeaderSchema.properties`

Also, for readability purpose, notation is described at the end of the schema description.

Resolves #287 

