### PR TITLE
Update LIP 0052 - Swap checks in verify transfer functions

### DIFF
--- a/proposals/lip-0052.md
+++ b/proposals/lip-0052.md
@@ -1304,15 +1304,15 @@ def verifyTransferInternal(
 
     owner = nft["owner"]
 
-    if owner != senderAddress:
-        if emitEvent:
-            emitFailedTransferEvent(senderAddress, recipientAddress, nftID, RESULT_INITIATED_BY_NONOWNER)
-        raise Exception("Transfer not initiated by the NFT owner")
-
     if isNFTEscrowed(nft):
         if emitEvent:
             emitFailedTransferEvent(senderAddress, recipientAddress, nftID, RESULT_NFT_ESCROWED)
         raise Exception("NFT is escrowed to another chain")
+
+    if owner != senderAddress:
+        if emitEvent:
+            emitFailedTransferEvent(senderAddress, recipientAddress, nftID, RESULT_INITIATED_BY_NONOWNER)
+        raise Exception("Transfer not initiated by the NFT owner")
 
     if isNFTLocked(nft):
         if emitEvent:
@@ -1403,15 +1403,15 @@ def verifyTransferCrossChainInternal(
             emitFailedTransferCrossChainEvent(senderAddress, recipientAddress, nftID, receivingChainID, RESULT_DATA_TOO_LONG)
         raise Exception("Data field is too long")    
 
-    if owner != senderAddress:
-        if emitEvent:
-            emitFailedTransferCrossChainEvent(senderAddress, recipientAddress, nftID, receivingChainID, RESULT_INITIATED_BY_NONOWNER)
-        raise Exception("Transfer not initiated by the NFT owner")
-
     if isNFTEscrowed(nft):
         if emitEvent:
             emitFailedTransferCrossChainEvent(senderAddress, recipientAddress, nftID, receivingChainID, RESULT_NFT_ESCROWED)
         raise Exception("NFT is escrowed to another chain")
+
+    if owner != senderAddress:
+        if emitEvent:
+            emitFailedTransferCrossChainEvent(senderAddress, recipientAddress, nftID, receivingChainID, RESULT_INITIATED_BY_NONOWNER)
+        raise Exception("Transfer not initiated by the NFT owner")
 
     if isNFTLocked(nft):
         if emitEvent:


### PR DESCRIPTION
Currently, in [`verifyTransferInteral`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0052.md#verifytransferinternal) and [`verifyTransferCrossChainInternal`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0052.md#verifytransferinternal) functions of LIP 0052, the check `owner != senderAddress` happens before the check `isNFTEscrowed`:

```
if owner != senderAddress:
    if emitEvent:
        emitFailedTransferEvent(senderAddress, recipientAddress, nftID, RESULT_INITIATED_BY_NONOWNER)
    raise Exception("Transfer not initiated by the NFT owner")

if isNFTEscrowed(nft):
    if emitEvent:
        emitFailedTransferEvent(senderAddress, recipientAddress, nftID, RESULT_NFT_ESCROWED)
    raise Exception("NFT is escrowed to another chain")
```
However, in case when NFT is escrowed to another chain, the first check would always fail because in that case the NFT owner is `chainID`, so it cannot possibly be `senderAddress`. Therefore, it makes sense to swap these checks, i.e. to check `isNFTEscrowed` before `owner != senderAddress`.