### PR TITLE
Fix rounding on shared rewards - LIP 70

### DIFF
--- a/proposals/lip-0070.md
+++ b/proposals/lip-0070.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-reward-sharing-mechanism/3
 Status: Draft
 Type: Standards Track
 Created: 2022-10-26
-Updated: 2023-04-13
+Updated: 2023-06-01
 Required: 0022, 0023, 0057
 ```
 


### PR DESCRIPTION
This PR fixes a rounding issue on the reward sharing mechanism that was discovered during testing of the SDK implementation

## Background

In the reward sharing mechanism, whenever a validator receives a reward of amount `reward`, part of it is shared with their voters. The total amount that will be shared to voters, gets locked (called `sharedRewards`) and can not be used by the validator; when a voter claims rewards, it gets unlocked and transferred to voter's account.

The important quantities are: `commission`, `totalStake` and `selfStake` of the validator. Assume for simplicity commission is in [0,1]. Then we have: 

`sharedRewards = reward * (1 - commission) * (totalStake-selfStake)/ totalStake`

The reason is that the commission is given to the validator, therefore the remaining part is `reward * (1 - commission) `; among this, the fraction `selfStake/totalStake` goes to the validator as well.


## Issue

For the calculation of the aforementioned quantities, we use Q96 numbers. The issue discovered during testing was that during calculation of `sharedRewards` as described above (in the [`updateSharedRewards` function](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0070.md#updatesharedrewards)), we round down (using `Q_n_ToInt` function). 

It was discovered that this rounding down results to the following precision issue: in some cases, the sum of the calculated rewards for the voters exceeds the `sharedRewards` amount, therefore the last voters might not be able to recover their rewards (the amount that they attempt to unlock is higher than the remaining locked amount).

After examining the specs carefully, we found that this happens in cases where rewards are provided multiple times to a validator before the stakers request to receive their share, which is actually the most common case in practice. 

In particular, assume that a validator has only one voter and that they receives `k` times the same reward, which implies each time`sharedRewards` amount `x`.  Then, the total locked amount is `k *roundDown(x)` and the claimable rewards are `roundDown(k *x)`.

Therefore in order to be able to unlock, we need `k *roundDown(x) >= roundDown(k*x)` which is not always true.


## Fix

To fix this, we propose rounding up instead of down in the calculation of `sharedRewards`. This way, the sum of the rewards for voters (calculated with rounding down) would never exceed the total shared rewards. In particular, in the example above, we will have that the shared rewards will be `k * roundUp(x)` and the claimable rewards `roundDown(k *x)`. Since it is always true that `k * roundUp(x) >= k*x >= roundDown(k * x)`, the locked amount will always be sufficient for the voter to recover their funds.

Moreover we have to take care of the following corner case: What happens if this rounding up results in having `sharedRewards > reward`? ( this could e.g., happen if commission is 0 and selfStake very small or vice-versa). For this reason we cap the `sharedRewards` to be at most the total reward. In particular, we set:

`sharedRewards = min(Q_96_ToIntRoundUp(sharedRewards), reward)`

## Implementation

The suggested change was implemented in the following SDK PR.: https://github.com/LiskHQ/lisk-sdk/pull/8137/