### PR TITLE
Set the snapshot time gap to 1 hr

### DIFF
--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -213,7 +213,7 @@ ffffff
    </td>
    <td>uint32
    </td>
-   <td>TBD
+   <td>3600
    </td>
    <td>The number of seconds elapsed between the block at height <code>HEIGHT_SNAPSHOT</code> and the snapshot block.
    </td>

--- a/proposals/lip-0063.md
+++ b/proposals/lip-0063.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/define-mainnet-configuration-and-mig
 Status: Draft
 Type: Standards Track
 Created: 2022-04-06
-Updated: 2023-09-15
+Updated: 2023-09-25
 Requires: 0060
 ```
 


### PR DESCRIPTION
Corresponding issue in migrator: https://github.com/LiskHQ/lisk-migrator/issues/135.