### PR TITLE
Update constant naming

### DIFF
--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -271,7 +271,7 @@ def execute(trs: Transaction) -> None:
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
         "messageFeeTokenID": Token.getTokenIDLSK(),
-        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_LSK
+        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_BEDDOWS
     }
     create an entry in the channel data substore with
         storeKey = chainID
@@ -317,7 +317,7 @@ def execute(trs: Transaction) -> None:
         "name": trsParams.name,
         "chainID": chainID,
         "messageFeeTokenID": sidechainChannel.messageFeeTokenID,
-        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_LSK
+        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_BEDDOWS
     }
 
     ccm = {
@@ -574,7 +574,7 @@ def execute(trs: Transaction) -> None:
         },
         "partnerChainOutboxRoot": EMPTY_HASH,
         "messageFeeTokenID": Token.getTokenIDLSK(),
-        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_LSK
+        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_BEDDOWS
     }
     create an entry in the channel data substore with
         storeKey = getMainchainID()
@@ -619,7 +619,7 @@ def execute(trs: Transaction) -> None:
         "name": CHAIN_NAME_MAINCHAIN,
         "chainID": getMainchainID(),
         "messageFeeTokenID": mainchainChannel.messageFeeTokenID,
-        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_LSK
+        "minReturnFeePerByte": MIN_RETURN_FEE_PER_BYTE_BEDDOWS
     }
 
     ccm = {

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/chain-registration
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-02-24
+Updated: 2023-03-24
 Requires: 0038, 0045, 0049, 0056
 ```
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -220,7 +220,7 @@ In this section, we specify the substores that are part of the Interoperability 
 | `MAX_RESERVED_ERROR_STATUS` | uint64 | 63 | The largest error code reserved for the Interoperability module. |
 | `EMPTY_BYTES` | bytes | "" | The empty byte string. |
 | `EMPTY_FEE_ADDRESS` | bytes | "" | The empty byte string. |
-| `MIN_RETURN_FEE_PER_BYTE_LSK` | uint64 | 1000 | The minimum return fee per byte for a cross-chain message in Beddows for channels between the mainchain and a sidechain. |
+| `MIN_RETURN_FEE_PER_BYTE_BEDDOWS` | uint64 | 1000 | The minimum return fee per byte for a cross-chain message in Beddows for channels between the mainchain and a sidechain. |
 | `MAX_CCM_SIZE` | uint32 | 10*1024 | The maximum size of a serialized cross-chain message in bytes. |
 | **Length Constants** | | | |
 | `ADDRESS_LENGTH` | uint32 | 20 | Length in bytes of type `Address`. |
@@ -476,7 +476,7 @@ channelDataSchema = {
   * `size`: The current size of the tree, i.e. the number of cross-chain messages sent to the partner chain. The default value of this property is 0.
 * `partnerChainOutboxRoot`: The value of this property is set to the outbox root computed from the last CCU from the partner chain containing some cross-chain messages. It is used to validate the cross-chain messages contained in a future CCU when the CCU does not certify a new outbox root. The default value of this property is the constant `EMPTY_HASH`.
 * `messageFeeTokenID`: This property is the token ID of the token used to pay for the cross-chain message fees. The value used in channels between mainchain and sidechains is `messageFeeTokenID = Token.getTokenIDLSK()`, corresponding to the LSK token.
-* `minReturnFeePerByte`: This property is the minimum fee per byte to automatically send back a CCM from the partner chain in case of exeuction errors (see the [`bounce`](#bounce) function). In particular, the CCM fee must be larger or equal than the product of its size in bytes and `minReturnFeePerByte`. The value used in channels between mainchain and sidechains is `minReturnFeePerByte = MIN_RETURN_FEE_PER_BYTE_LSK`.
+* `minReturnFeePerByte`: This property is the minimum fee per byte to automatically send back a CCM from the partner chain in case of exeuction errors (see the [`bounce`](#bounce) function). In particular, the CCM fee must be larger or equal than the product of its size in bytes and `minReturnFeePerByte`. The value used in channels between mainchain and sidechains is `minReturnFeePerByte = MIN_RETURN_FEE_PER_BYTE_BEDDOWS`.
 
 #### Chain Validators Substore
 
@@ -1551,7 +1551,7 @@ On the mainchain, the following checks are performed:
   * property `chainData.status` is in set `{CHAIN_STATUS_REGISTERED, CHAIN_STATUS_ACTIVE, CHAIN_STATUS_TERMINATED}`.
 * For each entry `chainInfo` in `chainInfos`, let `channelData = chainInfo.channelData`, then check:
   * `channelData.messageFeeTokenID == Token.getTokenIDLSK()`;
-  * `channelData.minReturnFeePerByte == MIN_RETURN_FEE_PER_BYTE_LSK`.
+  * `channelData.minReturnFeePerByte == MIN_RETURN_FEE_PER_BYTE_BEDDOWS`.
 * For each entry `chainInfo` in `chainInfos`, let `activeValidators = chainInfo.chainValidators.activeValidators` and let `certificateThreshold = chainInfo.chainValidators.certificateThreshold`, then check:
   * `activeValidators` must have at least 1 element and at most `MAX_NUM_VALIDATORS` elements;
   * `activeValidators` must be ordered lexicographically by `blsKey` property;
@@ -1586,7 +1586,7 @@ If `chainInfos` is not empty, then check that:
   * `mainchainInfo.chainID == getMainchainID()`;
   * `mainchainInfo.chainData.name == CHAIN_NAME_MAINCHAIN`, `mainchainInfo.chainData.status` is either equal to `CHAIN_STATUS_REGISTERED` or to `CHAIN_STATUS_ACTIVE`, and `mainchainInfo.chainData.lastCertificate.timestamp < g.header.timestamp`;
   * `mainchainInfo.channelData.messageFeeTokenID == Token.getTokenIDLSK()`;
-  * `mainchainInfo.channelData.minReturnFeePerByte == MIN_RETURN_FEE_PER_BYTE_LSK`.
+  * `mainchainInfo.channelData.minReturnFeePerByte == MIN_RETURN_FEE_PER_BYTE_BEDDOWS`.
 * Let `activeValidators = mainchainInfo.chainValidators.activeValidators` and let `certificateThreshold = mainchainInfo.chainValidators.certificateThreshold`, then check:
   * `activeValidators` must have at least 1 element and at most `MAX_NUM_VALIDATORS` elements;
   * `activeValidators` must be ordered lexicographically by `blsKey` property;

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-03-10
+Updated: 2023-03-24
 Requires: 0043, 0049, 0053, 0054
 ```
 


### PR DESCRIPTION
In this PR we have updated the constant naming from `MIN_RETURN_FEE_PER_BYTE_LSK` to `MIN_RETURN_FEE_PER_BYTE_BEDDOWS`

Resolves #281 