### PR TITLE
Update `getTotalSupply` function in LIP 0051, add pseudocode to endpoint, clarify store logic

### DIFF
--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -1604,7 +1604,6 @@ def getTotalSupply() -> dict[TokenID, uint64]:
         tokenID = storeKey
         totalSupply[tokenID] = storeValue.totalSupply
     return totalSupply
-
 ```
 
 #### getEscrowedAmount

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -2636,7 +2636,7 @@ This section specifies the non-trivial or recommended endpoints of the Token mod
 This function returns token IDs for both native and non-native tokens supported by the chain.
 
 ```python
-def getSupportedTokens() -> list[TokenID]:
+def getSupportedTokens() -> list[str]:
     
     if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
         return ['*']
@@ -2644,18 +2644,20 @@ def getSupportedTokens() -> list[TokenID]:
     supportedTokenIDs = []
 
     # Add mainchain token
-    supportedTokenIDs.append(getMainchainID() + b'\x00'*4)
+    mainchainTokenID = getMainchainID() + b'\x00'*4
+    supportedTokenIDs.append(mainchainTokenID.hex())
     
     # Add native tokens
     for tokenID in supplyStore.keys():
-        supportedTokenIDs.append(tokenID)
+        supportedTokenIDs.append(tokenID.hex())
 
     # Add supported non-native tokens	
     for chainID in supportedTokens.keys():
         if supportedTokens(chainID).supportedTokenIDs == []:
-            supportedTokenIDs.append(chainID+"********")
+            supportedTokenIDs.append(chainID.hex() + '********')
         else:
-            supportedTokenIDs.extend(supportedTokens(chainID).supportedTokenIDs)
+            for tokenID in supportedTokens(chainID).supportedTokenIDs:
+                supportedTokenIDs.append(tokenID.hex())
 
     return supportedTokenIDs
 ```

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -2636,32 +2636,28 @@ This section specifies the non-trivial or recommended endpoints of the Token mod
 This function returns token IDs for both native and non-native tokens supported by the chain.
 
 ```python
-def getSupportedTokens() -> dict[list]:
-    # Native tokens
-    nativeTokenIDs = [tokenID for tokenID in supplyStore.keys()]
-
-    # Non-native tokens	
-    if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
-        return {
-            "nativeTokenIDs": nativeTokenIDs,
-            "supportedChainIDs": "All",
-            "supportedTokenIDs": "All"
-        }
-
-    supportedChainIDs = []
-    supportedTokenIDs = [getMainchainID()]
+def getSupportedTokens() -> list[TokenID]:
     
+    if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
+        return ['*']
+    
+    supportedTokenIDs = []
+
+    # Add mainchain token
+    supportedTokenIDs.append(getMainchainID() + b'\x00'*4)
+    
+    # Add native tokens
+    for tokenID in supplyStore.keys():
+        supportedTokenIDs.append(tokenID)
+
+    # Add supported non-native tokens	
     for chainID in supportedTokens.keys():
         if supportedTokens(chainID).supportedTokenIDs == []:
-            supportedChainIDs.append(chainID)
+            supportedTokenIDs.append(chainID+"********")
         else:
             supportedTokenIDs.extend(supportedTokens(chainID).supportedTokenIDs)
 
-    return {
-        "nativeTokenIDs": nativeTokenIDs,
-        "supportedChainIDs": supportedChainIDs,
-        "supportedTokenIDs": supportedTokenIDs
-    }
+    return supportedTokenIDs
 ```
 
 ## Backwards Compatibility

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -347,7 +347,7 @@ For the rest of this proposal:
 * Let `supplyStore(tokenID)` be the supply substore entry with store key `tokenID`, deserialized using the `supplyStoreSchema` schema.
   * Let `totalSupply(tokenID)` be the `totalSupply` property stored in `supplyStore(tokenID)`.
 * Let `supportedTokens(chainID)` be the supported tokens substore entry with store key `chainID`, deserialized using the `supportedTokensSchema` schema.
-* Whenever a function calls property of a non-existing substore entry, an error is thrown. For example, if a state change attemps to increase `availableBalance(address, tokenID)` while `userStore(address, tokenID)` does not exist, this results to an error.
+* Whenever a queried substore entry does not exist, an error is thrown. For example, if a state change attemps to increase `availableBalance(address, tokenID)` while `userStore(address, tokenID)` does not exist, this results to an error.
 
 ### Commands
 
@@ -2634,6 +2634,35 @@ This section specifies the non-trivial or recommended endpoints of the Token mod
 #### getSupportedTokens
 
 This function returns token IDs for both native and non-native tokens supported by the chain.
+
+```python
+def getSupportedTokens() -> dict[list]:
+    # Native tokens
+    nativeTokenIDs = [tokenID for tokenID in supplyStore.keys()]
+
+    # Non-native tokens	
+    if supportedTokens(ALL_SUPPORTED_TOKENS_KEY) exists:
+        return {
+            "nativeTokenIDs": nativeTokenIDs,
+            "supportedChainIDs": "All",
+            "supportedTokenIDs": "All"
+        }
+
+    supportedChainIDs = []
+    supportedTokenIDs = [getMainchainID()]
+    
+    for chainID in supportedTokens.keys():
+        if supportedTokens(chainID).supportedTokenIDs == []:
+            supportedChainIDs.append(chainID)
+        else:
+            supportedTokenIDs.extend(supportedTokens(chainID).supportedTokenIDs)
+
+    return {
+        "nativeTokenIDs": nativeTokenIDs,
+        "supportedChainIDs": supportedChainIDs,
+        "supportedTokenIDs": supportedTokenIDs
+    }
+```
 
 ## Backwards Compatibility
 

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-08-10
+Updated: 2023-08-15
 ```
 
 ## Abstract

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -1598,10 +1598,13 @@ def getLockedAmount(address: Address, module: Module, tokenID: TokenID) -> uint6
 #### getTotalSupply
 
 ```python
-def getTotalSupply(tokenID: TokenID) -> uint64:
-     if totalSupply(tokenID) does not exist:
-         raise Exception("Total supply entry does not exist.")
-     return totalSupply(tokenID)
+def getTotalSupply() -> dict[TokenID, uint64]:
+    totalSupply: dict[TokenID, uint64] = {}
+    for (storeKey, storeValue) in supplyStore.items():
+        tokenID = storeKey
+        totalSupply[tokenID] = storeValue.totalSupply
+    return totalSupply
+
 ```
 
 #### getEscrowedAmount

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -998,7 +998,7 @@ For a given number of Yes, No and Pass votes, the function checks whether the pr
 
 ```python
 def getVoteOutcome(amountYes: uint64, amountNo: uint64, amountPass: uint64) -> uint32:
-    electorate = Token.getTotalSupply(TOKEN_ID_POS)
+    electorate = Token.getTotalSupply()[TOKEN_ID_POS]
     turnout = amountYes + amountNo + amountPass
     if amountYes * amountYes * turnout > amountNo * amountNo * electorate:
         return PROPOSAL_STATUS_FINISHED_ACCEPTED
@@ -1066,7 +1066,7 @@ def beforeTransactionsExecute(b: Block) -> None:
         turnout = proposal.votesYes + proposal.votesNo + proposal.votesPass
         # check quorum without division to avoid float arithmetic
         Token.unlock(proposal.creator, MODULE_NAME_GOVERNANCE, TOKEN_ID_POS, proposal.depositAmount)
-        if turnout * 1000000 < configStore.quorumPercentage * Token.getTotalSupply(TOKEN_ID_POS):
+        if turnout * 1000000 < configStore.quorumPercentage * Token.getTotalSupply()[TOKEN_ID_POS]:
             # quorum is failed
             proposalsStore[index].status = PROPOSAL_STATUS_FAILED_QUORUM
             Token.burn(proposal.creator, TOKEN_ID_POS, proposal.depositAmount)

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-governance-module/401
 Status: Draft
 Type: Standards Track
 Created: 2023-07-26
-Updated: 2023-08-11
+Updated: 2023-08-15
 Required: LIP 0048, 0051, 0057
 ```
 


### PR DESCRIPTION
Resolves Issue #448.

Additionally, following two changes are proposed:
1. In the [Store notation](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#store-notation) subsection, the statement "Whenever a function calls property of a non-existing substore entry, an error is thrown." is changed to "Whenever a queried substore entry does not exist, an error is thrown.", in order to conform to the description and original intention of [PR 259](https://github.com/LiskHQ/lips/pull/259), where it was introduced.
2. The pseudocode for `getSupportedTokens` endpoint has been added.