### PR TITLE
LIP0045: Replace raw spec line with a TODO comment

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -977,7 +977,7 @@ def createTerminatedStateAccount(chainID: ChainID, stateRoot: bytes = EMPTY_HASH
             topics = [chainID]
         )
 
-        remove the entry with storeKey = chainID from the outbox root substore
+        // TODO: remove the entry with storeKey = chainID from the outbox root substore
 
         # If no stateRoot is given as input, get it from the state.
         if stateRoot == EMPTY_HASH:


### PR DESCRIPTION
`remove the entry with storeKey = chainID from the outbox root substore`

Since there is no implementation given for above line, we can replace it with a TODO comment, hence it will be up to user how to implement it.

