### PR TITLE
Improve Governance module functionality

### DIFF
--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-governance-module/401
 Status: Draft
 Type: Standards Track
 Created: 2023-07-26
-Updated: 2023-08-15
+Updated: 2023-08-28
 Required: LIP 0048, 0051, 0057
 ```
 

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -96,7 +96,7 @@ where turnout denotes the total number of PoS staking tokens that participated i
 
 ### Treasury
 
-The treasury is a dedicated account holding tokens that can be accessed by a funding proposal (see `ADDRESS_TREASURY` in the [table of constants](#notation-and-constants)). A funding proposal can only access tokens in the treasury if they are locked by the Governance module. Tokens could be minted into the treasury each block by the Governance module, the amount is specified by `treasuryTokensPerBlock` in [config overview](#config-overview).
+The treasury is a dedicated account holding tokens that can be accessed by a funding proposal (see `ADDRESS_TREASURY` in the [table of constants](#notation-and-constants)). A funding proposal can only access tokens in the treasury if they are locked by the Governance module. Tokens could be minted into the treasury each block by the Governance module, the amount is specified by `treasuryTokensPerBlock` in [config overview](#config-overview). Users can also donate tokens by simply sending them to the address of the treasury.
 
 ### Config substore
 
@@ -127,7 +127,7 @@ This LIP uses the following terms:
 | **Name**                  |   **Type**        |       **Validation**       |       **Description**                                 |
 |---------------------------|-------------------|-----------------------|-------------------------------------------------------|
 |   Proposal                |   object          | Must satisfy `proposalSchema`.| Object containing information of a particular proposal.|
-|   Address                 |   bytes           | Must have length `LENGTH_ADDRESS`.| Account address in Lisk ecosystem.              |
+|   Address                 |   bytes           | Must have length `ADDRESS_LENGTH`.| Account address in Lisk ecosystem.              |
 
 
 ### Notation and Constants
@@ -148,9 +148,9 @@ We define the following constants:
 |`MAX_MODULE_NAME_LENGTH`|`uint32`|32|The maximum length of a string specifying the name of a module, as defined in [LIP 0068][lip68Const].|
 |`MAX_PARAM_NAME_LENGTH`|`uint32`|64|The maximum length of a string specifying the name of a modifiable parameter.|
 |`MAX_PARAM_VALUE_LENGTH`|`uint32`|64|The maximum length of a byte array specifying the new value of a modifiable parameter.|
-|`LENGTH_PROPOSAL_ID`|`uint32`|4|The number of bytes of a proposal ID.|
-|`LENGTH_TOKEN_ID`|`uint32`|8|The number of bytes of a token ID.|
-|`LENGTH_ADDRESS`|`uint32`|20|The number of bytes of an address.|
+|`PROPOSAL_ID_LENGTH`|`uint32`|4|The number of bytes of a proposal ID.|
+|`TOKEN_ID_LENGTH`|`uint32`|8|The number of bytes of a token ID.|
+|`ADDRESS_LENGTH`|`uint32`|20|The number of bytes of an address.|
 |`MODULE_NAME_GOVERNANCE`|`string`|"governance"|Name of the Governance module.|
 |`SUBSTORE_PREFIX_PROPOSALS`|`bytes`|`0x0000`|Substore prefix of the proposals substore.|
 |`SUBSTORE_PREFIX_VOTES`|`bytes`|`0x4000`|Substore prefix of the votes substore.|
@@ -183,7 +183,7 @@ The key-value pairs in the module store are organized as follows.
 ##### Substore Prefix, Store Key, and Store Value
 
 - The substore prefix is set to `SUBSTORE_PREFIX_PROPOSALS`.
-- Each store key given by `index.to_bytes(4, byteorder='big')` for the corresponding proposal index `index`. The store key is a byte array of length `LENGTH_PROPOSAL_ID`.
+- Each store key given by `index.to_bytes(4, byteorder='big')` for the corresponding proposal index `index`. The store key is a byte array of length `PROPOSAL_ID_LENGTH`.
 - Each store value is the serialization of an object following the JSON schema `proposalSchema` presented below.
 - Notation: For the rest of this proposal let `proposalsStore[index]` be the object value stored in the proposals substore with store key `index.to_bytes(4, byteorder='big')`, deserialized using `proposalSchema`.
 
@@ -207,7 +207,7 @@ proposalSchema = {
     "properties": {
         "creator": {
             "dataType": "bytes",
-            "length": LENGTH_ADDRESS,
+            "length": ADDRESS_LENGTH,
             "fieldNumber": 1
         },
         "creationHeight": {
@@ -303,7 +303,7 @@ proposalDescriptionSchema = {
 ##### Substore Prefix, Store Key, and Store Value
 
 - The substore prefix is set to `SUBSTORE_PREFIX_VOTES`.
-- Each store key is a voter address given as a byte array of length `LENGTH_ADDRESS`.
+- Each store key is a voter address given as a byte array of length `ADDRESS_LENGTH`.
 - Each store value is the serialization of an object following the JSON schema `votesSchema` presented below.
 - Notation: For the rest of this proposal let `votesStore[address]` be the object value stored in the votes substore with store key `address`, deserialized using `votesSchema`. Also `votesStore[address][i]` will denote the `i`-th object of the array `votesStore[address]`.
 
@@ -408,12 +408,12 @@ configSchema = {
         "proposalCreationDeposit",
         "proposalCreationMinBalance",
         "quorumPercentage",
-        "treasuryTokensPerBlock",
+        "treasuryTokensPerBlock"
     ],
     "properties": {
         "tokenIdTreasury": {
             "type": "bytes",
-            "length": LENGTH_TOKEN_ID,
+            "length": TOKEN_ID_LENGTH,
             "fieldNumber": 1
         },
         "voteDuration": {
@@ -483,7 +483,7 @@ fundingProposalDataSchema = {
     "properties": {
         "receivingAddress": {
             "dataType": "bytes",
-            "length": LENGTH_ADDRESS,
+            "length": ADDRESS_LENGTH,
             "fieldNumber": 1
         },
         "fundingAmount": {
@@ -575,7 +575,7 @@ The function [getAvailableBalance][getAvailableBalance] is defined in the Token 
 def verify(trs: Transaction) -> None:
     trsParams = decode(createProposalParamsSchema, trs.params)
 
-    senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    senderAddress = SHA256(trs.senderPublicKey)[:ADDRESS_LENGTH]
     availableBalance = Token.getAvailableBalance(senderAddress, TOKEN_ID_POS)
     lockedBalance = PoS.getLockedStakedAmount(senderAddress)
     if availableBalance + lockedBalance < configStore.proposalCreationMinBalance:
@@ -596,7 +596,7 @@ def execute(trs: Transaction) -> None:
     trsParams = decode(createProposalParamsSchema, trs.params)
     # non-trivial verification checks
     currentHeight = height of the block containing trs
-    senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    senderAddress = SHA256(trs.senderPublicKey)[:ADDRESS_LENGTH]
 
     # command execution
     Fee.payFee(configStore.proposalCreationFee)
@@ -677,7 +677,7 @@ The function [getLockedStakedAmount][getLockedStakedAmount] is defined in the Po
 def execute(trs: Transaction) -> None:
     trsParams = decode(voteOnProposalParamsSchema, trs.params)
     index = trsParams.proposalIndex
-    senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
+    senderAddress = SHA256(trs.senderPublicKey)[:ADDRESS_LENGTH]
     stakedAmount = PoS.getLockedStakedAmount(senderAddress)
     if votesStore[senderAddress] does not exist:
         votesStore[senderAddress] = []
@@ -733,7 +733,7 @@ proposalCreatedEventDataSchema = {
     "properties": {
         "creator": {
             "dataType": "bytes",
-            "length": LENGTH_ADDRESS,
+            "length": ADDRESS_LENGTH,
             "fieldNumber": 1
         },
         "index": {
@@ -839,7 +839,7 @@ proposalVotedEventSchema = {
         },
         "voterAddress": {
             "dataType": "bytes",
-            "length": LENGTH_ADDRESS,
+            "length": ADDRESS_LENGTH,
             "fieldNumber": 2
         },
         "decision": {
@@ -880,7 +880,7 @@ def validateProposal(type: int, data: bytes, description: dict) -> None:
     elif type == PROPOSAL_TYPE_CONFIG_UPDATE:
         proposalDataObj = decode(configUpdateProposalDataSchema, data)
         validateObjectSchema(configUpdateProposalDataSchema, proposalDataObj)
-        proposalDataObj.moduleName.validateConfigUpdate(proposalDataObj.paramName, proposalDataObj.value)
+        (proposalDataObj.moduleName).validateConfigUpdate(proposalDataObj.paramName, proposalDataObj.value)
     else:
         raise Exception("Wrong proposal type")
 ```
@@ -920,7 +920,17 @@ The function raises an exception if the proposed config update is invalid.
 
 ```python
 def validateConfigUpdate(name: string, value: bytes):
-    type = type of value with name in configSchema
+    if name not in [
+        "tokenIdTreasury",
+        "voteDuration",
+        "quorumDuration",
+        "proposalCreationFee",
+        "proposalCreationDeposit",
+        "proposalCreationMinBalance",
+        "quorumPercentage",
+        "treasuryTokensPerBlock"]:
+        raise Exception("Invalid config name")
+    type = string indicating the type of name property in configSchema
     valueDecoded = validateAndDecode(value, type)
     if name == "quorumPercentage":
         if valueDecoded > 1000000:
@@ -936,7 +946,7 @@ The function updates a value in the config substore.
 
 ```python
 def updateConfig(name: string, value: bytes) -> None:
-    type = type of value with name in configSchema
+    type = string indicating the type of name property in configSchema
     valueDecoded = validateAndDecode(value, type)
     # update the store value
     configStore.name = valueDecoded
@@ -1167,7 +1177,7 @@ genesisGovernanceSchema = {
                 "properties": {
                     "address": {
                         "dataType": "bytes",
-                        "length": LENGTH_ADDRESS,
+                        "length": ADDRESS_LENGTH,
                         "fieldNumber": 1
                     },
                     "votes": {

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -453,8 +453,8 @@ configSchema = {
 |   **Name**      |  **Type**   |   **Modifiable**  |**Initial Mainchain Value**|**Description**         |
 |-----------------|-------------|-------------------|----------------------------------|------------------------|
 |`tokenIdTreasury`|   `bytes`   |     No            | `TOKEN_ID_LSK`                   |Token ID of the tokens stored in the treasury and handled by funding proposals.|
-|`voteDuration`   | `uint32`    |       No          |   240000                         |Length of the vote period in blocks. As clarified in [Rationale](#voting-on-a-proposal), `voteDuration <= LOCKING_PERIOD_STAKING`, where `LOCKING_PERIOD_STAKING` is defined in [LIP 0057][posModule].|
-|`quorumDuration` | `uint32`    |       Yes          |   120000                         |Length of the quorum period in blocks. After this period the quorum is checked.|
+|`voteDuration`   | `uint32`    |       No          |   `241,920 = 28 * 24 * 3600 // BLOCK_TIME`                         |Length of the vote period in blocks. As clarified in [Rationale](#voting-on-a-proposal), `voteDuration <= LOCKING_PERIOD_STAKING`, where `LOCKING_PERIOD_STAKING` is defined in [LIP 0057][posModule].|
+|`quorumDuration` | `uint32`    |       Yes          |   `120,960 = 14 * 24 * 3600 // BLOCK_TIME`                         |Length of the quorum period in blocks. After this period the quorum is checked.|
 |`proposalCreationFee` | `uint64`    |       Yes          |   10 * 10^8                |Proposal creation fee to be paid in fee tokens (`TOKEN_ID_FEE` is defined in the [Fee module](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0048.md#notation-and-constants)).|
 |`proposalCreationDeposit` | `uint64`    |       Yes          |   1000 * 10^8          |The value of the proposal creation deposit.|
 |`proposalCreationMinBalance` | `uint64`    |       Yes          |   10000 * 10^8      |Minimal amount of PoS staking tokens an account should have to create a proposal (including PoS locked tokens).|

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -455,7 +455,7 @@ configSchema = {
 |-----------------|-------------|-------------------|----------------------------------|------------------------|
 |`tokenIdTreasury`|   `bytes`   |     No            | `TOKEN_ID_LSK`                   |Token ID of the tokens stored in the treasury and handled by funding proposals.|
 |`voteDuration`   | `uint32`    |       No          |   240000                         |Length of the vote period in blocks. As clarified in [Rationale](#voting-on-a-proposal), `voteDuration <= LOCKING_PERIOD_STAKING`, where `LOCKING_PERIOD_STAKING` is defined in [LIP 0057][posModule].|
-|`quorumDuration` | `uint32`    |       No          |   120000                         |Length of the quorum period in blocks. After this period the quorum is checked.|
+|`quorumDuration` | `uint32`    |       Yes          |   120000                         |Length of the quorum period in blocks. After this period the quorum is checked.|
 |`proposalCreationFee` | `uint64`    |       Yes          |   10 * 10^8                |Proposal creation fee to be paid in fee tokens (`TOKEN_ID_FEE` is defined in the [Fee module](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0048.md#notation-and-constants)).|
 |`proposalCreationDeposit` | `uint64`    |       Yes          |   1000 * 10^8          |The value of the proposal creation deposit.|
 |`proposalCreationMinBalance` | `uint64`    |       Yes          |   10000 * 10^8      |Minimal amount of PoS staking tokens an account should have to create a proposal (including PoS locked tokens).|
@@ -891,6 +891,7 @@ def validateProposal(type: int, data: bytes, description: dict) -> None:
     elif type == PROPOSAL_TYPE_CONFIG_UPDATE:
         proposalDataObj = decode(configUpdateProposalDataSchema, data)
         validateObjectSchema(configUpdateProposalDataSchema, proposalDataObj)
+        proposalDataObj.moduleName.validateConfigUpdate(proposalDataObj.paramName, proposalDataObj.value)
     else:
         raise Exception("Wrong proposal type")
 ```
@@ -904,6 +905,10 @@ def applyProposalOutcome(type: int, data: bytes) -> None:
     if type == PROPOSAL_TYPE_FUNDING:
         # assume that the data is valid
         dataObj = decode(fundingProposalDataSchema, data)
+        # lock donated treasury tokens together with minted treasury tokens
+        treasuryDonations = Token.getAvailableBalance(ADDRESS_TREASURY, configStore.tokenIdTreasury)
+        if (treasuryDonations != 0):
+            Token.lock(ADDRESS_TREASURY, MODULE_NAME_GOVERNANCE, configStore.tokenIdTreasury, treasuryDonations)
         # unlock and send treasury funds, all requested amount or nothing
         treasuryBalance = Token.getLockedAmount(ADDRESS_TREASURY, MODULE_NAME_GOVERNANCE, configStore.tokenIdTreasury)
         if treasuryBalance >= dataObj.fundingAmount:
@@ -918,6 +923,22 @@ def applyProposalOutcome(type: int, data: bytes) -> None:
         if dataObj.paramName is not registered for dataObj.moduleName:
             raise Exception()
         call updateConfig(dataObj.paramName, dataObj.value) method of module dataObj.moduleName
+```
+
+#### validateConfigUpdate
+
+The function raises an exception if the proposed config update is invalid.
+
+```python
+def validateConfigUpdate(name: string, value: bytes):
+    type = type of value with name in configSchema
+    valueDecoded = validateAndDecode(value, type)
+    if name == "quorumPercentage":
+        if valueDecoded > 1000000:
+            raise Exception("Quorum percentage must be in parts-per-million")
+    if name == "quorumDuration":
+        if valueDecoded > configStore.voteDuration:
+            raise Exception("Quorum duration can not be greater than vote duration")
 ```
 
 #### updateConfig

--- a/proposals/lip-0074.md
+++ b/proposals/lip-0074.md
@@ -159,7 +159,6 @@ We define the following constants:
 |`COMMAND_CREATE_PROPOSAL`|`string`|"createProposal"|Command name of the create proposal command.|
 |`COMMAND_VOTE_ON_PROPOSAL`|`string`|"voteOnProposal"|Command name of the vote command. |
 |`EVENT_NAME_PROPOSAL_CREATED`|`string`|"proposalCreated"| Event name of the Proposal Created event. |
-|`EVENT_NAME_PROPOSAL_CREATION_FAILED`|`string`|"proposalCreationFailed"| Event name of the Proposal Creation Failed event.|
 |`EVENT_NAME_PROPOSAL_QUORUM_CHECKED`|`string`|"proposalQuorumChecked"| Event name of the Proposal Quorum Checked event.|
 |`EVENT_NAME_PROPOSAL_OUTCOME`|`string`|"proposalOutcome"| Event name of the Proposal Outcome event.|
 |`EVENT_NAME_PROPOSAL_VOTED`|`string`|"proposalVoted"| Event name of the Proposal Voted event.|
@@ -582,6 +581,10 @@ def verify(trs: Transaction) -> None:
     if availableBalance + lockedBalance < configStore.proposalCreationMinBalance:
         raise Exception("Insufficient token balance to create proposal")
 
+    currentHeight = height of the block containing trs
+    if not hasEnded(indexStore.nextIndex - MAX_NUM_RECORDED_VOTES, currentHeight, configStore.voteDuration):
+        raise Exception("Limit of proposals with recorded votes is reached")
+
     validateProposal(trsParams.type, trsParams.data, trsParams.description)
 ```
 ##### Execution
@@ -594,14 +597,6 @@ def execute(trs: Transaction) -> None:
     # non-trivial verification checks
     currentHeight = height of the block containing trs
     senderAddress = SHA256(trs.senderPublicKey)[:LENGTH_ADDRESS]
-    if not hasEnded(indexStore.nextIndex - MAX_NUM_RECORDED_VOTES, currentHeight, configStore.voteDuration):
-        emitPersistentEvent(
-            module = MODULE_NAME_GOVERNANCE,
-            name = EVENT_NAME_PROPOSAL_CREATION_FAILED,
-            data = {},
-            topics = []
-        )
-        raise Exception("Limit of proposals with recorded votes is reached")
 
     # command execution
     Fee.payFee(configStore.proposalCreationFee)
@@ -756,12 +751,6 @@ proposalCreatedEventDataSchema = {
 - `creator`: The address of the account that created the proposal.
 - `index`: The index of the created proposal.
 - `type`: The type of the created proposal. Allowed values are `PROPOSAL_TYPE_UNIVERSAL`, `PROPOSAL_TYPE_FUNDING` and `PROPOSAL_TYPE_CONFIG_UPDATE`.
-
-#### Proposal Creation Failed
-
-This event is emitted when a proposal creation fails because the limit of proposals with recorded votes is reached. The name of this event is `EVENT_NAME_PROPOSAL_CREATION_FAILED`.
-
-The event does not define additional topics and its event data is an empty object.
 
 #### Proposal Quorum Checked
 


### PR DESCRIPTION
Changes introduced in the PR:
1. Make quorum duration modifiable.
2. Add value validation for config update proposals. In particular, for quorum duration and quorum percentage values.
3. Enable token donation to the treasury by a simple transfer: before using treasury tokens all available balance is locked together with the minted locked tokens.
4. Move the `hasEnded` check from execution to verification of the create proposal command, delete Proposal Creation Failed event as it is not needed anymore.
5. Resolve https://github.com/LiskHQ/lips/issues/463.