### PR TITLE
LIP0054: Replace `Recovered` with `Recoverable` in error message

### DIFF
--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -231,7 +231,7 @@ def verify(trs: Transaction) -> None:
 
     for entry in trsParams.storeEntries:
         if entry.storeValue is EMPTY_BYTES:
-            raise Exception("Recovered store value cannot be empty.")
+            raise Exception("Recoverable store value cannot be empty.")
 
         queryKey = storePrefix + entry.substorePrefix + sha256(entry.storeKey)
         queryKeys.append(queryKey)
@@ -245,7 +245,7 @@ def verify(trs: Transaction) -> None:
     # Check that all query keys are pariwise distinct, 
     # meaning that we are not trying to recover the same entry twice.
     if len(queryKeys) != len(set(queryKeys)):
-        raise Exception("Recovered store keys are not pairwise distinct.")
+        raise Exception("Recoverable store keys are not pairwise distinct.")
 
     proofOfInclusionStores = { siblingHashes: trsParams.siblingHashes, queries : storeQueries }
 


### PR DESCRIPTION
```{r}
# Check that all query keys are pariwise distinct, 
# meaning that we are not trying to recover the same entry twice.
```
This comment tells that we are intending to recover, hence `recovered` should be replaced with `Recoverable`