### PR TITLE
Update parameter recommendations for argon2id

### DIFF
--- a/proposals/lip-0067.md
+++ b/proposals/lip-0067.md
@@ -179,7 +179,7 @@ which correspond to the first recommended option of RFC 9106, except for the mem
 
 As some mobile devices have less memory, we recommend to use the second recommended option of RFC 9106 which requires less memory but uses more iterations instead:
 
-* iterations=3
+* iterations=3,
 * parallelism=4 lanes,
 * memory=65536 KiB (64 MiB),
 * 16 bytes salt,

--- a/proposals/lip-0067.md
+++ b/proposals/lip-0067.md
@@ -165,11 +165,23 @@ List of tags associated with the file.
 
 #### Argon2id
 
-We recommend using argon2id (instead of PBKDF2) to derive the encryption key, as it is recognised as a more secure key-derivation function (see for example [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)). We recommend to follow [RFC 9106](https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice) for basic parameter choices. Their first recommend options are:
+We recommend using argon2id (instead of PBKDF2) to derive the encryption key, as it is recognised as a more secure key-derivation function (see for example [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)). We recommend to follow [RFC 9106](https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice) for basic parameter choices. Whenever possible, in particular on a block generating node, we recommend the values
 
 * iterations=1,
 * parallelism=4 lanes,
-* memory=2048 (2 GiB of RAM),
+* memory=2097023 KiB,
+* 16 bytes salt,
+* 32 bytes output
+
+which correspond to the first recommended option of RFC 9106, except for the memory value. The chosen memory value is slighly smaller than the recommended 2 GiB such that it works also with libraries like [hash-wasm](https://github.com/Daninet/hash-wasm) which fails for 2 GiB.
+
+##### Argon2id for Wallets
+
+As some mobile devices have less memory, we recommend to use the second recommended option of RFC 9106 which requires less memory but uses more iterations instead:
+
+* iterations=3
+* parallelism=4 lanes,
+* memory=65536 KiB (64 MiB),
 * 16 bytes salt,
 * 32 bytes output.
 

--- a/proposals/lip-0067.md
+++ b/proposals/lip-0067.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-a-generic-keystore/360
 Status: Draft
 Type: Informational
 Created: 2022-06-28
-Updated: 2023-07-28
+Updated: 2023-08-28
 ```
 
 ## Abstract


### PR DESCRIPTION
Update the parameters to the ones used in the SDK that are based on the limitations of the library hash-wasm. Additionally, add extra recommendations for wallets.