### PR TITLE
Modify LIP 0052 genesis assets schema and genesis state initialization

### DIFF
--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -198,7 +198,7 @@ The following constants are used throughout the document:
 | `NFTID` | bytes | Must be of length `LENGTH_NFT_ID`. | Used for NFT identifiers. |
 | `ChainID` | bytes | Must be of length `LENGTH_CHAIN_ID`. | Used for chain identifiers. |
 | `CollectionID` | bytes | Must be of length `LENGTH_COLLECTION_ID`. | Used for NFT collection identifiers. |
-| `AttributesArray` | (Module &#124; bytes)[] | Two-dimensional array consisting of `Module` names and corresponding `attributes`. | Used for array of NFT attributes. |
+| `AttributesArray` | (Module &#124; bytes)[] | Two-dimensional array consisting of `Module` names and corresponding `attributes`. | Used to store information specific to the NFT. |
 
 #### uint64be Function
 

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-nft-module/297
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-06-12
+Updated: 2023-06-22
 Requires: 0045
 ```
 

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -2245,7 +2245,7 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
     - The `attributesArray` must be in lexicographic order of `module` name, and all values of `module` must be unique.
   - The `supportedNFTsSubstore` array, if non-empty, must adhere to one of the following two mutually exclusive conditions:
     - Have a single entry with `chainID` of length `0` and no other entries. This indicates that all NFTs are supported, i.e., `chainID == ALL_SUPPORTED_NFTS_KEY`. In this case, the `supportedCollectionIDArray` should be an empty array.
-    - Across all elements, the `chainID` must be unique and have length `LENGTH_CHAIN_ID`. Furthermore, the `supportedNFTsSubstore` array must be in lexicographic order of `chainID`. Also, for each entry of this array, the `supportedCollectionIDArray` should be in lexicographic order.
+    - Otherwise, across all elements, the `chainID` must be unique and have length `LENGTH_CHAIN_ID`. Furthermore, the `supportedNFTsSubstore` array must be in lexicographic order of `chainID`. Also, for each entry of this array, the `supportedCollectionIDArray` should be in lexicographic order.
   
 - For each entry `NFTEntry` in `genesisBlockAssetObject.NFTSubstore`:
   - Create an entry in the NFT substore with:
@@ -2272,14 +2272,13 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
         }
     )
     ```
-    maintaining the lexicographical ordering of the user substore by `NFTEntry.owner` and, for each `NFTEntry.owner`, by `NFTEntry.nftID`.
   
   - If `NFTEntry.owner` has length `LENGTH_CHAIN_ID` bytes, create an entry in the escrow substore with: 
 
     ```python
     storeKey = NFTEntry.owner + NFTEntry.nftID
+    storeValue = `EMPTY_BYTES`
     ```
-    maintaining the lexicographical ordering of the escrow substore by `NFTEntry.owner` and, for each `NFTEntry.owner`, by `NFTEntry.nftID`.
 
 - For each entry `supportedNFTsEntry` in `genesisBlockAssetObject.supportedNFTsSubstore`, create an entry in the supported NFTs substore with:
 

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -1252,7 +1252,7 @@ def createNFTEntry(
     attributesArray: AttributesArray
 ) -> None:
 
-    if len(attributesArray) != len(set(item['module'] for item in attributesArray)):
+    if len(attributesArray) != len(set(item.module for item in attributesArray)):
         raise Exception("Invalid attributes array provided")
 
     create substore entry with
@@ -1544,7 +1544,7 @@ def create(
     index = getNextAvailableIndex(collectionID)
     nftID = OWN_CHAIN_ID + collectionID + uint64be(index)
 
-    if len(attributesArray) != len(set(item['module'] for item in attributesArray)):
+    if len(attributesArray) != len(set(item.module for item in attributesArray)):
         raise Exception("Invalid attributes array provided")
 
     Fee.payFee(FEE_CREATE_NFT)

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -2277,7 +2277,7 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
 
     ```python
     storeKey = NFTEntry.owner + NFTEntry.nftID
-    storeValue = `EMPTY_BYTES`
+    storeValue = EMPTY_BYTES
     ```
 
 - For each entry `supportedNFTsEntry` in `genesisBlockAssetObject.supportedNFTsSubstore`, create an entry in the supported NFTs substore with:

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -1252,6 +1252,9 @@ def createNFTEntry(
     attributesArray: AttributesArray
 ) -> None:
 
+    if len(attributesArray) != len(set(item['module'] for item in attributesArray)):
+        raise Exception("Invalid attributes array provided")
+
     create substore entry with
         substorePrefix = SUBSTORE_PREFIX_NFT
         key = nftID

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -187,6 +187,7 @@ The following constants are used throughout the document:
 | `RESULT_INSUFFICIENT_BALANCE` | uint32 | 12 | Used when the balance is not sufficient to pay for the cross-chain message fee. |
 | `RESULT_DATA_TOO_LONG` | uint32 | 13 | Used when the data input is too long. |
 | `INVALID_RECEIVING_CHAIN` | uint32 | 14 | Used when, during the cross-chain token transfer, the receiving chain is set to be equal to the sending chain. |
+| `RESULT_INVALID_ACCOUNT` | uint32 | 15 | USed when recover function fails due to invalid account. |
 
 ### Type Definitions
 
@@ -1540,6 +1541,9 @@ def create(
     index = getNextAvailableIndex(collectionID)
     nftID = OWN_CHAIN_ID + collectionID + uint64be(index)
 
+    if len(attributesArray) != len(set(item['module'] for item in attributesArray)):
+        raise Exception("Invalid attributes array provided")
+
     Fee.payFee(FEE_CREATE_NFT)
     createNFTEntry(address, nftID, attributesArray)
     createUserEntry(address, nftID)
@@ -2294,7 +2298,7 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
     - The `userSubstore` array, if the value of the `owner` property has length `LENGTH_ADDRESS` bytes, or
     - The `escrowSubstore` array, if the value of the `owner` property has length `LENGTH_CHAIN_ID` bytes.
   - The `NFTSubstore` must be in lexicographical order of `nftID`.
-    - The `attributesArray` must be in lexicographic order of `module` name.
+    - The `attributesArray` must be in lexicographic order of `module` name, and all values of `module` must be unique.
   - Across all elements of the `userSubstore` array, the pairs `address`, `nftID` must be unique: each pair appears at most once, although a given `address` can appear multiple times with different unique `nftID`. Furthermore, each `nftID` should also be unique.
   - The `userSubstore` array must be in lexicographical order of `address`. For a given `address`, the entries must be in lexicographic order of `nftID`.
   - Across all elements of the `escrowSubstore` array, the pairs `escrowedChainID`, `nftID` must be unique: each pair appears at most once, although a given `escrowedChainID` can appear multiple times with different unique `nftID`. Furthermore, each `nftID` should also be unique.

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -1537,7 +1537,7 @@ This function creates an NFT.
 ```python
 def create(
     address: Address,
-    collectionID: Collection,
+    collectionID: CollectionID,
     attributesArray: AttributesArray
 ) -> None:
 
@@ -1840,11 +1840,11 @@ def transferCrossChain(
 ) -> None:
 
     if receivingChainID == OWN_CHAIN_ID:
-        emitFailedCrossChainTransferEvent(senderAddress, nftID, amount, receivingChainID, recipientAddress, INVALID_RECEIVING_CHAIN)
+        emitFailedTransferCrossChainEvent(senderAddress, nftID, amount, receivingChainID, recipientAddress, INVALID_RECEIVING_CHAIN)
         raise Exception("Receiving chain cannot be the sending chain.")
 
     if len(data) > MAX_LENGTH_DATA:
-        emitFailedCrossChainTransferEvent(senderAddress, nftID, amount, receivingChainID, recipientAddress, RESULT_DATA_TOO_LONG)
+        emitFailedTransferCrossChainEvent(senderAddress, nftID, amount, receivingChainID, recipientAddress, RESULT_DATA_TOO_LONG)
         raise Exception("Data field is too long")
 
     if NFT[nftID] does not exist:

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -187,7 +187,7 @@ The following constants are used throughout the document:
 | `RESULT_INSUFFICIENT_BALANCE` | uint32 | 12 | Used when the balance is not sufficient to pay for the cross-chain message fee. |
 | `RESULT_DATA_TOO_LONG` | uint32 | 13 | Used when the data input is too long. |
 | `INVALID_RECEIVING_CHAIN` | uint32 | 14 | Used when, during the cross-chain token transfer, the receiving chain is set to be equal to the sending chain. |
-| `RESULT_INVALID_ACCOUNT` | uint32 | 15 | USed when recover function fails due to invalid account. |
+| `RESULT_INVALID_ACCOUNT` | uint32 | 15 | Used when recover function fails due to invalid account. |
 
 ### Type Definitions
 

--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -2155,8 +2155,6 @@ genesisNFTStoreSchema = {
     "type": "object",
     "required": [
         "NFTSubstore",
-        "userSubstore",
-        "escrowSubstore",
         "supportedNFTsSubstore"
     ],
     "properties": {
@@ -2204,63 +2202,9 @@ genesisNFTStoreSchema = {
                 }
             }
         },
-        "userSubstore": {
-            "type": "array",
-            "fieldNumber": 2,
-            "items": {
-                "type": "object",
-                "required": [
-                    "address",
-                    "nftID",
-                    "lockingModule"
-                ],
-                "properties": {
-                    "address": {
-                        "dataType": "bytes",
-                        "length": LENGTH_ADDRESS,
-                        "fieldNumber": 1
-                    },
-                    "nftID": {
-                        "dataType": "bytes",
-                        "length": LENGTH_NFT_ID,
-                        "fieldNumber": 2
-                    },
-                    "lockingModule": {
-                        "dataType": "string",
-                        "minLength": MIN_LENGTH_MODULE_NAME,
-                        "maxLength": MAX_LENGTH_MODULE_NAME,
-                        "pattern": "^[a-zA-Z0-9]*$]",
-                        "fieldNumber": 3
-                    }
-                }
-            }
-        },
-        "escrowSubstore": {
-            "type": "array",
-            "fieldNumber": 3,
-            "items": {
-                "type": "object",
-                "required": [
-                    "escrowedChainID",
-                    "nftID"
-                ],
-                "properties": {
-                    "escrowedChainID": {
-                        "dataType": "bytes",
-                        "length": LENGTH_CHAIN_ID,
-                        "fieldNumber": 1
-                    },
-                    "nftID": {
-                        "dataType": "bytes",
-                        "length": LENGTH_NFT_ID,
-                        "fieldNumber": 2
-                    }
-                }
-            }
-        },
         "supportedNFTsSubstore": {
             "type": "array",
-            "fieldNumber": 4,
+            "fieldNumber": 2,
             "items": {
                 "type": "object",
                 "required": [
@@ -2295,51 +2239,47 @@ Let `genesisBlockAssetBytes` be the `data` bytes included in the block assets fo
 
 - Initial checks on the properties of `genesisBlockAssetObject`:
 
-  - Across all elements of the `NFTSubstore` array, all values given for `nftID` must be unique.
-  - For all elements of the `NFTSubstore` array, values given for `owner` must have either length `LENGTH_ADDRESS` bytes (representing a user address) or `LENGTH_CHAIN_ID` bytes (representing a chain ID).
-  - For every element in the `NFTSubstore` array, there should exist unique entry having the same value for `nftID` property in either:
-    - The `userSubstore` array, if the value of the `owner` property has length `LENGTH_ADDRESS` bytes, or
-    - The `escrowSubstore` array, if the value of the `owner` property has length `LENGTH_CHAIN_ID` bytes.
-  - The `NFTSubstore` must be in lexicographical order of `nftID`.
+  - The `NFTSubstore` must be in lexicographical order of `nftID`. Across all elements of the `NFTSubstore` array:
+    - All values given for `nftID` must be unique.
+    - All values given for `owner` must have either length `LENGTH_ADDRESS` bytes (representing a user address) or `LENGTH_CHAIN_ID` bytes (representing a chain ID).
     - The `attributesArray` must be in lexicographic order of `module` name, and all values of `module` must be unique.
-  - Across all elements of the `userSubstore` array, the pairs `address`, `nftID` must be unique: each pair appears at most once, although a given `address` can appear multiple times with different unique `nftID`. Furthermore, each `nftID` should also be unique.
-  - The `userSubstore` array must be in lexicographical order of `address`. For a given `address`, the entries must be in lexicographic order of `nftID`.
-  - Across all elements of the `escrowSubstore` array, the pairs `escrowedChainID`, `nftID` must be unique: each pair appears at most once, although a given `escrowedChainID` can appear multiple times with different unique `nftID`. Furthermore, each `nftID` should also be unique.
-  - For a given element of either the `userSubstore` or `escrowSubstore` arrays, there should exist a unique element in the `NFTSubstore` array, having the same value of the `nftID`.
   - The `supportedNFTsSubstore` array, if non-empty, must adhere to one of the following two mutually exclusive conditions:
     - Have a single entry with `chainID` of length `0` and no other entries. This indicates that all NFTs are supported, i.e., `chainID == ALL_SUPPORTED_NFTS_KEY`. In this case, the `supportedCollectionIDArray` should be an empty array.
     - Across all elements, the `chainID` must be unique and have length `LENGTH_CHAIN_ID`. Furthermore, the `supportedNFTsSubstore` array must be in lexicographic order of `chainID`. Also, for each entry of this array, the `supportedCollectionIDArray` should be in lexicographic order.
   
-- For each entry `NFTEntry` in `genesisBlockAssetObject.NFTSubstore`, create an entry in the NFT substore with:
+- For each entry `NFTEntry` in `genesisBlockAssetObject.NFTSubstore`:
+  - Create an entry in the NFT substore with:
 
-  ```python
-  storeKey = NFTEntry.nftID
-  storeValue = encode(
-      schema = NFTStoreSchema,
-      object = {
-          "owner": NFTEntry.owner,
-          "attributesArray": NFTEntry.attributesArray
-      }
-  )
-  ```
+    ```python
+    storeKey = NFTEntry.nftID
+    storeValue = encode(
+        schema = NFTStoreSchema,
+        object = {
+            "owner": NFTEntry.owner,
+            "attributesArray": NFTEntry.attributesArray
+        }
+    )
+    ```
 
-  Furthermore, if `NFTEntry.owner` has length `LENGTH_ADDRESS` bytes, create an entry in the user substore with:
+  - If `NFTEntry.owner` has length `LENGTH_ADDRESS` bytes, create an entry in the user substore with:
 
-  ```python
-  storeKey = NFTEntry.owner + NFTEntry.nftID
-  storeValue = encode(
-      schema = userStoreSchema,
-      object = {
-          "lockingModule": NFT_NOT_LOCKED
-      }
-  )
-  ```
+    ```python
+    storeKey = NFTEntry.owner + NFTEntry.nftID
+    storeValue = encode(
+        schema = userStoreSchema,
+        object = {
+            "lockingModule": NFT_NOT_LOCKED
+        }
+    )
+    ```
+    maintaining the lexicographical ordering of the user substore by `NFTEntry.owner` and, for each `NFTEntry.owner`, by `NFTEntry.nftID`.
+  
+  - If `NFTEntry.owner` has length `LENGTH_CHAIN_ID` bytes, create an entry in the escrow substore with: 
 
-- For each entry `escrowEntry` in `genesisBlockAssetObject.escrowSubstore`, create an entry in the escrow substore with:
-
-  ```python
-  storeKey = escrowEntry.escrowedChainID + escrowEntry.nftID
-  ```
+    ```python
+    storeKey = NFTEntry.owner + NFTEntry.nftID
+    ```
+    maintaining the lexicographical ordering of the escrow substore by `NFTEntry.owner` and, for each `NFTEntry.owner`, by `NFTEntry.nftID`.
 
 - For each entry `supportedNFTsEntry` in `genesisBlockAssetObject.supportedNFTsSubstore`, create an entry in the supported NFTs substore with:
 


### PR DESCRIPTION
Resolves [Issue #384](https://github.com/LiskHQ/lips/issues/384) and [Issue #388](https://github.com/LiskHQ/lips/issues/388).

## Note

Besides these implementation changes, the following typos were corrected:

1. In the `transferCrossChain` method, the first two mentions of the `emitFailedTransferCrossChainEvent` were incorrect (the event was reffered to as `emitFailedCrossChainTransferEvent`).

2. In the `create` method, the input parameter `collectionID` was incorrectly stated to be of type `Collection`. Instead, it should be of type `CollectionID`.