### PR TITLE
Fix interoperability commands naming pattern as per their values

### DIFF
--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/chain-registration
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-24
+Updated: 2023-03-31
 Requires: 0038, 0045, 0049, 0056
 ```
 

--- a/proposals/lip-0043.md
+++ b/proposals/lip-0043.md
@@ -122,7 +122,7 @@ Calling a function `fct` from another module (named `module`) is represented by 
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_SIDECHAIN_REG`.
+* `command = COMMAND_REGISTER_SIDECHAIN`.
 
 ##### Parameters
 
@@ -349,7 +349,7 @@ def execute(trs: Transaction) -> None:
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_MAINCHAIN_REG`.
+* `command = COMMAND_REGISTER_MAINCHAIN`.
 
 ##### Parameters
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -151,8 +151,8 @@ In this section, we specify the substores that are part of the Interoperability 
 | **Interoperability Commands** | | | |
 | `COMMAND_REGISTER_SIDECHAIN` | string | "registerSidechain" | Name of sidechain registration command. |
 | `COMMAND_REGISTER_MAINCHAIN` | string | "registerMainchain" | Name of mainchain registration command. |
-| `COMMAND_CCU_SIDECHAIN` | string | "submitSidechainCrossChainUpdate" | Name of sidechain cross-chain update command. |
-| `COMMAND_CCU_MAINCHAIN` | string | "submitMainchainCrossChainUpdate" | Name of mainchain cross-chain update command. |
+| `COMMAND_SUBMIT_SIDECHAIN_CCU` | string | "submitSidechainCrossChainUpdate" | Name of sidechain cross-chain update command. |
+| `COMMAND_SUBMIT_MAINCHAIN_CCU` | string | "submitMainchainCrossChainUpdate" | Name of mainchain cross-chain update command. |
 | `COMMAND_RECOVER_STATE` | string | "recoverState" | Name of state recovery initialization command. |
 | `COMMAND_RECOVER_MESSAGE` | string | "recoverMessage" | Name of message recovery command. |
 | `COMMAND_TERMINATE_LIVENESS` | string | "terminateSidechainForLiveness" | Name of liveness termination command. |

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -149,15 +149,15 @@ In this section, we specify the substores that are part of the Interoperability 
 | `SUBSTORE_PREFIX_TERMINATED_OUTBOX` | bytes | 0xd000 | Substore prefix of the terminated outbox substore. |
 | `SUBSTORE_PREFIX_REGISTERED_NAMES` | bytes | 0xe000 | Substore prefix of the chain names substore. |
 | **Interoperability Commands** | | | |
-| `COMMAND_SIDECHAIN_REG` | string | "registerSidechain" | Name of sidechain registration command. |
-| `COMMAND_MAINCHAIN_REG` | string | "registerMainchain" | Name of mainchain registration command. |
-| `COMMAND_SIDECHAIN_CCU` | string | "submitSidechainCrossChainUpdate" | Name of sidechain cross-chain update command. |
-| `COMMAND_MAINCHAIN_CCU` | string | "submitMainchainCrossChainUpdate" | Name of mainchain cross-chain update command. |
-| `COMMAND_STATE_RECOVERY` | string | "recoverState" | Name of state recovery initialization command. |
-| `COMMAND_MESSAGE_RECOVERY` | string | "recoverMessage" | Name of message recovery command. |
-| `COMMAND_LIVENESS_TERMINATION` | string | "terminateSidechainForLiveness" | Name of liveness termination command. |
-| `COMMAND_STATE_RECOVERY_INITIALIZATION` | string | "initializeStateRecovery" | Name of message recovery initialization command. |
-| `COMMAND_MESSAGE_RECOVERY_INITIALIZATION` | string | "initializeMessageRecovery" | Name of initiate recovery command. |
+| `COMMAND_REGISTER_SIDECHAIN` | string | "registerSidechain" | Name of sidechain registration command. |
+| `COMMAND_REGISTER_MAINCHAIN` | string | "registerMainchain" | Name of mainchain registration command. |
+| `COMMAND_CCU_SIDECHAIN` | string | "submitSidechainCrossChainUpdate" | Name of sidechain cross-chain update command. |
+| `COMMAND_CCU_MAINCHAIN` | string | "submitMainchainCrossChainUpdate" | Name of mainchain cross-chain update command. |
+| `COMMAND_RECOVER_STATE` | string | "recoverState" | Name of state recovery initialization command. |
+| `COMMAND_RECOVER_MESSAGE` | string | "recoverMessage" | Name of message recovery command. |
+| `COMMAND_TERMINATE_LIVENESS` | string | "terminateSidechainForLiveness" | Name of liveness termination command. |
+| `COMMAND_INITIALIZE_STATE_RECOVERY` | string | "initializeStateRecovery" | Name of message recovery initialization command. |
+| `COMMAND_INITIALIZE_MESSAGE_RECOVERY` | string | "initializeMessageRecovery" | Name of initiate recovery command. |
 | **Interoperability Cross-chain Commands** | | | |
 | `CROSS_CHAIN_COMMAND_REGISTRATION` | string | "registration" | Name of chain registration cross-chain command. |
 | `CROSS_CHAIN_COMMAND_CHANNEL_TERMINATED` | string | "channelTerminated" | Name of channel terminated cross-chain command. |

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-03-24
+Updated: 2023-03-31
 Requires: 0043, 0049, 0053, 0054
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -101,7 +101,7 @@ If an error occurs in stages 2,3, and 5, the CCM is invalid and discarded. All s
 
 ## Specification
 
-The Interoperability module supports two commands used to certify the state of another chain. Those commands have `module = MODULE_NAME_INTEROPERABILITY`. The mainchain cross-chain update, meant to be posted on the mainchain, has `command = COMMAND_CCU_MAINCHAIN`, while the sidechain cross-chain update, meant to be posted on sidechains, has `command = COMMAND_CCU_SIDECHAIN`.
+The Interoperability module supports two commands used to certify the state of another chain. Those commands have `module = MODULE_NAME_INTEROPERABILITY`. The mainchain cross-chain update, meant to be posted on the mainchain, has `command = COMMAND_SUBMIT_MAINCHAIN_CCU`, while the sidechain cross-chain update, meant to be posted on sidechains, has `command = COMMAND_SUBMIT_SIDECHAIN_CCU`.
 
 ### Notation and Constants
 
@@ -355,7 +355,7 @@ This command is used to submit a cross-chain update on the mainchain.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_CCU_MAINCHAIN`.
+* `command = COMMAND_SUBMIT_MAINCHAIN_CCU`.
 
 ##### Parameters
 
@@ -614,7 +614,7 @@ This command is used to submit a cross-chain update on a sidechain.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_CCU_SIDECHAIN`.
+* `command = COMMAND_SUBMIT_SIDECHAIN_CCU`.
 
 ##### Parameters
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -101,7 +101,7 @@ If an error occurs in stages 2,3, and 5, the CCM is invalid and discarded. All s
 
 ## Specification
 
-The Interoperability module supports two commands used to certify the state of another chain. Those commands have `module = MODULE_NAME_INTEROPERABILITY`. The mainchain cross-chain update, meant to be posted on the mainchain, has `command = COMMAND_MAINCHAIN_CCU`, while the sidechain cross-chain update, meant to be posted on sidechains, has `command = COMMAND_SIDECHAIN_CCU`.
+The Interoperability module supports two commands used to certify the state of another chain. Those commands have `module = MODULE_NAME_INTEROPERABILITY`. The mainchain cross-chain update, meant to be posted on the mainchain, has `command = COMMAND_CCU_MAINCHAIN`, while the sidechain cross-chain update, meant to be posted on sidechains, has `command = COMMAND_CCU_SIDECHAIN`.
 
 ### Notation and Constants
 
@@ -355,7 +355,7 @@ This command is used to submit a cross-chain update on the mainchain.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_MAINCHAIN_CCU`.
+* `command = COMMAND_CCU_MAINCHAIN`.
 
 ##### Parameters
 
@@ -614,7 +614,7 @@ This command is used to submit a cross-chain update on a sidechain.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_SIDECHAIN_CCU`.
+* `command = COMMAND_CCU_SIDECHAIN`.
 
 ##### Parameters
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-09
+Updated: 2023-03-31
 Requires: 0045, 0049, 0058, 0061
 ```
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -602,7 +602,7 @@ This command is used to initialize a terminated state account or update the stat
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_RECOVER_STATE_INITIALIZATION`.
+* `command = COMMAND_INITIALIZE_STATE_RECOVERY`.
 
 #### Parameters
 
@@ -708,7 +708,7 @@ This command is used to initialize a terminated outbox account.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_RECOVER_MESSAGE_INITIALIZATION`.
+* `command = COMMAND_INITIALIZE_MESSAGE_RECOVERY`.
 
 #### Parameters
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -129,7 +129,7 @@ This command is used to recover the state from a terminated chain.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_STATE_RECOVERY`.
+* `command = COMMAND_RECOVER_STATE`.
 
 #### Parameters
 
@@ -305,7 +305,7 @@ This command is used to recover cross-chain messages from a terminated outbox.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_MESSAGE_RECOVERY`.
+* `command = COMMAND_RECOVER_MESSAGE`.
 
 #### Parameters
 
@@ -547,7 +547,7 @@ This command is used to terminate a sidechain that violated the liveness conditi
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_LIVENESS_TERMINATION`.
+* `command = COMMAND_TERMINATE_LIVENESS`.
 
 #### Parameters
 
@@ -602,7 +602,7 @@ This command is used to initialize a terminated state account or update the stat
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_STATE_RECOVERY_INITIALIZATION`.
+* `command = COMMAND_RECOVER_STATE_INITIALIZATION`.
 
 #### Parameters
 
@@ -708,7 +708,7 @@ This command is used to initialize a terminated outbox account.
 Transactions executing this command have:
 
 * `module = MODULE_NAME_INTEROPERABILITY`,
-* `command = COMMAND_MESSAGE_RECOVERY_INITIALIZATION`.
+* `command = COMMAND_RECOVER_MESSAGE_INITIALIZATION`.
 
 #### Parameters
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-sidechain-recovery-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-03-10
+Updated: 2023-03-31
 Requires: 0040, 0045, 0049, 0051
 ```
 


### PR DESCRIPTION
In this PR we have updated the naming of interoperability commands so that it should be in order form (starting with action first).

Resolves #302