### PR TITLE
Add `getMessageFeeTokenIDFromCCM` method to Interoperability module

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -1393,6 +1393,9 @@ def getChainAccount(chainID: ChainID) -> ChainAccount:
 
 ```python
 def getMessageFeeTokenID(chainID: ChainID) -> TokenID:
+    if chainID == ownChainAccount.chainID:
+        raise Exception('Channel with own chain account does not exist.')
+        
     # Processing on a sidechain.
     if ownChainAccount.chainID != getMainchainID():
         # Check for direct channel.

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -1405,6 +1405,13 @@ def getMessageFeeTokenID(chainID: ChainID) -> TokenID:
     return channel(chainID).messageFeeTokenID
 ```
 
+#### getMessageFeeTokenIDFromCCM
+
+```python
+def getMessageFeeTokenIDFromCCM(ccm: CCM) -> TokenID:
+    return getMessageFeeTokenID(ccm.sendingChainID)
+```
+
 #### getMinReturnFeePerByte
 
 ```python

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-08-08
+Updated: 2023-08-10
 Requires: 0043, 0049, 0053, 0054
 ```
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-fee-module/318
 Status: Draft
 Type: Standards Track
 Created: 2021-08-09
-Updated: 2023-07-20
+Updated: 2023-08-10
 Requires: 0051
 ```
 

--- a/proposals/lip-0048.md
+++ b/proposals/lip-0048.md
@@ -342,7 +342,7 @@ def afterCommandExecute(trs: Transaction) -> None:
 def beforeCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     # The Token module handles checks on the ccm.fee validity
     # with respect to the escrow account of the ccm sending chain.
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    messageFeeTokenID = Interoperability.getMessageFeeTokenIDFromCCM(ccm)
     relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
 
     # The Token module beforeCrossChainCommandExecution needs to be called first
@@ -357,7 +357,7 @@ def beforeCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
 def afterCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     # The fee paid to the relayer is the difference between the message fee and the paid fees.
     relayerAddress = sha256(trs.senderPublicKey)[:LENGTH_ADDRESS]
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    messageFeeTokenID = Interoperability.getMessageFeeTokenIDFromCCM(ccm)
     Token.unlock(relayerAddress, MODULE_NAME_FEE, messageFeeTokenID, ccm.fee)
 
     burnConsumedFee = False if (ADDRESS_FEE_POOL is not None and Token.userSubstoreExists(ADDRESS_FEE_POOL, messageFeeTokenID)) else True

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -2539,7 +2539,7 @@ The following steps are executed as part of the execution of a cross-chain updat
 ```python
 def verifyCrossChainMessage(trs: Transaction, ccm: CCM) -> None:
     # This is getTokenIDLSK() for channels with the mainchain.
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.sendingChainID)
+    messageFeeTokenID = Interoperability.getMessageFeeTokenIDFromCCM(ccm)
     if getChainID(messageFeeTokenID) == OWN_CHAIN_ID:
         if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:
             raise Exception("Insufficient escrow amount.")
@@ -2551,7 +2551,7 @@ def verifyCrossChainMessage(trs: Transaction, ccm: CCM) -> None:
 def beforeCrossChainCommandExecution(trs: Transaction, ccm: CCM) -> None:
     relayerAddress = sha256(trs.senderPublicKey)[:ADDRESS_LENGTH]
 
-    messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID)
+    messageFeeTokenID = Interoperability.getMessageFeeTokenIDFromCCM(ccm)
     # If the chain is the fee token native chain, un-escrow before assigning fee to relayer.
     if getChainID(messageFeeTokenID) == OWN_CHAIN_ID:
         # This should never fail since it is checked in verifyCrossChainMessage.
@@ -2584,7 +2584,7 @@ This function is defined only in the Lisk mainchain.
 def beforeCrossChainMessageForwarding(trs: Transaction, ccm: CCM, ccmFailed: bool) -> None:
     if ccm.fee > 0:
         # This should never fail since it is checked in verifyCrossChainMessage.
-        messageFeeTokenID = Interoperability.getMessageFeeTokenID(ccm.receivingChainID)
+        messageFeeTokenID = Interoperability.getMessageFeeTokenIDFromCCM(ccm)
         if messageFeeTokenID != getTokenIDLSK():
             raise Exception("Message fee token should be LSK.")
         if escrowAmount(ccm.sendingChainID, messageFeeTokenID) < ccm.fee:

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-07-27
+Updated: 2023-08-10
 ```
 
 ## Abstract


### PR DESCRIPTION
Closes https://github.com/LiskHQ/lips/issues/436.