### PR TITLE
Add explicit decoding and verification of trs.params in LIP 0074

### DIFF
--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -575,7 +575,6 @@ The function [getAvailableBalance][getAvailableBalance] is defined in the Token 
 ```python
 def verify(trs: Transaction) -> None:
     trsParams = decode(createProposalParamsSchema, trs.params)
-    validateObjectSchema(createProposalParamsSchema, trsParams)
 
     senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     availableBalance = Token.getAvailableBalance(senderAddress, TOKEN_ID_POS)
@@ -666,7 +665,6 @@ voteOnProposalParamsSchema = {
 ```python
 def verify(trs: Transaction) -> None:
     trsParams = decode(voteOnProposalParamsSchema, trs.params)
-    validateObjectSchema(voteOnProposalParamsSchema, trsParams)
 
     if proposalsStore[trsParams.proposalIndex] does not exist:
         raise Exception("Proposal does not exist")

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-governance-module/401
 Status: Draft
 Type: Standards Track
 Created: 2023-07-26
-Updated: 2023-07-26
+Updated: 2023-08-11
 Required: LIP 0048, 0051, 0057
 ```
 

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -574,13 +574,16 @@ The function [getAvailableBalance][getAvailableBalance] is defined in the Token 
 
 ```python
 def verify(trs: Transaction) -> None:
+    trsParams = decode(createProposalParamsSchema, trs.params)
+    validateObjectSchema(createProposalParamsSchema, trsParams)
+
     senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     availableBalance = Token.getAvailableBalance(senderAddress, TOKEN_ID_POS)
     lockedBalance = PoS.getLockedStakedAmount(senderAddress)
     if availableBalance + lockedBalance < configStore.proposalCreationMinBalance:
         raise Exception("Insufficient token balance to create proposal")
 
-    validateProposal(trs.params.type, trs.params.data, trs.params.description)
+    validateProposal(trsParams.type, trsParams.data, trsParams.description)
 ```
 ##### Execution
 
@@ -588,6 +591,7 @@ The function [payFee][payFee] is defined in the Fee module, the function [lock][
 
 ```python
 def execute(trs: Transaction) -> None:
+    trsParams = decode(createProposalParamsSchema, trs.params)
     # non-trivial verification checks
     currentHeight = height of the block containing trs
     senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
@@ -612,9 +616,9 @@ def execute(trs: Transaction) -> None:
         "votesYes": 0,
         "votesNo": 0,
         "votesPass": 0,
-        "type": trs.params.type,
-        "description": trs.params.description,
-        "data": trs.params.data,
+        "type": trsParams.type,
+        "description": trsParams.description,
+        "data": trsParams.data,
         "status": PROPOSAL_STATUS_ACTIVE
     })
     indexStore.nextIndex = index + 1
@@ -625,7 +629,7 @@ def execute(trs: Transaction) -> None:
         data = {
             "creator": senderAddress,
             "index": index,
-            "type": trs.params.type
+            "type": trsParams.type
         },
         topics = [index.to_bytes(4, byteorder='big'), senderAddres]
     )
@@ -661,11 +665,14 @@ voteOnProposalParamsSchema = {
 
 ```python
 def verify(trs: Transaction) -> None:
-    if proposalsStore[trs.params.proposalIndex] does not exist:
+    trsParams = decode(voteOnProposalParamsSchema, trs.params)
+    validateObjectSchema(voteOnProposalParamsSchema, trsParams)
+
+    if proposalsStore[trsParams.proposalIndex] does not exist:
         raise Exception("Proposal does not exist")
-    if trs.params.decision > 2:
+    if trsParams.decision > 2:
         raise Exception("Decision does not exist")
-    if proposalsStore[trs.params.proposalIndex].status != PROPOSAL_STATUS_ACTIVE:
+    if proposalsStore[trsParams.proposalIndex].status != PROPOSAL_STATUS_ACTIVE:
         raise Exception("Proposal is not active")
 ```
 
@@ -675,7 +682,8 @@ The function [getLockedStakedAmount][getLockedStakedAmount] is defined in the Po
 
 ```python
 def execute(trs: Transaction) -> None:
-    index = trs.params.proposalIndex
+    trsParams = decode(voteOnProposalParamsSchema, trs.params)
+    index = trsParams.proposalIndex
     senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
     stakedAmount = PoS.getLockedStakedAmount(senderAddress)
     if votesStore[senderAddress] does not exist:
@@ -683,7 +691,7 @@ def execute(trs: Transaction) -> None:
 
     newVoteInfo = {
         "proposalIndex": index,
-        "decision": trs.params.decision,
+        "decision": trsParams.decision,
         "amount": stakedAmount
     }
     if votesStore[senderAddress] contains voteInfo with voteInfo.proposalIndex == index:
@@ -697,7 +705,7 @@ def execute(trs: Transaction) -> None:
         # replace the oldest element in the vote infos queue withe the newest
         replace an element voteInfo with smallest voteInfo.proposalIndex with newVoteInfo in votesStore[senderAddress]
     # vote
-    addVotes(index, stakedAmount, trs.params.decision)
+    addVotes(index, stakedAmount, trsParams.decision)
 
     emitEvent(
         module = MODULE_NAME_GOVERNANCE,
@@ -705,7 +713,7 @@ def execute(trs: Transaction) -> None:
         data = {
             "index": index,
             "voterAddress": senderAddress,
-            "decision": trs.params.decision,
+            "decision": trsParams.decision,
             "amount": stakedAmount
         },
         topics = [senderAddress, index.to_bytes(4, byteorder='big')]


### PR DESCRIPTION
The LIP treated `trs.params` as a decoded object. To align with the other LIPs and to be more explicit, command verification and execution performs:
`trsParams = decode(commandParamsSchema, trs.params)`.