### PR TITLE
Add `isChannelActive` check to cross-chain transfer of LIP 0051

### DIFF
--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -25,15 +25,34 @@ This LIP defines the fee system in a modular way, as currently [used in the Lisk
 
 ## Rationale
 
+The fee structure presented here serves to allow defining sufficient cost to manage state growth and prevent transaction pool spamming. In principle, any transaction resulting in a state change should incur a fee. This reasoning is implemented in the `payFee` method, which can be invoked by other modules.
+
 ### Fee Token ID
 
-Each chain can configure the token used to pay fees. On the Lisk mainchain, the token used for transaction fees is the LSK token.
+Each chain can configure the token used to pay fees, as defined by `TOKEN_ID_FEE`. On the Lisk mainchain, the token used for transaction fees is the LSK token.
 
 ### Minimum Fee per Transaction
 
-As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee (which can be zero). The minimum fee is computed from the transaction size. Chains can configure their minimum fee per byte, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when the minimum fee per byte is set to zero.
+As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee, which can be set to zero. For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
 
-Chains can choose that this minimum fee gets either burned (to avoid that validators can send transactions in the blocks they generate without cost) or transferred to the specified pool address `ADDRESS_FEE_POOL`. The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants. In the Lisk mainchain, the minimum fee is always burned.
+```python
+trsSize = length(encodeTransaction(trs))
+minFee = MIN_FEE_PER_BYTE * trsSize
+```
+
+Note that chains can freely configure their `MIN_FEE_PER_BYTE`, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when it is set to zero.
+
+### Fee Pool
+
+Chains can choose to either burn the minimum fee - to discourage validators from sending zero-cost transactions in the blocks they generate - or, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. 
+
+The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
+
+In the Lisk mainchain, the minimum fee is always burned.
+
+### Cross-chain Message Fees
+
+Cross-chain messages or CCMs facilitate interoperability by enabling cross-chain transfer of data. They require an associated fee, distinct from the usual transaction fee, paid by the relayer. Similarly to transaction fees, the minimum CCM fee can be either burned or transferred to a fee pool, depending on the chain configuration.
 
 ## Specification
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -25,32 +25,43 @@ This LIP defines the fee system in a modular way, as currently [used in the Lisk
 
 ## Rationale
 
-The fee structure presented here serves to allow defining sufficient cost to manage state growth and prevent transaction pool spamming. In principle, any transaction resulting in a state change should incur a fee. This reasoning is implemented in the `payFee` method, which can be invoked by other modules.
+### Initialization Fee
 
-### Fee Token ID
+The fee structure presented here allows for defining a sufficient cost to manage state growth. In principle, any transaction resulting in a state increase should imply a fee. This reasoning is implemented in the [`payFee`](#payfee) method, which can be invoked by other modules to charge *initialization fee* for data store initializations or some other special purposes, e.g., chain or validator registration. 
+
+For example, this method is called during the execution of the [validator registration command][lip-0057#execution] in LIP 0057: 
+```python
+Fee.payFee(VALIDATOR_REGISTRATION_FEE)
+```
+
+### Transaction Fee
+
+*Transaction fees* are introduced to motivate validators. Any remaining amount from the transaction fee, not consumed by the transaction processing, is given as a reward to the validator that includes the transaction in a block. 
+
+#### Fee Token ID
 
 Each chain can configure the token used to pay fees, as defined by `TOKEN_ID_FEE`. On the Lisk mainchain, the token used for transaction fees is the LSK token.
 
-### Minimum Fee per Transaction
+#### Minimum Fee per Transaction
 
-As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee, which can be set to zero. For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
+As introduced in [LIP 0013][lip-0013], all transactions must have a transaction fee greater or equal to a *minimum fee*, which is introduced in order to discourage validators from sending zero-cost transactions in the blocks they generate. 
 
+For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
 ```python
 trsSize = length(encodeTransaction(trs))
 minFee = MIN_FEE_PER_BYTE * trsSize
 ```
+Note that chains can freely configure their `MIN_FEE_PER_BYTE`, which can be even set to zero. The value `MIN_FEE_PER_BYTE` can not be modified, unless a hard fork occurs. For this reason, we allow sidechains the possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block for which the minimum fee does not apply. 
 
-Note that chains can freely configure their `MIN_FEE_PER_BYTE`, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when it is set to zero.
+This could be useful, for example, for sidechains that want to use LSK as the fee token: Initially, no LSK is present on the sidechain, so the sidechain would not be able to process any transactions unless `MIN_FEE_PER_BYTE` is set to zero. By allowing an initial exception period, users have a time window to transfer LSK tokens to this sidechain, after which the initially set value of `MIN_FEE_PER_BYTE` would start being applied. 
 
 ### Fee Pool
 
-Chains can choose to either burn the minimum fee - to discourage validators from sending zero-cost transactions in the blocks they generate - or, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. 
+Chains can choose to either burn the fee consumed by transaction processing, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
 
-The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
+In the Lisk mainchain, the remaining fee is always burned, reducing the total supply and thus introducing a deflationary pressure to counteract the inflation.
 
-In the Lisk mainchain, the minimum fee is always burned.
-
-### Cross-chain Message Fees
+### Cross-chain Message Fee
 
 Cross-chain messages or CCMs facilitate interoperability by enabling cross-chain transfer of data. They require an associated fee, distinct from the usual transaction fee, paid by the relayer. Similarly to transaction fees, the minimum CCM fee can be either burned or transferred to a fee pool, depending on the chain configuration.
 
@@ -198,9 +209,9 @@ insufficientFeeDataSchema = {
 
 ```python
 def payFee(amount: uint64) -> None:
-    # ccm.ccmProcessing is set by the Interoperability module during the CCM processing.
-    # In particular, before the CCM is processed, ccm.ccmProcessing is set to True.
-    # After the CCM is processed, ccm.ccmProcessing is set to False.
+    # ctx.ccmProcessing is set by the Interoperability module during the CCM processing.
+    # In particular, before the CCM is processed, ctx.ccmProcessing is set to True.
+    # After the CCM is processed, ctx.ccmProcessing is set to False.
     if ctx.ccmProcessing:
         ctx.availableCCMFee -= amount
         if ctx.availableCCMFee < 0:
@@ -241,10 +252,11 @@ def verify(trs: Transaction) -> None:
     b = block including trs
     h = b.header.height
     if h < MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE:
-	    # Set MIN_FEE_PER_BYTE = 0 for the first MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE blocks.
-        MIN_FEE_PER_BYTE = 0
-    trsSize = length(encodeTransaction(trs))
-    minFee = MIN_FEE_PER_BYTE * trsSize
+	    # Set minFee = 0 for the first MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE blocks.
+        minFee = 0
+    else:    
+        trsSize = length(encodeTransaction(trs))
+        minFee = MIN_FEE_PER_BYTE * trsSize
     if trs.fee < minFee:
         raise Exception("Insufficient transaction fee")
     senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
@@ -366,3 +378,4 @@ TBA
 [lip-0013]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0013.md
 [lip-0040]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0040.md
 [lip-0049#ccmschema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#cross-chain-message-schema
+[lip-0057#execution]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#execution

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -25,34 +25,15 @@ This LIP defines the fee system in a modular way, as currently [used in the Lisk
 
 ## Rationale
 
-The fee structure presented here serves to allow defining sufficient cost to manage state growth and prevent transaction pool spamming. In principle, any transaction resulting in a state change should incur a fee. This reasoning is implemented in the `payFee` method, which can be invoked by other modules.
-
 ### Fee Token ID
 
-Each chain can configure the token used to pay fees, as defined by `TOKEN_ID_FEE`. On the Lisk mainchain, the token used for transaction fees is the LSK token.
+Each chain can configure the token used to pay fees. On the Lisk mainchain, the token used for transaction fees is the LSK token.
 
 ### Minimum Fee per Transaction
 
-As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee, which can be set to zero. For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
+As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee (which can be zero). The minimum fee is computed from the transaction size. Chains can configure their minimum fee per byte, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when the minimum fee per byte is set to zero.
 
-```python
-trsSize = length(encodeTransaction(trs))
-minFee = MIN_FEE_PER_BYTE * trsSize
-```
-
-Note that chains can freely configure their `MIN_FEE_PER_BYTE`, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when it is set to zero.
-
-### Fee Pool
-
-Chains can choose to either burn the minimum fee - to discourage validators from sending zero-cost transactions in the blocks they generate - or, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. 
-
-The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
-
-In the Lisk mainchain, the minimum fee is always burned.
-
-### Cross-chain Message Fees
-
-Cross-chain messages or CCMs facilitate interoperability by enabling cross-chain transfer of data. They require an associated fee, distinct from the usual transaction fee, paid by the relayer. Similarly to transaction fees, the minimum CCM fee can be either burned or transferred to a fee pool, depending on the chain configuration.
+Chains can choose that this minimum fee gets either burned (to avoid that validators can send transactions in the blocks they generate without cost) or transferred to the specified pool address `ADDRESS_FEE_POOL`. The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants. In the Lisk mainchain, the minimum fee is always burned.
 
 ## Specification
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -25,43 +25,32 @@ This LIP defines the fee system in a modular way, as currently [used in the Lisk
 
 ## Rationale
 
-### Initialization Fee
+The fee structure presented here serves to allow defining sufficient cost to manage state growth and prevent transaction pool spamming. In principle, any transaction resulting in a state change should incur a fee. This reasoning is implemented in the `payFee` method, which can be invoked by other modules.
 
-The fee structure presented here allows for defining a sufficient cost to manage state growth. In principle, any transaction resulting in a state increase should imply a fee. This reasoning is implemented in the [`payFee`](#payfee) method, which can be invoked by other modules to charge *initialization fee* for data store initializations or some other special purposes, e.g., chain or validator registration. 
-
-For example, this method is called during the execution of the [validator registration command][lip-0057#execution] in LIP 0057: 
-```python
-Fee.payFee(VALIDATOR_REGISTRATION_FEE)
-```
-
-### Transaction Fee
-
-*Transaction fees* are introduced to motivate validators. Any remaining amount from the transaction fee, not consumed by the transaction processing, is given as a reward to the validator that includes the transaction in a block. 
-
-#### Fee Token ID
+### Fee Token ID
 
 Each chain can configure the token used to pay fees, as defined by `TOKEN_ID_FEE`. On the Lisk mainchain, the token used for transaction fees is the LSK token.
 
-#### Minimum Fee per Transaction
+### Minimum Fee per Transaction
 
-As introduced in [LIP 0013][lip-0013], all transactions must have a transaction fee greater or equal to a *minimum fee*, which is introduced in order to discourage validators from sending zero-cost transactions in the blocks they generate. 
+As introduced in [LIP 0013][lip-0013], all transactions must have a fee greater or equal to a minimum fee, which can be set to zero. For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
 
-For a transaction `trs`, the minimum fee is determined by its size and the proportionality constant `MIN_FEE_PER_BYTE`: 
 ```python
 trsSize = length(encodeTransaction(trs))
 minFee = MIN_FEE_PER_BYTE * trsSize
 ```
-Note that chains can freely configure their `MIN_FEE_PER_BYTE`, which can be even set to zero. The value `MIN_FEE_PER_BYTE` can not be modified, unless a hard fork occurs. For this reason, we allow sidechains the possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block for which the minimum fee does not apply. 
 
-This could be useful, for example, for sidechains that want to use LSK as the fee token: Initially, no LSK is present on the sidechain, so the sidechain would not be able to process any transactions unless `MIN_FEE_PER_BYTE` is set to zero. By allowing an initial exception period, users have a time window to transfer LSK tokens to this sidechain, after which the initially set value of `MIN_FEE_PER_BYTE` would start being applied. 
+Note that chains can freely configure their `MIN_FEE_PER_BYTE`, with a possibility to define a period of `MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE` blocks after the genesis block when it is set to zero.
 
 ### Fee Pool
 
-Chains can choose to either burn the fee consumed by transaction processing, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
+Chains can choose to either burn the minimum fee - to discourage validators from sending zero-cost transactions in the blocks they generate - or, on the other hand, to transfer it to a dedicated pool address, `ADDRESS_FEE_POOL`. 
 
-In the Lisk mainchain, the remaining fee is always burned, reducing the total supply and thus introducing a deflationary pressure to counteract the inflation.
+The latter choice could be beneficial for sidechains, as fees collected in this way can be used as an incentive for validators and other protocol participants for various purposes like funding a community pool for on-chain governance spending, sharing the funds among validators proportionally per round, incentivizing ecosystem developers, supporting chain maintenance and improvement, rewarding user staking/voting activity, etc.
 
-### Cross-chain Message Fee
+In the Lisk mainchain, the minimum fee is always burned.
+
+### Cross-chain Message Fees
 
 Cross-chain messages or CCMs facilitate interoperability by enabling cross-chain transfer of data. They require an associated fee, distinct from the usual transaction fee, paid by the relayer. Similarly to transaction fees, the minimum CCM fee can be either burned or transferred to a fee pool, depending on the chain configuration.
 
@@ -209,9 +198,9 @@ insufficientFeeDataSchema = {
 
 ```python
 def payFee(amount: uint64) -> None:
-    # ctx.ccmProcessing is set by the Interoperability module during the CCM processing.
-    # In particular, before the CCM is processed, ctx.ccmProcessing is set to True.
-    # After the CCM is processed, ctx.ccmProcessing is set to False.
+    # ccm.ccmProcessing is set by the Interoperability module during the CCM processing.
+    # In particular, before the CCM is processed, ccm.ccmProcessing is set to True.
+    # After the CCM is processed, ccm.ccmProcessing is set to False.
     if ctx.ccmProcessing:
         ctx.availableCCMFee -= amount
         if ctx.availableCCMFee < 0:
@@ -252,11 +241,10 @@ def verify(trs: Transaction) -> None:
     b = block including trs
     h = b.header.height
     if h < MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE:
-	    # Set minFee = 0 for the first MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE blocks.
-        minFee = 0
-    else:    
-        trsSize = length(encodeTransaction(trs))
-        minFee = MIN_FEE_PER_BYTE * trsSize
+	    # Set MIN_FEE_PER_BYTE = 0 for the first MAX_BLOCK_HEIGHT_ZERO_FEE_PER_BYTE blocks.
+        MIN_FEE_PER_BYTE = 0
+    trsSize = length(encodeTransaction(trs))
+    minFee = MIN_FEE_PER_BYTE * trsSize
     if trs.fee < minFee:
         raise Exception("Insufficient transaction fee")
     senderAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
@@ -378,4 +366,3 @@ TBA
 [lip-0013]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0013.md
 [lip-0040]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0040.md
 [lip-0049#ccmschema]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#cross-chain-message-schema
-[lip-0057#execution]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0057.md#execution

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -194,6 +194,7 @@ We further use the utility function `getMainchainID()` defined in [LIP 0037][lip
 | `TOKEN_ID_NOT_NATIVE` | uint32 | 12 | Used when the specified token ID is not native to the chain. |
 | `INSUFFICIENT_ESCROW_BALANCE` | uint32 | 13 | Used when the escrowed account does not have sufficient balance. |
 | `INVALID_RECEIVING_CHAIN` | uint32 | 14 | Used when, during the cross-chain token transfer, the receiving chain is set to be equal to the sending chain. |
+| `RECEIVING_CHAIN_NOT_ACTIVE` | uint32 | 15 | Used when, during the cross-chain token transfer, the receiving chain is not active. |
 
 ### Type Definition
 
@@ -510,6 +511,9 @@ def verify(trs: Transaction) -> None:
 
     if receivingChainID == OWN_CHAIN_ID:
         raise Exception("Receiving chain cannot be the sending chain.")
+
+    if not Interoperability.isChannelActive(receivingChainID):
+        raise Exception("Receiving chain is not active.")    
 
     # Transfer is only possible for tokens native to either sending or receiving chain.
     tokenChainID = getChainID(tokenID) # The native chain of the token used for the transaction.
@@ -1920,6 +1924,10 @@ def transferCrossChain(
     if receivingChainID == OWN_CHAIN_ID:
         emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, INVALID_RECEIVING_CHAIN)
         raise Exception("Receiving chain cannot be the sending chain.")
+
+    if not Interoperability.isChannelActive(receivingChainID):
+        emitFailedCrossChainTransferEvent(senderAddress, tokenID, amount, receivingChainID, recipientAddress, RECEIVING_CHAIN_NOT_ACTIVE)
+        raise Exception("Receiving chain is not active.")
 
     # Balance checks.
     balanceChecks: dict[TokenID, uint64] = {}

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-06-12
+Updated: 2023-07-03
 ```
 
 ## Abstract


### PR DESCRIPTION
Resolves Issue [#393](https://github.com/LiskHQ/lips/issues/393).