### PR TITLE
fix notation in genesis terminated account verification

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -1562,7 +1562,7 @@ On the mainchain, the following checks are performed:
   * check that the corresponding `validatorsHash` stored in `chainInfo.chainData.lastCertificate.validatorsHash` matches with the value computed from `activeValidators` and `certificateThreshold`.
 * For each entry `chainInfo` in `chainInfos`, `chainInfo.chainData.status == CHAIN_STATUS_TERMINATED` if and only if a corresponding entry (i.e., with `chainID == chainInfo.chainID`) exists in `terminatedStateAccounts`.
 * Each entry `stateAccount` in `terminatedStateAccounts` has a unique `stateAccount.chainID` and `terminatedStateAccounts` is ordered lexicographically by `stateAccount.chainID`.
-* For each entry `stateAccount` in `terminatedStateAccounts` holds `stateAccount.stateRoot == chainData.lastCertificate.stateRoot`, `stateAccount.mainchainStateRoot == EMPTY_HASH`, and `stateAccount.initialized == True`. Here `chainData` is the corresponding entry (i.e., with `chainID == stateAccount.chainID`) in `chainInfos`.
+* For each entry `stateAccount` in `terminatedStateAccounts` holds `stateAccount.terminatedStateAccount.mainchainStateRoot == EMPTY_HASH`, and `stateAccount.terminatedStateAccount.initialized == True`. Moreover, let `chainInfo` be the corresponding entry in `chainInfos` (i.e., with `chainInfo.chainID == stateAccount.chainID`); then it holds that `stateAccount.terminatedStateAccount.stateRoot == chainInfo.chainData.lastCertificate.stateRoot`.
 * Each entry `outboxAccount` in `terminatedOutboxAccounts` has a unique `outboxAccount.chainID` and `terminatedOutboxAccounts` is ordered lexicographically by `outboxAccount.chainID`. Furthermore, an entry `outboxAccount` in `terminatedOutboxAccounts` must have a corresponding entry (i.e., with `chainID == outboxAccount.chainID`) in `terminatedStateAccounts`. Notice that the opposite is not necessarily true, so that there could be an entry in `terminatedStateAccounts` without a corresponding entry in `terminatedOutboxAccounts`.
 
 
@@ -1597,8 +1597,8 @@ If `chainInfos` is not empty, then check that:
   * check that the corresponding `validatorsHash` stored in `mainchainInfo.chainData.lastCertificate.validatorsHash` matches with the value computed from `activeValidators` and `certificateThreshold`.
 * Each entry `stateAccount` in `terminatedStateAccounts` has a unique `stateAccount.chainID` and `terminatedStateAccounts` is ordered lexicographically by `stateAccount.chainID`. Furthermore for each entry it holds `stateAccount.chainID != getMainchainID()` and `stateAccount.chainID != ownChainAccount.chainID`.
 * For each entry `stateAccount` in `terminatedStateAccounts` either:
-  * `stateAccount.stateRoot != EMPTY_HASH`, `stateAccount.mainchainStateRoot == EMPTY_HASH`, and `stateAccount.initialized == True`;
-  * or `stateAccount.stateRoot == EMPTY_HASH`, `stateAccount.mainchainStateRoot != EMPTY_HASH`, and `stateAccount.initialized == False`.
+  * `stateAccount.terminatedStateAccount.stateRoot != EMPTY_HASH`, `stateAccount.terminatedStateAccount.mainchainStateRoot == EMPTY_HASH`, and `stateAccount.terminatedStateAccount.initialized == True`;
+  * or `stateAccount.terminatedStateAccount.stateRoot == EMPTY_HASH`, `stateAccount.terminatedStateAccount.mainchainStateRoot != EMPTY_HASH`, and `stateAccount.terminatedStateAccount.initialized == False`.
 * `terminatedOutboxAccounts` is empty;
 
 ##### Genesis State Processing


### PR DESCRIPTION
This PR fixes the following inconsistency/typo in genesis assets verification:

While verifying the `terminatedStateAccounts` (see schema [here](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#genesis-assets-schema)), for an entry `stateAccount`  in `terminatedStateAccounts` , we use `stateAccount.stateRoot` , `stateAccount.mainchainStateRoot` and `stateAccount.initialized` which is inconsistent. Instead this should be `stateAccount.terminatedStateAccount.stateRoot` and so on. 

Similarly the usage of `chainData` does not correspond to an item in `chainInfos`; it is corrected such that `chainInfo` is an item in `chainInfos` and use `chainInfo.chainData` instead.