### PR TITLE
Specify registration order of interoperable modules in LIP 0063

### DIFF
--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -630,7 +630,7 @@ def ceiling(x: uint32,y: uint32) -> uint32:
 
 ### Registration Order of Interoperable Modules
 
-The Token module must be registered before the Fee module such that `token.beforeCrossChainCommandExecution` is called before `fee.beforeCrossChainCommandExecution` to ensure that a relayer has enough funds. See also [here](https://github.com/LiskHQ/lips/blob/ddbf5067d05a52ea846afec129a076db0fb89b16/proposals/lip-0048.md?plain=1#L295-L296).
+The Token module must be registered before the Fee module such that `Token.beforeCrossChainCommandExecution` is called before `Fee.beforeCrossChainCommandExecution` to ensure that a relayer has enough funds. See also [here](https://github.com/LiskHQ/lips/blob/ddbf5067d05a52ea846afec129a076db0fb89b16/proposals/lip-0048.md?plain=1#L295-L296).
 
 ### Keeping Lisk Core v3 Block History
 

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -270,7 +270,7 @@ Lisk Core v4 will use the following modules, where the given order defines the m
 
 ##### Registration of Interoperable Modules
 
-The Interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order for iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
+The Interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order of modules to execute interoperability hooks in the [apply](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#apply) and [forward](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#forward) functions of the interoperability module. The order is as follows:
 
 1. Token
 2. Fee

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -270,7 +270,7 @@ Lisk Core v4 will use the following modules, where the given order defines the m
 
 ##### Registration of Interoperable Modules
 
-The interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order for iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
+The Interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order for iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
 
 1. Token
 2. Fee

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-mainnet-configuration-and-mig
 Status: Draft
 Type: Standards Track
 Created: 2022-04-06
-Updated: 2023-05-09
+Updated: 2023-06-08
 Requires: 0060
 ```
 

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -272,8 +272,8 @@ Lisk Core v4 will use the following modules, where the given order defines the m
 
 The Interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order of modules to execute interoperability hooks in the [apply](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#apply) and [forward](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#forward) functions of the interoperability module. The order is as follows:
 
-1. Token
-2. Fee
+1. [Token](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md)
+2. [Fee](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0048.md)
 
 #### Constants
 

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -268,6 +268,13 @@ Lisk Core v4 will use the following modules, where the given order defines the m
 8. [Dynamic Block Reward](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0071.md)
 9. [Legacy](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0050.md)
 
+##### Registration of Interoperable Modules
+
+The interoperability modules requires to define the registration order all interoperable modules. This is needed to define the order when iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
+
+1. Token
+2. Fee
+
 #### Constants
 
 Some new LIPs introduced configurable constants. The values for these constants are specified in the following table:

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -628,6 +628,10 @@ def ceiling(x: uint32,y: uint32) -> uint32:
 
 ## Rationale
 
+### Registration Order of Interoperable Modules
+
+The Token module must be registered before the Fee module such that `token.beforeCrossChainCommandExecution` is called before `fee.beforeCrossChainCommandExecution` to ensure that a relayer has enough funds. See also [here](https://github.com/LiskHQ/lips/blob/ddbf5067d05a52ea846afec129a076db0fb89b16/proposals/lip-0048.md?plain=1#L295-L296).
+
 ### Keeping Lisk Core v3 Block History
 
 The decision to discard the block history of Lisk Mainnet at the hard fork from Lisk Core v2 to Lisk Core v3 was considered as rather disadvantageous. One reason is that the entire transaction history of an account can not be retrieved anymore from a node running Lisk Core v3\. Therefore, the block history of blocks created with Lisk Core v3 shall be kept on Lisk Core v4 nodes.

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -270,7 +270,7 @@ Lisk Core v4 will use the following modules, where the given order defines the m
 
 ##### Registration of Interoperable Modules
 
-The interoperability modules requires to define the registration order all interoperable modules. This is needed to define the order when iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
+The interoperability modules requires to define the registration order of all interoperable modules. This is needed to define the order for iterating through all interoperable modules, e.g., [here](https://github.com/LiskHQ/lips/blob/87dc7bc4294e20fe74b5e713e999c7448b5ad26b/proposals/lip-0049.md?plain=1#L259). The order is as follows:
 
 1. Token
 2. Fee


### PR DESCRIPTION
Fixes #372 