### PR TITLE
Update LIP 0052 - Additional check in the `transferCrossChain` command

### DIFF
--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -1828,6 +1828,9 @@ def transferCrossChain(
     includeAttributes: bool
 ) -> None:
 
+    if receivingChainID == OWN_CHAIN_ID:
+        raise Exception("Receiving chain cannot be the sending chain.")
+
     if len(data) > MAX_LENGTH_DATA:
         emitFailedCrossChainTransferEvent(senderAddress, nftID, amount, receivingChainID, recipientAddress, RESULT_DATA_TOO_LONG)
         raise Exception("Data field is too long")


### PR DESCRIPTION
## Description

As of now, it is possible to use the `transferCrossChain` command to initiate the cross-chain NFT transfer in the way it is not intended, i.e., to use it for transferring NFT on the same chain.

## Proposed Solution

In `transferCrossChain` command, we add the following additional check, to ensure that `receivingChainID` is not the same as `OWN_CHAIN_ID` (i.e., the `sendingChainID`):

```
if receivingChainID == OWN_CHAIN_ID:
        raise Exception("Receiving chain cannot be the sending chain.")
```