### PR TITLE
Change chain status from string to value - LIP0049

### DIFF
--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-messages/299
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-06
+Updated: 2023-03-20
 Requires: 0053
 ```
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -558,7 +558,7 @@ def verify(trs: Transaction, ccm: CCM) -> None:
         raise Exception("Registration message must be sent from a direct channel.")
 
     if chainAccount(ccm.sendingChainID).status != CHAIN_STATUS_REGISTERED:
-        raise Exception("Registration message must be sent from a chain with status 0.")
+        raise Exception("Registration message must be sent from a chain with status "+str(CHAIN_STATUS_REGISTERED)+".")
 
     if channel(ccm.sendingChainID).inbox.size != 0:
         raise Exception("Registration message must be the first message in the inbox.")

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -558,7 +558,7 @@ def verify(trs: Transaction, ccm: CCM) -> None:
         raise Exception("Registration message must be sent from a direct channel.")
 
     if chainAccount(ccm.sendingChainID).status != CHAIN_STATUS_REGISTERED:
-        raise Exception("Registration message must be sent from a chain with status 'registered'.")
+        raise Exception("Registration message must be sent from a chain with status 0.")
 
     if channel(ccm.sendingChainID).inbox.size != 0:
         raise Exception("Registration message must be the first message in the inbox.")

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-messages/299
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-20
+Updated: 2023-03-21
 Requires: 0053
 ```
 


### PR DESCRIPTION
Resolves Issue [#301](https://github.com/LiskHQ/lips/issues/301):

In [registration CCM verification](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#verification-1
), in the error message, `'registered'` should be replaced with it's integral value 0.

```
if chainAccount(ccm.sendingChainID).status != CHAIN_STATUS_REGISTERED:
        raise Exception("Registration message must be sent from a chain with status 'registered'.")
```

Rationale: 

As per [Notations and Constants table](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#notation-and-constants), `CHAIN_STATUS_REGISTERED` has integral value 0.

If we pass/provide `'registered'` as hard coded string value in some test fixture, above `if` condition will fail and it will lead to confusion. User will think that we've passed correct value as per error message, but in reality comparison was made with integral value of `CHAIN_STATUS_REGISTERED`.