### PR TITLE
Fix "if" checks in forward() (LIP 49)

### DIFF
--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -351,18 +351,12 @@ def forward(trs: Transaction, ccm: CCM) -> None:
         return
 
     ccmFailed = False
-    # If the chain account does not exist, do not continue.
-    if chainAccount(ccm.receivingChainID) does not exist:
+    # If the chain account does not exist, or if the chain is registered do not continue.
+    if chainAccount(ccm.receivingChainID) does not exist or chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
         ccmFailed = True
         ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
         ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
         
-    # If the chain is registered, do not continue.
-    elif chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
-        ccmFailed = True  
-        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
-        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
-
     elif not isLive(ccm.receivingChainID):
         ccmFailed = True
         ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-cross-chain-messages/299
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-07-17
+Updated: 2023-08-17
 Requires: 0053
 ```
 

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -358,12 +358,12 @@ def forward(trs: Transaction, ccm: CCM) -> None:
         ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
         
     # If the chain is registered, do not continue.
-    if chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
+    elif chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
         ccmFailed = True  
         ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
         ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
 
-    if not isLive(ccm.receivingChainID):
+    elif not isLive(ccm.receivingChainID):
         ccmFailed = True
         ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
         ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE

--- a/proposals/lip-0049.md
+++ b/proposals/lip-0049.md
@@ -354,13 +354,9 @@ def forward(trs: Transaction, ccm: CCM) -> None:
     # If the chain account does not exist, or if the chain is registered do not continue.
     if chainAccount(ccm.receivingChainID) does not exist or chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
         ccmFailed = True
-        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
-        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
         
     elif not isLive(ccm.receivingChainID):
         ccmFailed = True
-        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
-        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
         # If the receiving chain is active, it means it violated the liveness condition and we terminate it.
         # If the receiving chain is already terminated, terminateChain does nothing.
         terminateChain(ccm.receivingChainID)
@@ -398,7 +394,7 @@ def forward(trs: Transaction, ccm: CCM) -> None:
         return
     
     if ccmFailed:
-        bounce(ccm, ccmError, ccmProcessedEventCode)
+        bounce(ccm, CCM_STATUS_CODE_CHANNEL_UNAVAILABLE, CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE)
     else:
         addToOutbox(ccm.receivingChainID, ccm)
         # Emit CCM forwarded event.


### PR DESCRIPTION
This PR replaces the following sequence of "if" statements in the forward function:

```
    # If the chain account does not exist, do not continue.
    if chainAccount(ccm.receivingChainID) does not exist:
        ccmFailed = True
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
        
    # If the chain is registered, do not continue.
    if chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
        ccmFailed = True  
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE

    if not isLive(ccm.receivingChainID):
        ccmFailed = True
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
        # If the receiving chain is active, it means it violated the liveness condition and we terminate it.
        # If the receiving chain is already terminated, terminateChain does nothing.
        terminateChain(ccm.receivingChainID)
```

by a singe "if" statement using "elif", as follows:

```
    # If the chain account does not exist, do not continue.
    if chainAccount(ccm.receivingChainID) does not exist:
        ccmFailed = True
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
        
    # If the chain is registered, do not continue.
    elif chainAccount(ccm.receivingChainID).status == CHAIN_STATUS_REGISTERED:
        ccmFailed = True  
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE

    elif not isLive(ccm.receivingChainID):
        ccmFailed = True
        ccmError = CCM_STATUS_CODE_CHANNEL_UNAVAILABLE
        ccmProcessedEventCode = CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE
        # If the receiving chain is active, it means it violated the liveness condition and we terminate it.
        # If the receiving chain is already terminated, terminateChain does nothing.
        terminateChain(ccm.receivingChainID)

```

The reason is that only one of those checks should be performed (depending on the case) and performing all checks introduces bugs for some cases. For example, if chain account does not exist for the receiving chain, i.e., first "if" is satisfied, then the third "if" should not be executed, because `isLive()` would return `False` and then there would be an attempt to terminate the receiving chain, which would raise an error. 