### PR TITLE
Disallow signing with key equal to zero modulo the group order in BLS

### DIFF
--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bls-signatures/282
 Status: Draft
 Type: Informational
 Created: 2021-04-13
-Updated: 2023-04-05
+Updated: 2023-08-16
 ```
 
 ## Abstract

--- a/proposals/lip-0038.md
+++ b/proposals/lip-0038.md
@@ -215,12 +215,13 @@ To create a new key pair, an initial randomness of at least 32 bytes is created,
 
 #### `Sign`
 
-The [Eth2.0 specification tests for `Sign`](https://github.com/ethereum/eth2.0-spec-tests/tree/master/tests/general/phase0/bls/sign/small) should be used. However, an implementation for this proposal should NOT fulfill the test for [the zero secret key](https://media.githubusercontent.com/media/ethereum/eth2.0-spec-tests/master/tests/general/phase0/bls/sign/small/sign_case_zero_privkey/data.yaml). To be conforming with the [BLS specifications for `Sign`](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6), the following must hold instead (note that this is the expected output for any message):
+The [Eth2.0 specification tests for `Sign`](https://github.com/ethereum/eth2.0-spec-tests/tree/master/tests/general/phase0/bls/sign/small) should be used. Additionally, the following case for a secret key that is non-zero but zero modulo the group order must hold (note that this must hold for any message):
 
 ```python
-sk = 0x0000000000000000000000000000000000000000000000000000000000000000
+# sk equals 2*r where r is order of the groups G1 and G2
+sk = 0xe7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002
 message = 0xabababababababababababababababababababababababababababababababab
-Sign(sk, message) == 0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+Sign(sk, message) == INVALID
 ```
 
 #### `Verify`


### PR DESCRIPTION
Disallow signing with a secret key that is zero or zero modulo the group order.