### PR TITLE
Define `blsKeyAndBftWeightSchema` and inject it where used

### DIFF
--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -149,10 +149,10 @@ sidechainRegParams = {
         },
         "sidechainValidators": {
             "type": "array",
-            "items": ...blsKeyAndBftWeightSchema,
             "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
-            "fieldNumber": 3
+            "fieldNumber": 3,
+            "items": { ...blsKeyAndBftWeightSchema } // Defined in LIP 0058
         },
         "sidechainCertificateThreshold": {
             "dataType": "uint64",
@@ -161,7 +161,6 @@ sidechainRegParams = {
     }
 }
 ```
-where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -365,10 +364,10 @@ mainchainRegParams = {
         },
         "mainchainValidators": {
             "type": "array",
-            "items": ...blsKeyAndBftWeightSchema,
             "minItems": 1,
             "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
-            "fieldNumber": 3
+            "fieldNumber": 3,
+            "items": { ...blsKeyAndBftWeightSchema } // Defined in LIP 0058
         },
         "mainchainCertificateThreshold": {
             "dataType": "uint64",
@@ -386,7 +385,6 @@ mainchainRegParams = {
     }
 }
 ```
-where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -435,7 +433,6 @@ def verify(trs: Transaction) -> None:
 ```
 
 ##### Execution
-We use `blsKeyAndBftWeightSchema` defined in [LIP 0058][lip-0058].
 
 ```python
 def execute(trs: Transaction) -> None:
@@ -463,15 +460,15 @@ def execute(trs: Transaction) -> None:
             },
             "mainchainValidators": {
                 "type": "array",
-                "items": ...blsKeyAndBftWeightSchema,
                 "minItems": 1,
                 "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
-                "fieldNumber": 3
+                "fieldNumber": 3,
+                "items": { ...blsKeyAndBftWeightSchema } // Defined in LIP 0058
             },
             "mainchainCertificateThreshold": {
                 "dataType": "uint64",
                 "fieldNumber": 4
-            },
+            }
         }
     }
 
@@ -635,5 +632,4 @@ TBA
 [lip-0053#outbox-root-witness]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#outboxrootwitness
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
-[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -148,7 +148,9 @@ sidechainRegParams = {
             "fieldNumber": 2
         },
         "sidechainValidators": {
-            ...validatorsBlsKeysAndBftWeightsSchema,
+            "type": "array",
+            "items": ...blsKeyAndBftWeightSchema,
+            "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
             "fieldNumber": 3
         },
@@ -159,7 +161,7 @@ sidechainRegParams = {
     }
 }
 ```
-where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
+where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -362,7 +364,9 @@ mainchainRegParams = {
             "fieldNumber": 2
         },
         "mainchainValidators": {
-            ...validatorsBlsKeysAndBftWeightsSchema,
+            "type": "array",
+            "items": ...blsKeyAndBftWeightSchema,
+            "minItems": 1,
             "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
             "fieldNumber": 3
         },
@@ -382,7 +386,7 @@ mainchainRegParams = {
     }
 }
 ```
-where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
+where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -431,7 +435,7 @@ def verify(trs: Transaction) -> None:
 ```
 
 ##### Execution
-We use `validatorsBlsKeysAndBftWeightsSchema` defined in [LIP 0058][lip-0058].
+We use `blsKeyAndBftWeightSchema` defined in [LIP 0058][lip-0058].
 
 ```python
 def execute(trs: Transaction) -> None:
@@ -458,7 +462,9 @@ def execute(trs: Transaction) -> None:
                 "fieldNumber": 2
             },
             "mainchainValidators": {
-                ...validatorsBlsKeysAndBftWeightsSchema,
+                "type": "array",
+                "items": ...blsKeyAndBftWeightSchema,
+                "minItems": 1,
                 "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
                 "fieldNumber": 3
             },

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -152,21 +152,7 @@ sidechainRegParams = {
             "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
             "fieldNumber": 3,
-            "items": {
-                "type": "object",
-                "required": ["blsKey", "bftWeight"],
-                "properties": {
-                    "blsKey": {
-                        "dataType": "bytes",
-                        "length": BLS_PUBLIC_KEY_LENGTH,
-                        "fieldNumber": 1
-                    },
-                    "bftWeight": {
-                        "dataType": "uint64",
-                        "fieldNumber": 2
-                    }
-                }
-            }
+            "items": validatorBlsKeyAndBftWeightSchema
         },
         "sidechainCertificateThreshold": {
             "dataType": "uint64",
@@ -175,6 +161,7 @@ sidechainRegParams = {
     }
 }
 ```
+where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -381,21 +368,7 @@ mainchainRegParams = {
             "minItems": 1,
             "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
             "fieldNumber": 3,
-            "items": {
-                "type": "object",
-                "required": ["blsKey", "bftWeight"],
-                "properties": {
-                    "blsKey": {
-                        "dataType": "bytes",
-                        "length": BLS_PUBLIC_KEY_LENGTH,
-                        "fieldNumber": 1
-                    },
-                    "bftWeight": {
-                        "dataType": "uint64",
-                        "fieldNumber": 2
-                    }
-                }
-            }
+            "items": validatorBlsKeyAndBftWeightSchema
         },
         "mainchainCertificateThreshold": {
             "dataType": "uint64",
@@ -413,6 +386,7 @@ mainchainRegParams = {
     }
 }
 ```
+where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -461,6 +435,7 @@ def verify(trs: Transaction) -> None:
 ```
 
 ##### Execution
+We use `validatorBlsKeyAndBftWeightSchema` defined in [LIP 0058][lip-0058].
 
 ```python
 def execute(trs: Transaction) -> None:
@@ -491,21 +466,7 @@ def execute(trs: Transaction) -> None:
                 "minItems": 1,
                 "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
                 "fieldNumber": 3,
-                "items": {
-                    "type": "object",
-                    "required": ["blsKey", "bftWeight"],
-                    "properties": {
-                        "blsKey": {
-                            "dataType": "bytes",
-                            "length": BLS_PUBLIC_KEY_LENGTH,
-                            "fieldNumber": 1
-                        },
-                        "bftWeight": {
-                            "dataType": "uint64",
-                            "fieldNumber": 2
-                        }
-                    }
-                }
+                "items": validatorBlsKeyAndBftWeightSchema
             },
             "mainchainCertificateThreshold": {
                 "dataType": "uint64",
@@ -674,4 +635,5 @@ TBA
 [lip-0053#outbox-root-witness]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#outboxrootwitness
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
+[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -152,7 +152,21 @@ sidechainRegParams = {
             "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
             "fieldNumber": 3,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "items": {
+                "type": "object",
+                "required": ["blsKey", "bftWeight"],
+                "properties": {
+                    "blsKey": {
+                        "dataType": "bytes",
+                        "length": BLS_PUBLIC_KEY_LENGTH,
+                        "fieldNumber": 1
+                    },
+                    "bftWeight": {
+                        "dataType": "uint64",
+                        "fieldNumber": 2
+                    }
+                }
+            }
         },
         "sidechainCertificateThreshold": {
             "dataType": "uint64",
@@ -161,7 +175,6 @@ sidechainRegParams = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -368,7 +381,21 @@ mainchainRegParams = {
             "minItems": 1,
             "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
             "fieldNumber": 3,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "items": {
+                "type": "object",
+                "required": ["blsKey", "bftWeight"],
+                "properties": {
+                    "blsKey": {
+                        "dataType": "bytes",
+                        "length": BLS_PUBLIC_KEY_LENGTH,
+                        "fieldNumber": 1
+                    },
+                    "bftWeight": {
+                        "dataType": "uint64",
+                        "fieldNumber": 2
+                    }
+                }
+            }
         },
         "mainchainCertificateThreshold": {
             "dataType": "uint64",
@@ -386,7 +413,6 @@ mainchainRegParams = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -435,7 +461,6 @@ def verify(trs: Transaction) -> None:
 ```
 
 ##### Execution
-We use `validatorBlsKeyAndBftWeightSchema` defined in [LIP 0058][lip-0058].
 
 ```python
 def execute(trs: Transaction) -> None:
@@ -466,7 +491,21 @@ def execute(trs: Transaction) -> None:
                 "minItems": 1,
                 "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
                 "fieldNumber": 3,
-                "items": validatorBlsKeyAndBftWeightSchema
+                "items": {
+                    "type": "object",
+                    "required": ["blsKey", "bftWeight"],
+                    "properties": {
+                        "blsKey": {
+                            "dataType": "bytes",
+                            "length": BLS_PUBLIC_KEY_LENGTH,
+                            "fieldNumber": 1
+                        },
+                        "bftWeight": {
+                            "dataType": "uint64",
+                            "fieldNumber": 2
+                        }
+                    }
+                }
             },
             "mainchainCertificateThreshold": {
                 "dataType": "uint64",
@@ -635,5 +674,4 @@ TBA
 [lip-0053#outbox-root-witness]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#outboxrootwitness
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0056]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md
-[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0058#computevalidatorshash]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#computevalidatorshash

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -148,11 +148,9 @@ sidechainRegParams = {
             "fieldNumber": 2
         },
         "sidechainValidators": {
-            "type": "array",
-            "minItems": 1,
+            ...validatorsBlsKeysAndBftWeightsSchema,
             "maxItems": MAX_NUM_VALIDATORS,
-            "fieldNumber": 3,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "fieldNumber": 3
         },
         "sidechainCertificateThreshold": {
             "dataType": "uint64",
@@ -161,7 +159,7 @@ sidechainRegParams = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
+where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -364,11 +362,9 @@ mainchainRegParams = {
             "fieldNumber": 2
         },
         "mainchainValidators": {
-            "type": "array",
-            "minItems": 1,
+            ...validatorsBlsKeysAndBftWeightsSchema,
             "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
-            "fieldNumber": 3,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "fieldNumber": 3
         },
         "mainchainCertificateThreshold": {
             "dataType": "uint64",
@@ -386,7 +382,7 @@ mainchainRegParams = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
+where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Verification
 
@@ -435,7 +431,7 @@ def verify(trs: Transaction) -> None:
 ```
 
 ##### Execution
-We use `validatorBlsKeyAndBftWeightSchema` defined in [LIP 0058][lip-0058].
+We use `validatorsBlsKeysAndBftWeightsSchema` defined in [LIP 0058][lip-0058].
 
 ```python
 def execute(trs: Transaction) -> None:
@@ -462,11 +458,9 @@ def execute(trs: Transaction) -> None:
                 "fieldNumber": 2
             },
             "mainchainValidators": {
-                "type": "array",
-                "minItems": 1,
+                ...validatorsBlsKeysAndBftWeightsSchema,
                 "maxItems": NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
-                "fieldNumber": 3,
-                "items": validatorBlsKeyAndBftWeightSchema
+                "fieldNumber": 3
             },
             "mainchainCertificateThreshold": {
                 "dataType": "uint64",

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -499,21 +499,7 @@ chainValidatorsSchema = {
         "activeValidators": {
             "type": "array",
             "fieldNumber": 1,
-            "items": {
-                "type": "object",
-                "required": ["blsKey", "bftWeight"],
-                "properties": {
-                    "blsKey": {
-                        "dataType": "bytes",
-                        "length": BLS_PUBLIC_KEY_LENGTH,
-                        "fieldNumber": 1
-                    },
-                    "bftWeight": {
-                        "dataType": "uint64",
-                        "fieldNumber": 2
-                    }
-                }
-            }
+            "items": validatorBlsKeyAndBftWeightSchema
         },
         "certificateThreshold": {
             "dataType": "uint64",
@@ -522,6 +508,7 @@ chainValidatorsSchema = {
     }
 }
 ```
+where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Properties
 
@@ -1629,4 +1616,5 @@ This proposal, together with [LIP 0043][lip-0043], [LIP 0049][lip-0049], [LIP 00
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0055#block-processing-stages]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-processing-stages
+[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0061#certificate-schema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#schema

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -498,10 +498,10 @@ chainValidatorsSchema = {
     "properties": {
         "activeValidators": {
             "type": "array",
-            "items": ...blsKeyAndBftWeightSchema,
             "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
-            "fieldNumber": 1
+            "fieldNumber": 1,
+            "items": { ...blsKeyAndBftWeightSchema } // Defined in LIP 0058
         },
         "certificateThreshold": {
             "dataType": "uint64",
@@ -510,7 +510,6 @@ chainValidatorsSchema = {
     }
 }
 ```
-where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Properties
 
@@ -1618,5 +1617,4 @@ This proposal, together with [LIP 0043][lip-0043], [LIP 0049][lip-0049], [LIP 00
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0055#block-processing-stages]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-processing-stages
-[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0061#certificate-schema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#schema

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -476,7 +476,7 @@ channelDataSchema = {
   * `size`: The current size of the tree, i.e. the number of cross-chain messages sent to the partner chain. The default value of this property is 0.
 * `partnerChainOutboxRoot`: The value of this property is set to the outbox root computed from the last CCU from the partner chain containing some cross-chain messages. It is used to validate the cross-chain messages contained in a future CCU when the CCU does not certify a new outbox root. The default value of this property is the constant `EMPTY_HASH`.
 * `messageFeeTokenID`: This property is the token ID of the token used to pay for the cross-chain message fees. The value used in channels between mainchain and sidechains is `messageFeeTokenID = Token.getTokenIDLSK()`, corresponding to the LSK token.
-* `minReturnFeePerByte`: This property is the minimum fee per byte to automatically send back a CCM from the partner chain in case of exeuction errors (see the [`bounce`](#bounce) function). In particular, the CCM fee must be larger or equal than the product of its size in bytes and `minReturnFeePerByte`. The value used in channels between mainchain and sidechains is `minReturnFeePerByte = MIN_RETURN_FEE_PER_BYTE_LSK`.
+* `minReturnFeePerByte`: This property is the minimum fee per byte to automatically send back a CCM from the partner chain in case of execution errors (see the [`bounce`](#bounce) function). In particular, the CCM fee must be larger or equal than the product of its size in bytes and `minReturnFeePerByte`. The value used in channels between mainchain and sidechains is `minReturnFeePerByte = MIN_RETURN_FEE_PER_BYTE_LSK`.
 
 #### Chain Validators Substore
 
@@ -497,7 +497,9 @@ chainValidatorsSchema = {
     "required": ["activeValidators", "certificateThreshold"],
     "properties": {
         "activeValidators": {
-            ...validatorsBlsKeysAndBftWeightsSchema,
+            "type": "array",
+            "items": ...blsKeyAndBftWeightSchema,
+            "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
             "fieldNumber": 1
         },
@@ -508,7 +510,7 @@ chainValidatorsSchema = {
     }
 }
 ```
-where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
+where `blsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Properties
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -499,7 +499,21 @@ chainValidatorsSchema = {
         "activeValidators": {
             "type": "array",
             "fieldNumber": 1,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "items": {
+                "type": "object",
+                "required": ["blsKey", "bftWeight"],
+                "properties": {
+                    "blsKey": {
+                        "dataType": "bytes",
+                        "length": BLS_PUBLIC_KEY_LENGTH,
+                        "fieldNumber": 1
+                    },
+                    "bftWeight": {
+                        "dataType": "uint64",
+                        "fieldNumber": 2
+                    }
+                }
+            }
         },
         "certificateThreshold": {
             "dataType": "uint64",
@@ -508,7 +522,6 @@ chainValidatorsSchema = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Properties
 
@@ -1616,5 +1629,4 @@ This proposal, together with [LIP 0043][lip-0043], [LIP 0049][lip-0049], [LIP 00
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0054]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md
 [lip-0055#block-processing-stages]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-processing-stages
-[lip-0058]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0058.md#execution-1
 [lip-0061#certificate-schema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#schema

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -497,9 +497,9 @@ chainValidatorsSchema = {
     "required": ["activeValidators", "certificateThreshold"],
     "properties": {
         "activeValidators": {
-            "type": "array",
-            "fieldNumber": 1,
-            "items": validatorBlsKeyAndBftWeightSchema
+            ...validatorsBlsKeysAndBftWeightsSchema,
+            "maxItems": MAX_NUM_VALIDATORS,
+            "fieldNumber": 1
         },
         "certificateThreshold": {
             "dataType": "uint64",
@@ -508,7 +508,7 @@ chainValidatorsSchema = {
     }
 }
 ```
-where `validatorBlsKeyAndBftWeightSchema` is defined in [LIP 0058][lip-0058].
+where `validatorsBlsKeysAndBftWeightsSchema` is defined in [LIP 0058][lip-0058].
 
 ##### Properties
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -364,27 +364,7 @@ The value of the validators hash corresponding to the validator information and 
 
 ##### Execution
 
-We define JSON schema for validator's BLS key and BFT weight:
-
-```java
-validatorBlsKeyAndBftWeightSchema = {
-    "type": "object",
-    "required": ["blsKey", "bftWeight"],
-    "properties": {
-        "blsKey": {
-            "dataType": "bytes",
-            "length": BLS_PUBLIC_KEY_LENGTH,
-            "fieldNumber": 1,
-        },
-        "bftWeight": {
-            "dataType": "uint64",
-            "fieldNumber": 2
-        }
-    }
-}
-```            
-
-We then use the following JSON schema for the computation of the validators hash.
+We use the following JSON schema for the computation of the validators hash.
 
 ```java
 validatorsHashInputSchema = {
@@ -394,7 +374,20 @@ validatorsHashInputSchema = {
         "validators": {
             "type": "array",
             "fieldNumber": 1,
-            "items": validatorBlsKeyAndBftWeightSchema
+            "items": {
+                "type": "object",
+                "required": ["blsKey", "bftWeight"],
+                "properties": {
+                    "blsKey": {
+                        "dataType": "bytes",
+                        "fieldNumber": 1
+                    },
+                    "bftWeight": {
+                        "dataType": "uint64",
+                        "fieldNumber": 2
+                    }
+                }
+            }
         },
         "certificateThreshold": {
             "dataType": "uint64",

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -393,10 +393,10 @@ validatorsHashInputSchema = {
     "properties": {
         "validators": {
             "type": "array",
-            "items": ...blsKeyAndBftWeightSchema, 
             "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
-            "fieldNumber": 1
+            "fieldNumber": 1,
+            "items": { ...blsKeyAndBftWeightSchema }
         },
         "certificateThreshold": {
             "dataType": "uint64",

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -364,7 +364,27 @@ The value of the validators hash corresponding to the validator information and 
 
 ##### Execution
 
-We use the following JSON schema for the computation of the validators hash.
+We define JSON schema for validator's BLS key and BFT weight:
+
+```java
+validatorBlsKeyAndBftWeightSchema = {
+    "type": "object",
+    "required": ["blsKey", "bftWeight"],
+    "properties": {
+        "blsKey": {
+            "dataType": "bytes",
+            "length": BLS_PUBLIC_KEY_LENGTH,
+            "fieldNumber": 1,
+        },
+        "bftWeight": {
+            "dataType": "uint64",
+            "fieldNumber": 2
+        }
+    }
+}
+```            
+
+We then use the following JSON schema for the computation of the validators hash.
 
 ```java
 validatorsHashInputSchema = {
@@ -374,20 +394,7 @@ validatorsHashInputSchema = {
         "validators": {
             "type": "array",
             "fieldNumber": 1,
-            "items": {
-                "type": "object",
-                "required": ["blsKey", "bftWeight"],
-                "properties": {
-                    "blsKey": {
-                        "dataType": "bytes",
-                        "fieldNumber": 1
-                    },
-                    "bftWeight": {
-                        "dataType": "uint64",
-                        "fieldNumber": 2
-                    }
-                }
-            }
+            "items": validatorBlsKeyAndBftWeightSchema
         },
         "certificateThreshold": {
             "dataType": "uint64",

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -364,25 +364,21 @@ The value of the validators hash corresponding to the validator information and 
 
 ##### Execution
 
-We define JSON schema for validators' BLS keys and BFT weights:
+We define JSON schema for validator's BLS key and BFT weight:
 
 ```java
-validatorsBlsKeysAndBftWeightsSchema = {
-	"type": "array",
-    "minItems": 1,
-	"items": {
-        "type": "object",
-        "required": ["blsKey", "bftWeight"],
-        "properties": {
-            "blsKey": {
-                "dataType": "bytes",
-                "length": BLS_PUBLIC_KEY_LENGTH,
-                "fieldNumber": 1
-            },
-            "bftWeight": {
-                "dataType": "uint64",
-                "fieldNumber": 2
-            }
+blsKeyAndBftWeightSchema = {
+    "type": "object",
+    "required": ["blsKey", "bftWeight"],
+    "properties": {
+        "blsKey": {
+            "dataType": "bytes",
+            "length": BLS_PUBLIC_KEY_LENGTH,
+            "fieldNumber": 1
+        },
+        "bftWeight": {
+            "dataType": "uint64",
+            "fieldNumber": 2
         }
     }
 }    
@@ -396,7 +392,9 @@ validatorsHashInputSchema = {
     "required": ["validators", "certificateThreshold"],
     "properties": {
         "validators": {
-            ...validatorsBlsKeysAndBftWeightsSchema,
+            "type": "array",
+            "items": ...blsKeyAndBftWeightSchema, 
+            "minItems": 1,
             "maxItems": MAX_NUM_VALIDATORS,
             "fieldNumber": 1
         },

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -364,24 +364,28 @@ The value of the validators hash corresponding to the validator information and 
 
 ##### Execution
 
-We define JSON schema for validator's BLS key and BFT weight:
+We define JSON schema for validators' BLS keys and BFT weights:
 
 ```java
-validatorBlsKeyAndBftWeightSchema = {
-    "type": "object",
-    "required": ["blsKey", "bftWeight"],
-    "properties": {
-        "blsKey": {
-            "dataType": "bytes",
-            "length": BLS_PUBLIC_KEY_LENGTH,
-            "fieldNumber": 1,
-        },
-        "bftWeight": {
-            "dataType": "uint64",
-            "fieldNumber": 2
+validatorsBlsKeysAndBftWeightsSchema = {
+	"type": "array",
+    "minItems": 1,
+	"items": {
+        "type": "object",
+        "required": ["blsKey", "bftWeight"],
+        "properties": {
+            "blsKey": {
+                "dataType": "bytes",
+                "length": BLS_PUBLIC_KEY_LENGTH,
+                "fieldNumber": 1
+            },
+            "bftWeight": {
+                "dataType": "uint64",
+                "fieldNumber": 2
+            }
         }
     }
-}
+}    
 ```            
 
 We then use the following JSON schema for the computation of the validators hash.
@@ -392,9 +396,9 @@ validatorsHashInputSchema = {
     "required": ["validators", "certificateThreshold"],
     "properties": {
         "validators": {
-            "type": "array",
-            "fieldNumber": 1,
-            "items": validatorBlsKeyAndBftWeightSchema
+            ...validatorsBlsKeysAndBftWeightsSchema,
+            "maxItems": MAX_NUM_VALIDATORS,
+            "fieldNumber": 1
         },
         "certificateThreshold": {
             "dataType": "uint64",

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2023-03-24
+Updated: 2023-03-31
 Requires: 0055, 0056, 0061
 ```
 


### PR DESCRIPTION
Resolves Issue [#290](https://github.com/LiskHQ/lips/issues/290).

In LIP 0058, we define a new schema `blsKeyAndBftWeightSchema`, and then inject it where it occurs:
- In LIP 0058: `validatorsHashInputSchema`
- In LIP 0045: `chainValidatorsSchema`
- In LIP 0043: `sidechainRegParams`, `mainchainRegParams`, and `registrationSignatureMessageSchema`.