### PR TITLE
Small edits to LIP 0047 PoA module

### DIFF
--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -87,6 +87,8 @@ The LIP uses the following types.
 | `MAX_UINT64` | uint64 | 18446744073709551615 |
 | `MESSAGE_TAG_POA` | bytes | ASCII encoded string “LSK_POA_” |
 
+The constant `REGISTRATION_FEE` is configured for each chain separately. For a reference, an analogous parameter in [PoS](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#notation-and-constants) is set to `10*(10^8)` on the Lisk mainchain.
+
 #### uint32be Function
 
 The function `uint32be(x)` returns the big endian uint32 serialization of an integer `x`, with `0 <= x < 2^32`. This serialization is always 4 bytes long.
@@ -511,7 +513,7 @@ def execute(trs: Transaction) -> None:
                                     [validatorInfo["weight"] for validatorInfo in validatorInfos],
                                     snapshotStore(0).threshold,
                                     m)
-    if verified != VALID:
+    if verified == False:
         emitPersistentEvent(
             module = MODULE_NAME_POA,
             name = EVENT_NAME_AUTHORITY_UPDATE,
@@ -584,8 +586,8 @@ def shuffleValidatorsList(validatorsAddresses: list[Address], randomSeed: Random
         roundHash[address] = SHA-256(randomSeed + address)
 
     # Reorder the validator list.
-    shuffledValidatorAddresses = sort validatorsAddresses where address1 < address2 if (roundHash(address1) < roundHash(address2))
-                                 or ((roundHash(address1) == roundHash(address2)) and address1 < address2)         
+    shuffledValidatorAddresses = sort validatorsAddresses where address1 < address2 if (roundHash[address1] < roundHash[address2])
+                                 or ((roundHash[address1] == roundHash[address2]) and address1 < address2)         
 
     return shuffledValidatorAddresses
 ```
@@ -635,7 +637,7 @@ Let `genesisBlockAssetBytes` be the bytes included in the `data` property of a d
 
 * Create three entries in the snapshot substore as:
   * The `storeKey` of each of the entries are `uint32be(0)`, `uint32be(1)`, and `uint32be(2)` respectively.
-  * The `storeValue` is the same for the three entries and equal to the serialization of `assetPoA.snapshotSubstore`.
+  * The `storeValue` is the same for the three entries and equal to the serialization of `assetPoA.snapshotSubstore` where parameter name `activeValidators` is replaced with `validators`.
 
 * Create an entry in the chain properties substore as:
   * The `storeValue` is the serialization of a `chainProperties` object following `chainPropSchema` where:

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-poa-module/288
 Status: Draft
 Type: Standards Track
 Created: 2021-04-29
-Updated: 2023-04-05
+Updated: 2023-06-07
 Requires: 0038, 0040, 0044
 ```
 

--- a/proposals/lip-0047.md
+++ b/proposals/lip-0047.md
@@ -172,13 +172,13 @@ This substore contains the snapshot of the active authorities for the current ro
 
 * The substore prefix is set to `SUBSTORE_PREFIX_SNAPSHOT`.
 * Each substore key is `uint32be(roundNumber)`, where `roundNumber` can be 0, 1 or 2 corresponding to the current round, the next round and in two rounds respectively.
-* Each substore value is the serialization of an object following `snapshotStoreSchema`.
-* Notation: Let `snapshotStore(roundNumber)` be the substore entry in the snapshot substore with the key `uint32be(roundNumber)`, deserialized using the `snapshotStoreSchema` schema.
+* Each substore value is the serialization of an object following `snapshotSubstoreSchema`.
+* Notation: Let `snapshotStore(roundNumber)` be the substore entry in the snapshot substore with the key `uint32be(roundNumber)`, deserialized using the `snapshotSubstoreSchema` schema.
 
 ##### JSON Schema
 
 ```java
-snapshotStoreSchema = {
+snapshotSubstoreSchema = {
     "type": "object",
     "required": ["validators", "threshold"],
     "properties": {


### PR DESCRIPTION
List of changes:

- Fixed the return value of `verifyWeightedAggSig` to be boolean.
- Added a reference value for `REGISTRATION_FEE`.
- Fixed `roundHash(i)` notation to dictionary notation.
- Renamed `snapshotStoreSchema` into `snapshotSubstoreSchema`
- Mentioned schema difference between `genesisPoAStoreSchema.snapshotSubstore` and `snapshotSubstoreSchema` when initializing genesis state.