### PR TITLE
Create single commits only from MIN_CERTIFICATE_HEIGHT height onwards

### DIFF
--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -405,7 +405,7 @@ The height up to which single commits can be removed.
 ```python
 def getMaxRemovalHeight() -> uint32:
     b = block at height maxHeightFinalized
-    return max(b.header.aggregateCommit.height, genesisHeight)
+    return max(b.header.aggregateCommit.height, MIN_CERTIFICATE_HEIGHT - 1)
 ```
 
 In the function above, `maxHeightFinalized` is the maximum height up to which the current chain is considered final, as introduced in [LIP 0056](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#finalized-height), and `genesisHeight` is the height of the genesis block.
@@ -418,8 +418,8 @@ If a validator node starts for the first time or loses all previously created si
 
 If for a validator `v`, after applying a block the value returned by the function `getBFTHeights().maxHeightPrecommitted` increases from `h1` to `h2`, then the following commit messages are created by the validator `v` and gossiped as described further below:
 
-* For every height `h` in `{h1+1, h1+2, ..., h2}` such that `existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters), validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
-* If `existBFTParameters(h2+1)` returns `False` (i.e., `h2` is not the height of a block authenticating a change of BFT parameters), `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
+* For every height `h` in `{h1+1, h1+2, ..., h2}` such that `existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters) and `h >= MIN_CERTIFICATE_HEIGHT`, validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
+* If `existBFTParameters(h2+1)` returns `False` (i.e., `h2` is not the height of a block authenticating a change of BFT parameters) and `h >= MIN_CERTIFICATE_HEIGHT`, `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
 
 #### Single Commit P2P Gossip
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -6,7 +6,7 @@ Discussions-To: https://research.lisk.com/t/introduce-certificate-generation-mec
 Status: Draft
 Type: Standards Track
 Created: 2021-05-22
-Updated: 2023-09-28
+Updated: 2023-10-04
 Requires: 0044, 0055, 0058
 ```
 

--- a/proposals/lip-0061.md
+++ b/proposals/lip-0061.md
@@ -408,18 +408,18 @@ def getMaxRemovalHeight() -> uint32:
     return max(b.header.aggregateCommit.height, MIN_CERTIFICATE_HEIGHT - 1)
 ```
 
-In the function above, `maxHeightFinalized` is the maximum height up to which the current chain is considered final, as introduced in [LIP 0056](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#finalized-height), and `genesisHeight` is the height of the genesis block.
+In the function above, `maxHeightFinalized` is the maximum height up to which the current chain is considered final, as introduced in [LIP 0056](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0056.md#finalized-height).
 
 #### Initial Single Commit Creation
 
-If a validator node starts for the first time or loses all previously created single commits due to a restart, the node should automatically re-create all recent single commits, which may be essential for the network to create aggregate commits. Let `h1 = getMaxRemovalHeight()` and `h2 = getBFTHeights().maxHeightPrecommitted`. Then the single commits are created as described in the next section [Creation After Block Processing](#creation-after-block-processing) for these values of `h1` and `h2`.
+If a validator node starts for the first time or loses all previously created single commits due to a restart, the node should automatically re-create all recent single commits, which may be essential for the network to create aggregate commits. Let `h1 = getMaxRemovalHeight()` and `h2 = getBFTHeights().maxHeightPrecommitted`. If `h2 > h1`, then the single commits are created as described in the next section [Creation After Block Processing](#creation-after-block-processing) for these values of `h1` and `h2`.
 
 #### Creation After Block Processing
 
 If for a validator `v`, after applying a block the value returned by the function `getBFTHeights().maxHeightPrecommitted` increases from `h1` to `h2`, then the following commit messages are created by the validator `v` and gossiped as described further below:
 
-* For every height `h` in `{h1+1, h1+2, ..., h2}` such that `existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters) and `h >= MIN_CERTIFICATE_HEIGHT`, validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
-* If `existBFTParameters(h2+1)` returns `False` (i.e., `h2` is not the height of a block authenticating a change of BFT parameters) and `h >= MIN_CERTIFICATE_HEIGHT`, `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
+* For every height `h` in `{max(MIN_CERTIFICATE_HEIGHT, h1+1), ..., h2 - 1}` such that `existBFTParameters(h+1)` returns `True` (i.e., `h` is the height of a block authenticating a change of BFT parameters), validator `v` creates a commit message for the block `b` at height `h` in its chain if validator `v` was active at height `h`.
+* If `h2 >= MIN_CERTIFICATE_HEIGHT`, `v` creates a commit message for the block `b` at height `h2` in its chain if validator `v` was active at height `h`.
 
 #### Single Commit P2P Gossip
 


### PR DESCRIPTION
Certificates are only be generated for blocks of height at least `MIN_CERTIFICATE_HEIGHT`. However, in the current certificate generation mechanism single commits are created from `genesisHeight + 1` onwards leading to uncessary storage and memory usage if `genesisHeight + 1 << MIN_CERTIFICATE_HEIGHT`. This PR changes the single commit creation in LIP 61 to only create them from height `MIN_CERTIFICATE_HEIGHT` onwards. 

Related Lisk SDK issue: https://github.com/LiskHQ/lisk-sdk/issues/9057