### PR TITLE
Update `getTotalSupply` function in LIP-0051

### DIFF
--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -1600,9 +1600,8 @@ def getLockedAmount(address: Address, module: Module, tokenID: TokenID) -> uint6
 ```python
 def getTotalSupply() -> dict[TokenID, uint64]:
     totalSupply: dict[TokenID, uint64] = {}
-    for (storeKey, storeValue) in supplyStore.items():
-        tokenID = storeKey
-        totalSupply[tokenID] = storeValue.totalSupply
+    for tokenID in supplyStore.keys():
+        totalSupply[tokenID] = supplyStore(tokenID).totalSupply
     return totalSupply
 ```
 

--- a/proposals/lip-0051.md
+++ b/proposals/lip-0051.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-state-and-state-transitions-o
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-08-15
+Updated: 2023-08-17
 ```
 
 ## Abstract


### PR DESCRIPTION
The [`getTotalSupply`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#gettotalsupply) function of LIP-0051 has been rewritten to align with [comment1](https://github.com/LiskHQ/lips/pull/446#discussion_r1291604878) and [comment2](https://github.com/LiskHQ/lips/pull/446#discussion_r1291606666) from [PR 446](https://github.com/LiskHQ/lips/pull/446).