### PR TITLE
LIP0061: fix return type in `getNextCertificateFromAggregateCommits`

### DIFF
--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -732,7 +732,7 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromSingleCommits` and the auxiliary function `computeEligibleSingleCommits`.
 
 ```python
-def getNextCertificateFromSingleCommits(lastCertifiedHeight: uint32) -> Certificate:
+def getNextCertificateFromSingleCommits(lastCertifiedHeight: uint32) -> Certificate | None:
     # Obtain the BFT Parameters that were certified by the last certificate.
     bftParams = getBFTParameters(lastCertifiedHeight + 1)
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-certificate-generation-mec
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-04-05
+Updated: 2023-04-24
 Requires: 0044, 0055, 0058
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -664,7 +664,7 @@ The function returns a valid certificate object that can be submitted to blockch
 For readability, we describe the logic using two functions, the main function `getNextCertificateFromAggregateCommits` and the auxiliary function `checkChainOfTrust`.
 
 ```python
-def getNextCertificateFromAggregateCommits(lastCertifiedHeight: uint32) -> Certificate:
+def getNextCertificateFromAggregateCommits(lastCertifiedHeight: uint32) -> Certificate | None:
     lastValidatorsHash  = validatorsHash property of block header at height lastCertifiedHeight
     lastCertifiedValidators = validatorsHashPreimage[lastValidatorsHash].validators
     lastCertificateThreshold = validatorsHashPreimage[lastValidatorsHash].certificateThreshold


### PR DESCRIPTION
Closes https://github.com/LiskHQ/lips/issues/325.