### PR TITLE
Adjust aggregateCommit.height in genesis block and getMaxRemovalHeight() function

### DIFF
--- a/proposals/lip-0060.md
+++ b/proposals/lip-0060.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/update-genesis-block-schema-and-proc
 Status: Draft
 Type: Standards Track
 Created: 2021-10-08
-Updated: 2023-05-22
+Updated: 2023-09-28
 Requires: 0040, 0058, 0055
 ```
 

--- a/proposals/lip-0060.md
+++ b/proposals/lip-0060.md
@@ -138,7 +138,7 @@ The block header is processed as follows:
   * The value of `b.header.maxHeightPrevoted` is equal to `b.header.height`.
   * The value of `b.header.impliesMaxPrevotes` is equal to `True`.
   * The value `b.header.maxHeightGenerated`  is equal to 0.
-  * The value of `b.header.aggregateCommit.height` is 0.
+  * The value of `b.header.aggregateCommit.height` is `b.header.height`.
   * The value of `b.header.aggregateCommit.signature` is empty bytes.
   * The value of `b.header.aggregateCommit.aggregationBits` is empty bytes.
   * The value of `b.header.signature` is empty bytes.

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -405,10 +405,10 @@ The height up to which single commits can be removed.
 ```python
 def getMaxRemovalHeight() -> uint32:
     b = block at height maxHeightFinalized
-    return b.header.aggregateCommit.height
+    return max(b.header.aggregateCommit.height, genesisHeight)
 ```
 
-In the function above, `maxHeightFinalized` is the maximum height up to which the current chain is considered final, as introduced in [LIP 0056](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#finalized-height).
+In the function above, `maxHeightFinalized` is the maximum height up to which the current chain is considered final, as introduced in [LIP 0056](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#finalized-height), and `genesisHeight` is the height of the genesis block.
 
 #### Initial Single Commit Creation
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-certificate-generation-mec
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-09-13
+Updated: 2023-09-28
 Requires: 0044, 0055, 0058
 ```
 


### PR DESCRIPTION
Fixes #491 