### PR TITLE
Remove the support for all tokens on Lisk mainchain

### DIFF
--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-mainnet-configuration-and-mig
 Status: Draft
 Type: Standards Track
 Created: 2022-04-06
-Updated: 2023-08-08
+Updated: 2023-09-15
 Requires: 0060
 ```
 
@@ -82,16 +82,6 @@ This value will be used for every validator account in the snapshot block.
    <td><code>0x 00 00 00 00 00 00 00 00</code>
    </td>
    <td>Token ID of the LSK token for Mainnet, see <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#token-id">LIP 0051</a>.
-   </td>
-  </tr>
-  <tr>
-   <td><code>ALL_SUPPORTED_TOKENS_KEY</code>
-   </td>
-   <td>bytes
-   </td>
-   <td>empty byte string
-   </td>
-   <td>The key for the <a href="https://github.com/LiskHQ/lips/blob/main/proposals/lip-0051.md#supported-tokens-substore">supported tokens substore</a> of the Token module to specify that all tokens are supported.
    </td>
   </tr>
   <tr>
@@ -445,10 +435,7 @@ def addTokenModuleEntry():
     tokenObj.userSubstore = createUserSubstoreArray()
     tokenObj.supplySubstore = createSupplySubstoreArray()
     tokenObj.escrowSubstore = []
-    # support all tokens
-    tokenObj.supportedTokensSubstore = [
-        {"chainID": ALL_SUPPORTED_TOKENS_KEY, "supportedTokenIDs": []}
-    ]
+    tokenObj.supportedTokensSubstore = []
     data = serialization of tokenObj using genesisTokenStoreSchema
     append {"module": MODULE_NAME_TOKEN, "data": data} to b.assets
 


### PR DESCRIPTION
Reverts the effects of [this PR](https://github.com/LiskHQ/lips/pull/378).

The reason is that adding support for all tokens was planned for the Diamond phase.