### PR TITLE
Change sapphire phase terminology in LIP67

### DIFF
--- a/proposals/lip-0067.md
+++ b/proposals/lip-0067.md
@@ -46,9 +46,9 @@ We store secret recovery phrases and private keys in a JSON file following the f
 ```java
 keystoreSchema = {
   "type": "object",
-  "required": ["encryptedPassphrase", "metadata", "ID"],
+  "required": ["crypto", "metadata", "ID"],
   "properties": {
-    "encryptedPassphrase": {
+    "crypto": {
       "type": "object",
       "properties": {
         "version": {"type": "string"},
@@ -81,7 +81,7 @@ keystoreSchema = {
 
 In the following sections, we describe the uses of the properties of `keystoreSchema`.
 
-#### encryptedPassphrase
+#### crypto
 
 ##### version
 
@@ -209,7 +209,7 @@ Secret recovery phrase: `target cancel solution recipe vague faint bomb convince
 
 ```json
 {
-  "encryptedPassphrase": {
+  "crypto": {
     "version": "1",
     "ciphertext": "866c6f1cab3ef67514bdc54cf0143b8b824ebe7c045efb97707c158c81d313cd1a6399b7aa3002248984d39ea2604b0263fe7bdbd8cb04286a9cbd2d353fc79908daab9af04b2528bf4f06a82d79483c",
     "mac": "a476979ca68fe90f3c96f8a5f3f0a9fe33aef8b091d1169861e44a11a680aae9",
@@ -242,7 +242,7 @@ Key pair derived from the secret recovery phrase above, and the path `m/44'/134'
 
 ```json
 {
-  "encryptedPassphrase": {
+  "crypto": {
     "version": "1",
     "ciphertext": "086a59889e0e311422eeb15bb6c753aeead210c4494eb37cf7b8f01b0ed372d64e6a08cc77e0bc8170f79f199e2ce7b4c47fe5353e97e67d53c846c029c6cd08",
     "mac": "9497dd4a84f05c941b22df1cce0cb7558fb3bdd66481c462d63e003dab837c7c",

--- a/proposals/lip-0067.md
+++ b/proposals/lip-0067.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-a-generic-keystore/360
 Status: Draft
 Type: Informational
 Created: 2022-06-28
-Updated: 2022-08-03
+Updated: 2023-03-21
 ```
 
 ## Abstract


### PR DESCRIPTION
This PR changes the terminology `encryptedPassphrase` to `crypto`.

Resolves #303 