### PR TITLE
Verify sparse Merkle tree inclusion proofs in command exectutions 

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-07-03
+Updated: 2023-07-12
 Requires: 0043, 0049, 0053, 0054
 ```
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -171,6 +171,8 @@ In this section, we specify the substores that are part of the Interoperability 
 | `EVENT_NAME_CCM_PROCESSED` | string | "ccmProcessed" | Name of the cross-chain message processed event. |
 | `EVENT_NAME_TERMINATED_STATE_CREATED` | string | "terminatedStateCreated" | Name of the terminated state account created event. |
 | `EVENT_NAME_TERMINATED_OUTBOX_CREATED` | string | "terminatedOutboxCreated"| Name of the terminated outbox created event. |
+| `EVENT_NAME_INVALID_SMT_VERIFICATION` | string | "invalidSMTVerification"| Name of the invalid sparse Merkle tree verification event. |
+| `EVENT_NAME_INVALID_RMT_VERIFICATION` | string | "invalidRMTVerification"| Name of the invalid regular Merkle tree verification event. |
 | **CCM Processed Event Results** | | | |
 | `CCM_PROCESSED_RESULT_APPLIED` | uint32 | 0 | Value of `result` of CCM Processed Event if CCM is applied. |
 | `CCM_PROCESSED_RESULT_FORWARDED` | uint32 | 1 | Value of `result` of CCM Processed Event if CCM is forwarded. |
@@ -1274,6 +1276,42 @@ This event has `name = EVENT_NAME_TERMINATED_OUTBOX_CREATED`. This event is emit
 ##### Data
 
 The data property follows the `terminatedOutboxAccountSchema` schema given [above](#json-schema-6).
+
+#### InvalidSMTVerification
+
+This event has `name = EVENT_NAME_INVALID_SMT_VERIFICATION`. This event is emitted when the an inclusion proof for a sparse Merkle tree is invalid.
+
+##### Topics
+
+The event just has the default topic.
+
+##### Data
+
+```java
+invalidSMTVerificationSchema = {
+    "type": "object",
+    "required": [],
+    "properties": {}
+}
+```
+
+#### InvalidRMTVerification
+
+This event has `name = EVENT_NAME_INVALID_RMT_VERIFICATION`. This event is emitted when the an inclusion proof for a regular Merkle tree is invalid.
+
+##### Topics
+
+The event just has the default topic.
+
+##### Data
+
+```java
+invalidRMTVerificationSchema = {
+    "type": "object",
+    "required": [],
+    "properties": {}
+}
+```
 
 ### Protocol Logic for Other Modules
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -1071,6 +1071,10 @@ The `verifyValidatorsUpdate` function verifies the validity of a validators upda
 
 The `calculateNewActiveValidators` function calculates the new active validators of a chain account based on the `activeValidatorsUpdate` property of a CCU. It is specified in [LIP 0053][lip-0053].
 
+#### verifyOutboxRootWitness
+
+The `verifyOutboxRootWitness` function verifies the validity of the outbox root witness of the inbox update of a CCU. It is specified in [LIP 0053][lip-0053].
+
 #### verifyPartnerChainOutboxRoot
 
 The `verifyPartnerChainOutboxRoot` function verifies the validity of the outbox root of a partner chain. It is specified in [LIP 0053][lip-0053].

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -416,6 +416,10 @@ def beforeCrossChainMessagesExecution(ccu: CCU) -> None:
     verifyCertificateSignature(ccu)
 
     if ccu.params.inboxUpdate is not empty:
+        # This check is expensive. Therefore, it is done in the execute step instead of the verify
+        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+        # costly CCU verifications without paying fees.
+        verifyPartnerChainOutboxRoot(ccu)
         # Initialize the relayer account for the message fee token.
         # This is necessary to ensure that the relayer can receive the CCM fees
         # If the account already exists, nothing is done.
@@ -637,12 +641,6 @@ def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
 
-    if ccu.params.inboxUpdate is not empty:
-        # This check is expensive. Therefore, it is done in the execute step instead of the verify
-        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
-        # costly CCU verifications without paying fees.
-        verifyPartnerChainOutboxRoot(ccu)
-
     try:
         beforeCrossChainMessagesExecution(ccu)
     except:
@@ -709,12 +707,6 @@ _Figure 2: A schematic of the steps of a sidechain CCU execution. Some details a
 def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
-
-    if ccu.params.inboxUpdate is not empty:
-        # This check is expensive. Therefore, it is done in the execute step instead of the verify
-        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
-        # costly CCU verifications without paying fees.
-        verifyPartnerChainOutboxRoot(ccu)
 
     try:
         beforeCrossChainMessagesExecution(ccu)

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -246,6 +246,25 @@ def calculateNewActiveValidators(activeValidators: list[ActiveValidator], blsKey
     return [v for v in newActiveValidators if v.bftWeight > 0]
 ```
 
+#### verifyOutboxRootWitness
+
+```python
+def verifyOutboxRootWitness(ccu: CCU) -> None:
+    outboxRootWitness = ccu.params.inboxUpdate.outboxRootWitness
+    # The outbox root witness properties must be set either both to their default values
+    # or both to a non-default value.
+    if outboxRootWitness.bitmap == EMPTY_BYTES and len(outboxRootWitness.siblingHashes) > 0:
+        raise Exception("The bitmap in the outbox root witness must be non-mepty if the sibling hashes are non-empty.")
+    if outboxRootWitness.bitmap != EMPTY_BYTES and len(outboxRootWitness.siblingHashes) == 0:
+        raise Exception("The sibling hashes in the outbox root witness must be non-mepty if the bitmap is non-empty.")
+
+    # The outbox root witness is empty if and only if the certificate is empty
+    if outboxRootWitness.bitmap == EMPTY_BYTES and len(ccu.params.certificate) > 0:
+        raise Exception("The outbox root witness must be non-empty to authenticate the new partnerChainOutboxRoot.")
+    if outboxRootWitness.bitmap != EMPTY_BYTES  and len(ccu.params.certificate) == 0:
+        raise Exception("The outbox root witness can be non-empty only if the certificate is non-empty.")
+```
+
 #### verifyPartnerChainOutboxRoot
 
 ```python
@@ -262,23 +281,9 @@ def verifyPartnerChainOutboxRoot(ccu: CCU) -> None:
     # because all messages have been included in the CCU.
     newInboxRoot = calculateRootFromRightWitness(inboxTree.size, inboxTree.appendPath, ccu.params.inboxUpdate.messageWitnessHashes)
 
-
-    outboxRootWitness = ccu.params.inboxUpdate.outboxRootWitness
-    # The outbox root witness properties must be set either both to their default values
-    # or both to a non-default value.
-    if outboxRootWitness.bitmap == EMPTY_BYTES and len(outboxRootWitness.siblingHashes) > 0:
-        raise Exception("The bitmap in the outbox root witness must be non-mepty if the sibling hashes are non-empty.")
-    if outboxRootWitness.bitmap != EMPTY_BYTES and len(outboxRootWitness.siblingHashes) == 0:
-        raise Exception("The sibling hashes in the outbox root witness must be non-mepty if the bitmap is non-empty.")
-
-    # The outbox root witness is empty if and only if the certificate is empty
-    if outboxRootWitness.bitmap == EMPTY_BYTES and len(ccu.params.certificate) > 0:
-        raise Exception("The outbox root witness must be non-empty to authenticate the new partnerChainOutboxRoot.")
-    if outboxRootWitness.bitmap != EMPTY_BYTES  and len(ccu.params.certificate) == 0:
-        raise Exception("The outbox root witness can be non-empty only if the certificate is non-empty.")
-
     # Verification for non-empty certificates.
     if len(ccu.params.certificate) > 0:
+        outboxRootWitness = ccu.params.inboxUpdate.outboxRootWitness
         outboxKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_OUTBOX_ROOT + sha256(OWN_CHAIN_ID)
         proof = {
             siblingHashes: outboxRootWitness.siblingHashes,
@@ -330,6 +335,9 @@ def verifyCommon(ccu: CCU) -> None:
     validatorsUpdate = ccu.params.activeValidatorsUpdate
     if len(validatorsUpdate.blsKeysUpdate) > 0 or len(validatorsUpdate.bftWeightsUpdate) > 0 or validatorsUpdate.bftWeightsUpdateBitmap != EMPTY_BYTES or ccu.params.certificateThreshold != validators(ccu.params.sendingChainID).certificateThreshold:
         verifyValidatorsUpdate(ccu)
+
+    if ccu.params.inboxUpdate is not empty:
+        verifyOutboxRootWitness(ccu)
 ```
 
 #### updateValidators

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-update-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-06-08
+Updated: 2023-07-12
 Requires: 0045, 0049, 0058, 0061
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -330,8 +330,6 @@ def verifyCommon(ccu: CCU) -> None:
     validatorsUpdate = ccu.params.activeValidatorsUpdate
     if len(validatorsUpdate.blsKeysUpdate) > 0 or len(validatorsUpdate.bftWeightsUpdate) > 0 or validatorsUpdate.bftWeightsUpdateBitmap != EMPTY_BYTES or ccu.params.certificateThreshold != validators(ccu.params.sendingChainID).certificateThreshold:
         verifyValidatorsUpdate(ccu)
-    if ccu.params.inboxUpdate is not empty:
-        verifyPartnerChainOutboxRoot(ccu)
 ```
 
 #### updateValidators
@@ -630,6 +628,13 @@ _Figure 1: A schematic of the steps of a mainchain CCU execution. Some details a
 def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
+
+    if ccu.params.inboxUpdate is not empty:
+        # This check is expensive. Therefore, it is done in the execute step instead of the verify
+        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+        # costly CCU verifications without paying fees.
+        verifyPartnerChainOutboxRoot(ccu)
+
     try:
         beforeCrossChainMessagesExecution(ccu)
     except:
@@ -696,6 +701,13 @@ _Figure 2: A schematic of the steps of a sidechain CCU execution. Some details a
 def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
+
+    if ccu.params.inboxUpdate is not empty:
+        # This check is expensive. Therefore, it is done in the execute step instead of the verify
+        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+        # costly CCU verifications without paying fees.
+        verifyPartnerChainOutboxRoot(ccu)
+
     try:
         beforeCrossChainMessagesExecution(ccu)
     except:

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -221,21 +221,18 @@ def verify(trs: Transaction) -> None:
     if recoveryModule does not have a recover function:
         raise Exception("Module is not recoverable.")
 
-    queryKeys = []
-
-    # Calculate store prefix from the module name according to LIP 0040.
-    storePrefix = module_name_to_store_prefix(trsParams.module)
+    keys = []
 
     for entry in trsParams.storeEntries:
         if entry.storeValue is EMPTY_BYTES:
             raise Exception("Recovered store value cannot be empty.")
 
-        queryKey = storePrefix + entry.substorePrefix + sha256(entry.storeKey)
-        queryKeys.append(queryKey)
+        key = entry.substorePrefix + sha256(entry.storeKey)
+        keys.append(key)
     
-    # Check that all query keys are pariwise distinct, 
+    # Check that all keys are pariwise distinct, 
     # meaning that we are not trying to recover the same entry twice.
-    if len(queryKeys) != len(set(queryKeys)):
+    if len(keys) != len(set(keys)):
         raise Exception("Recovered store keys are not pairwise distinct.")
 ```
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -383,10 +383,15 @@ def verify(trs: Transaction) -> None:
     if len(trsParams.idxs) != len(set(trsParams.idxs)):
         raise Exception("Cross-chain message indexes are not unique.")
     
-    # Check that the CCMs are still pending. We can check only the first one,
+    # Check that the CCMs are still pending. We check only the first one,
     # as the idxs are sorted in ascending order.
     if trsParams.idxs[0] < terminatedOutboxAccount(trsParams.chainID).partnerChainInboxSize:
         raise Exception("Cross-chain message is not pending.")
+
+    # Check that the CCM indices do not exceed the outbox size. We check only the last one,
+    # as the idxs are sorted in ascending order.
+    if terminatedOutboxAccount(trsParams.chainID).outboxSize <= trsParams.idxs[-1]:
+        raise Exception("Cross-chain message was never in the outbox.")
 
     # Process basic checks for all CCMs.
     for ccmBytes in trsParams.crossChainMessages:

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -671,8 +671,10 @@ def verify(trs: Transaction) -> None:
 
     sidechainAccount = decode(chainDataSchema, trsParams.sidechainAccount)
     validateObjectSchema(chainDataSchema, sidechainAccount)
-    # The command fails if the sidechain is not terminated and did not violate the liveness requirement.
-    if sidechainAccount.status != CHAIN_STATUS_TERMINATED
+    # The sidechain must either be terminated or must have violated the liveness limit while being active.
+    if sidechainAccount.status == CHAIN_STATUS_REGISTERED:
+        raise Exception("Sidechain is not terminated.")
+    if sidechainAccount.status == CHAIN_STATUS_ACTIVE
         and chainAccount(getMainchainID()).lastCertificate.timestamp - sidechainAccount.lastCertificate.timestamp <= LIVENESS_LIMIT:
         raise Exception("Sidechain is not terminated.")
 ```

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -369,7 +369,7 @@ messageRecoveryParams = {
 }
 ```
 
-* `chainID`: The ID of the terminated sidechain identifyng the terminated outbox from which messages will be recovered.
+* `chainID`: The ID of the terminated sidechain identifying the terminated outbox from which messages will be recovered.
 * `crossChainMessages`: The cross-chain messages to be recovered.
 * `idxs`: The indices of the messages to be recovered.
 * `siblingHashes`: The sibling hashes of the inclusion proof of the cross-shain messages in the sidechain outbox.

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -670,6 +670,7 @@ def verify(trs: Transaction) -> None:
         raise Exception("Sidechain is already terminated.")
 
     sidechainAccount = decode(chainDataSchema, trsParams.sidechainAccount)
+    validateObjectSchema(chainDataSchema, sidechainAccount)
     # The command fails if the sidechain is not terminated and did not violate the liveness requirement.
     if sidechainAccount.status != CHAIN_STATUS_TERMINATED
         and chainAccount(getMainchainID()).lastCertificate.timestamp - sidechainAccount.lastCertificate.timestamp <= LIVENESS_LIMIT:

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -786,7 +786,8 @@ def verify(trs: Transaction) -> None:
         raise Exception("Terminated outbox account already exists.")
 
     # The command fails if the channel parameter is not a valid serialized channel.
-    validateObjectSchema(channelDataSchema, trsParams.channel)
+    partnerChannel = decode(channelDataSchema, trsParams.channel)
+    validateObjectSchema(channelDataSchema, partnerChannel)
 ```
 
 #### Execution

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -402,6 +402,15 @@ def verify(trs: Transaction) -> None:
         # The sending chain must be live.
         if not isLive(ccm.sendingChainID):
             raise Exception("Cross-chain message sending chain is not live.")
+```
+
+The function `validateFormat` is defined in [LIP 0049][lip-0049#validateFormat].
+
+#### Execution
+
+```python
+def execute(trs: Transaction) -> None:
+    trsParams = decode(messageRecoveryParams, trs.params)
 
     # Check the inclusion proof against the sidechain outbox root.
     proof = {
@@ -416,15 +425,6 @@ def verify(trs: Transaction) -> None:
         terminatedOutboxAccount(trsParams.chainID).outboxRoot
         ) == False:
         raise Exception("Message recovery proof of inclusion is not valid.")
-```
-
-The function `validateFormat` is defined in [LIP 0049][lip-0049#validateFormat].
-
-#### Execution
-
-```python
-def execute(trs: Transaction) -> None:
-    trsParams = decode(messageRecoveryParams, trs.params)
 
     recoveredCCMs = []
     for ccmBytes in trsParams.crossChainMessages:

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -375,13 +375,10 @@ def verify(trs: Transaction) -> None:
     if len(trsParams.idxs) != len(trsParams.crossChainMessages):
         raise Exception("Inclusion proof indices and cross-chain messages do not have the same length.")
 
-    # Check that the idxs are sorted in ascending order.
-    if trsParams.idxs != sorted(trsParams.idxs):
-        raise Exception("Cross-chain message indexes are not sorted in ascending order.")
-
-    # Check that the idxs are unique.
-    if len(trsParams.idxs) != len(set(trsParams.idxs)):
-        raise Exception("Cross-chain message indexes are not unique.")
+    # Check that the idxs are strictly increasing
+    for i in range(len(trsParams.idxs)-1):
+        if not (trsParams.idxs[i] < trsParams.idxs[i+1]):
+            raise Exception("Cross-chain message indexes are not strictly increasing.")
     
     # Check that the CCMs are still pending. We check only the first one,
     # as the idxs are sorted in ascending order.

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -221,18 +221,18 @@ def verify(trs: Transaction) -> None:
     if recoveryModule does not have a recover function:
         raise Exception("Module is not recoverable.")
 
-    keys = []
+    keys = set()
 
     for entry in trsParams.storeEntries:
         if entry.storeValue is EMPTY_BYTES:
             raise Exception("Recovered store value cannot be empty.")
 
-        key = entry.substorePrefix + sha256(entry.storeKey)
-        keys.append(key)
+        key = entry.substorePrefix + entry.storeKey
+        keys.add(key)
     
     # Check that all keys are pariwise distinct, 
     # meaning that we are not trying to recover the same entry twice.
-    if len(keys) != len(set(keys)):
+    if len(keys) != len(trsParams.storeEntries):
         raise Exception("Recovered store keys are not pairwise distinct.")
 ```
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-sidechain-recovery-mechani
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-06-22
+Updated: 2023-07-12
 Requires: 0040, 0045, 0049, 0051
 ```
 

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -221,10 +221,7 @@ def verify(trs: Transaction) -> None:
     if recoveryModule does not have a recover function:
         raise Exception("Module is not recoverable.")
 
-    terminatedStateRoot = terminatedStateAccount(trsParams.chainID).stateRoot
-
     queryKeys = []
-    storeQueries = []
 
     # Calculate store prefix from the module name according to LIP 0040.
     storePrefix = module_name_to_store_prefix(trsParams.module)
@@ -235,22 +232,11 @@ def verify(trs: Transaction) -> None:
 
         queryKey = storePrefix + entry.substorePrefix + sha256(entry.storeKey)
         queryKeys.append(queryKey)
-        query = {
-            "key": queryKey,
-            "value": sha256(entry.storeValue),
-            "bitmap": entry.bitmap
-        }
-        storeQueries.append(query)
     
     # Check that all query keys are pariwise distinct, 
     # meaning that we are not trying to recover the same entry twice.
     if len(queryKeys) != len(set(queryKeys)):
         raise Exception("Recovered store keys are not pairwise distinct.")
-
-    proofOfInclusionStores = { siblingHashes: trsParams.siblingHashes, queries : storeQueries }
-
-    if SMTVerify(queryKeys, proofOfInclusionStores, terminatedStateRoot) == False:
-        raise Exception("State recovery proof of inclusion is not valid.")
 ```
 
 The function `module_name_to_store_prefix` is defined in [LIP 0040][lip-0040#module-store-prefix].
@@ -261,10 +247,34 @@ The function `module_name_to_store_prefix` is defined in [LIP 0040][lip-0040#mod
 def execute(trs: Transaction) -> None:
     trsParams = decode(stateRecoveryParams, trs.params)
 
-    storeQueries = []
+    terminatedStateRoot = terminatedStateAccount(trsParams.chainID).stateRoot
+
+    queryKeys = []
+    storeQueriesVerify = []
+
+    # Calculate store prefix from the module name according to LIP 0040.
+    storePrefix = module_name_to_store_prefix(trsParams.module)
+
+    for entry in trsParams.storeEntries:
+        queryKey = storePrefix + entry.substorePrefix + sha256(entry.storeKey)
+        queryKeys.append(queryKey)
+        query = {
+            "key": queryKey,
+            "value": sha256(entry.storeValue),
+            "bitmap": entry.bitmap
+        }
+        storeQueriesVerify.append(query)
+
+    proofOfInclusionStores = { siblingHashes: trsParams.siblingHashes, queries : storeQueriesVerify }
+
+    # The SMT verification step is computationally expensive. Therefore, it is done in the
+    # execution step such that the transaction fee must be paid.
+    if SMTVerify(queryKeys, proofOfInclusionStores, terminatedStateRoot) == False:
+        raise Exception("State recovery proof of inclusion is not valid.")
+
+    storeQueriesUpdate = []
 
     recoveryModule = module associated with trsParams.module
-    storePrefix = module_name_to_store_prefix(trsParams.module)
     for entry in trsParams.storeEntries:
         # The recover function corresponding to trsParams.module applies the recovery logic.
         recoveryModule.recover(trsParams.chainID, entry.substorePrefix, entry.storeKey, entry.storeValue)
@@ -275,9 +285,9 @@ def execute(trs: Transaction) -> None:
             "value": sha256(emptyStore),
             "bitmap": entry.bitmap
         }
-        storeQueries.append(query)
+        storeQueriesUpdate.append(query)
 
-    terminatedStateAccount(trsParams.chainID).stateRoot = SMTCalculateRoot(trsParams.siblingHashes, storeQueries)
+    terminatedStateAccount(trsParams.chainID).stateRoot = SMTCalculateRoot(trsParams.siblingHashes, storeQueriesUpdate)
 ```
 
 #### Recover Function

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -788,6 +788,13 @@ def verify(trs: Transaction) -> None:
 
     # The command fails if the channel parameter is not a valid serialized channel.
     validateObjectSchema(channelDataSchema, trsParams.channel)
+```
+
+#### Execution
+
+```python
+def execute(trs: Transaction) -> None:
+    trsParams = decode(messageRecoveryInitializationParams, trs.params)
     
     queryKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_CHANNEL_DATA + sha256(OWN_CHAIN_ID)
 
@@ -799,15 +806,10 @@ def verify(trs: Transaction) -> None:
 
     proofOfInclusion = { siblingHashes: trsParams.siblingHashes, queries : [query] }
 
+    # The SMT verification step is computationally expensive. Therefore, it is done in the
+    # execution step such that the transaction fee must be paid.
     if SMTVerify([queryKey], proofOfInclusion, terminatedStateAccount(trsParams.chainID).stateRoot) == False:
         raise Exception("Message recovery initialization proof of inclusion is not valid.")
-```
-
-#### Execution
-
-```python
-def execute(trs: Transaction) -> None:
-    trsParams = decode(messageRecoveryInitializationParams, trs.params)
     
     partnerChannel = decode(channelDataSchema, trsParams.channel)
     createTerminatedOutboxAccount(

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -110,7 +110,7 @@ Furthermore, for the rest of this section:
 * Let `SMTVerify` be the `verify` function specified in [LIP 0039][lip-0039].
 * Let `SMTCalculateRoot` be the `calculateRoot` function specified in [LIP 0039][lip-0039].
 
-We also define the following auxiliary function to make the specifications more readable.
+We also define the following auxiliary functions to make the specifications more readable.
 
 ```python
 def emitCCMEvent(ccm: CCM, result: uint32, code: uint32) -> None:
@@ -119,6 +119,22 @@ def emitCCMEvent(ccm: CCM, result: uint32, code: uint32) -> None:
         name = EVENT_NAME_CCM_PROCESSED,
         data = {"ccm": ccm, "result": result, "code": code},
         topics = [ccm.sendingChainID, ccm.receivingChainID]
+    )
+
+def emitInvalidSMTVerificationEvent() -> None:
+    emitEvent(
+        module = MODULE_NAME_INTEROPERABILITY,
+        name = EVENT_NAME_INVALID_SMT_VERIFICATION,
+        data = {},
+        topic = []
+    )
+
+def emitInvalidRMTVerificationEvent() -> None:
+    emitEvent(
+        module = MODULE_NAME_INTEROPERABILITY,
+        name = EVENT_NAME_INVALID_RMT_VERIFICATION,
+        data = {},
+        topic = []
     )
 ```
 
@@ -267,6 +283,7 @@ def execute(trs: Transaction) -> None:
     # The SMT verification step is computationally expensive. Therefore, it is done in the
     # execution step such that the transaction fee must be paid.
     if SMTVerify(queryKeys, proofOfInclusionStores, terminatedStateRoot) == False:
+        emitInvalidSMTVerificationEvent()
         raise Exception("State recovery proof of inclusion is not valid.")
 
     storeQueriesUpdate = []
@@ -426,6 +443,7 @@ def execute(trs: Transaction) -> None:
         proof,
         terminatedOutboxAccount(trsParams.chainID).outboxRoot
         ) == False:
+        emitInvalidRMTVerificationEvent()
         raise Exception("Message recovery proof of inclusion is not valid.")
 
     recoveredCCMs = []
@@ -699,9 +717,11 @@ def execute(trs: Transaction) -> None:
     # execution step such that the transaction fee must be paid.
     if terminatedStateAccount(trsParams.chainID) exists:
         if SMTVerify([queryKey], proofOfInclusion, terminatedStateAccount(trsParams.chainID).mainchainStateRoot) == False:
+            emitInvalidSMTVerificationEvent()
             raise Exception("State recovery initialization proof of inclusion is not valid.")
     else:
         if SMTVerify([queryKey], proofOfInclusion, chainAccount(getMainchainID()).lastCertificate.stateRoot) == False:
+            emitInvalidSMTVerificationEvent()
             raise Exception("State recovery initialization proof of inclusion is not valid.")
 
     sidechainAccount = decode(chainDataSchema, trsParams.sidechainAccount)
@@ -812,6 +832,7 @@ def execute(trs: Transaction) -> None:
     # The SMT verification step is computationally expensive. Therefore, it is done in the
     # execution step such that the transaction fee must be paid.
     if SMTVerify([queryKey], proofOfInclusion, terminatedStateAccount(trsParams.chainID).stateRoot) == False:
+        emitInvalidSMTVerificationEvent()
         raise Exception("Message recovery initialization proof of inclusion is not valid.")
     
     partnerChannel = decode(channelDataSchema, trsParams.channel)

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -691,10 +691,10 @@ def verify(trs: Transaction) -> None:
     validateObjectSchema(chainDataSchema, sidechainAccount)
     # The sidechain must either be terminated or must have violated the liveness limit while being active.
     if sidechainAccount.status == CHAIN_STATUS_REGISTERED:
-        raise Exception("Sidechain is not terminated.")
+        raise Exception("Sidechain has status registered.")
     if sidechainAccount.status == CHAIN_STATUS_ACTIVE
         and chainAccount(getMainchainID()).lastCertificate.timestamp - sidechainAccount.lastCertificate.timestamp <= LIVENESS_LIMIT:
-        raise Exception("Sidechain is not terminated.")
+        raise Exception("Sidechain is still active and obeys the liveness requirment.")
 ```
 
 #### Execution

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -122,7 +122,7 @@ def emitCCMEvent(ccm: CCM, result: uint32, code: uint32) -> None:
     )
 
 def emitInvalidSMTVerificationEvent() -> None:
-    emitEvent(
+    emitPersistentEvent(
         module = MODULE_NAME_INTEROPERABILITY,
         name = EVENT_NAME_INVALID_SMT_VERIFICATION,
         data = {},
@@ -130,7 +130,7 @@ def emitInvalidSMTVerificationEvent() -> None:
     )
 
 def emitInvalidRMTVerificationEvent() -> None:
-    emitEvent(
+    emitPersistentEvent(
         module = MODULE_NAME_INTEROPERABILITY,
         name = EVENT_NAME_INVALID_RMT_VERIFICATION,
         data = {},

--- a/proposals/lip-0054.md
+++ b/proposals/lip-0054.md
@@ -675,6 +675,13 @@ def verify(trs: Transaction) -> None:
     if sidechainAccount.status != CHAIN_STATUS_TERMINATED
         and chainAccount(getMainchainID()).lastCertificate.timestamp - sidechainAccount.lastCertificate.timestamp <= LIVENESS_LIMIT:
         raise Exception("Sidechain is not terminated.")
+```
+
+#### Execution
+
+```python
+def execute(trs: Transaction) -> None:
+    trsParams = decode(stateRecoveryInitializationParams, trs.params)
 
     queryKey = STORE_PREFIX_INTEROPERABILITY + SUBSTORE_PREFIX_CHAIN_DATA + sha256(trsParams.chainID)
 
@@ -686,19 +693,14 @@ def verify(trs: Transaction) -> None:
 
     proofOfInclusion = { "siblingHashes": trsParams.siblingHashes, "queries" : [query] }
 
+    # The SMT verification step is computationally expensive. Therefore, it is done in the
+    # execution step such that the transaction fee must be paid.
     if terminatedStateAccount(trsParams.chainID) exists:
         if SMTVerify([queryKey], proofOfInclusion, terminatedStateAccount(trsParams.chainID).mainchainStateRoot) == False:
             raise Exception("State recovery initialization proof of inclusion is not valid.")
     else:
         if SMTVerify([queryKey], proofOfInclusion, chainAccount(getMainchainID()).lastCertificate.stateRoot) == False:
             raise Exception("State recovery initialization proof of inclusion is not valid.")
-```
-
-#### Execution
-
-```python
-def execute(trs: Transaction) -> None:
-    trsParams = decode(stateRecoveryInitializationParams, trs.params)
 
     sidechainAccount = decode(chainDataSchema, trsParams.sidechainAccount)
     if terminatedStateAccount(trsParams.chainID) exists:


### PR DESCRIPTION
This PR does the following:
- fixes #398 
- emit events in LIP 0054 for inclusion proof failures 
- add additional cheap check in verification of message recovery command to ensure that the indices of all provides messages are in the range `[0, ..., outboxSize -1]`
- improve checks (in terms of efficiency) in message recovery command to ensure uniqueness and increasing order  
- fix a bug in state recovery initialization command (it was accepting a chain account with status "registered" which should not be the case)
- add schema validation of sidechain account in state recovery initialization command
- fix schema validation of channel in message recovery initialization command