### PR TITLE
Fix typo LIP 0058

### DIFF
--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-bft-module/321
 Status: Draft
 Type: Standards Track
 Created: 2021-09-07
-Updated: 2023-08-28
+Updated: 2023-09-04
 Requires: 0055, 0056, 0061
 ```
 

--- a/proposals/lip-0058.md
+++ b/proposals/lip-0058.md
@@ -518,7 +518,7 @@ def setBFTParameters(precommitThreshold, certificateThreshold, validatorList):
 
     # Compute the validators hash.
     activeValidators = []
-    for validator in validators:
+    for validator in validatorList:
         if validator.bftWeight > 0:
             activeValidator = object with property bftWeight and blsKey
             activeValidator.bftWeight = validator.bftWeight


### PR DESCRIPTION
In function `setBFTParameters` there is the for loop:

```
    for validator in validators:
        if validator.bftWeight > 0:
            activeValidator = object with property bftWeight and blsKey
            activeValidator.bftWeight = validator.bftWeight
            activeValidator.blsKey =  validator.blsKey
            add activeValidator to activeValidators
```

where `validators` is not defined. Instead it should be replaced by `validatorList`. This PR fixes this typo. 