### PR TITLE
add available balance check in stake verify

### DIFF
--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -732,7 +732,7 @@ Let `trsParams = decode(stakeTransactionParams, trs.params)` for the given trans
 * A given `validatorAddress` is included in at most one stake from the list of stakes (regardless of the associated amounts).
 * For all stakes included in `trsParams.stakes`, we have:
   * `amount` value is a multiple of `BASE_STAKING_AMOUNT`, i.e., `amount % BASE_STAKING_AMOUNT == 0`. For the Lisk mainchain, where `BASE_STAKING_AMOUNT = 10^9` and `TOKEN_ID_POS` is the token ID of the LSK token, this corresponds to multiples of 10 LSK.
-  * `amount != 0`.   
+  * `amount != 0`.
 
 ##### Execution
 

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -9,7 +9,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-09-03
-Updated: 2023-02-24
+Updated: 2023-04-05
 Required: 0022, 0023, 0024, 0040, 0044, 0046, 0058, 0059
 ```
 

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -727,12 +727,13 @@ stakeTransactionParams = {
 
 Let `trsParams = decode(stakeTransactionParams, trs.params)` for the given transaction `trs`. Then the following verification steps are performed:
 
-* The function `validateObjectSchema(stakeTransactionParams, trsParams)` muss pass without exception.
+* The function `validateObjectSchema(stakeTransactionParams, trsParams)` must pass without exception.
 * `trsParams.stakes` has at most `2 * MAX_NUMBER_STAKING_SLOTS` elements. The reason of choosing this bound on the size is to allow a staker to unstake all current validators (which are at most `MAX_NUMBER_STAKING_SLOTS`) and stake with `MAX_NUMBER_STAKING_SLOTS` new ones in the same transaction.
 * A given `validatorAddress` is included in at most one stake from the list of stakes (regardless of the associated amounts).
 * For all stakes included in `trsParams.stakes`, we have:
   * `amount` value is a multiple of `BASE_STAKING_AMOUNT`, i.e., `amount % BASE_STAKING_AMOUNT == 0`. For the Lisk mainchain, where `BASE_STAKING_AMOUNT = 10^9` and `TOKEN_ID_POS` is the token ID of the LSK token, this corresponds to multiples of 10 LSK.
   * `amount != 0`.
+* Let `senderAddress` be the address of the user sending the transaction (i.e., the staker). Let `totalUpstake` be the sum of all positive amounts of the `trsParams.stakes` array, i.e., the total amount that the sender is staking in this transaction. Then the following should hold: `Token.getAvailableBalance(senderAddress, TOKEN_ID_POS) >= totalUpstake`.    
 
 ##### Execution
 

--- a/proposals/lip-0057.md
+++ b/proposals/lip-0057.md
@@ -732,8 +732,7 @@ Let `trsParams = decode(stakeTransactionParams, trs.params)` for the given trans
 * A given `validatorAddress` is included in at most one stake from the list of stakes (regardless of the associated amounts).
 * For all stakes included in `trsParams.stakes`, we have:
   * `amount` value is a multiple of `BASE_STAKING_AMOUNT`, i.e., `amount % BASE_STAKING_AMOUNT == 0`. For the Lisk mainchain, where `BASE_STAKING_AMOUNT = 10^9` and `TOKEN_ID_POS` is the token ID of the LSK token, this corresponds to multiples of 10 LSK.
-  * `amount != 0`.
-* Let `senderAddress` be the address of the user sending the transaction (i.e., the staker). Let `totalUpstake` be the sum of all positive amounts of the `trsParams.stakes` array, i.e., the total amount that the sender is staking in this transaction. Then the following should hold: `Token.getAvailableBalance(senderAddress, TOKEN_ID_POS) >= totalUpstake`.    
+  * `amount != 0`.   
 
 ##### Execution
 


### PR DESCRIPTION
last edit April 3. 

This PR was supposed to make the following modification in PoS Module:

> Currently, when a user stakes using the stake command, there is no check of available balance in the transaction verification stage. Instead, an exception and corresponding failure event is emitted once there is attempt to lock the staked amount, if balance is not enough. In this PR, we add this extra check in the verification, so that a transaction does not proceed to execution unless there is sufficient available balance for staking. 

It was finally decided to don't add this check for performance reasons and keep `verify` as is. We just kept some typo corrections in this PR.  