### PR TITLE
Introduce tags for all default topics

### DIFF
--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -263,7 +263,7 @@ This LIP, and in general the new block header proposed in [LIP 0055][lip-0055], 
 [lip-0042]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0042.md
 [lip-0049]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
-[lip-0053#ccu-processing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#cross-chain-update-command-processing-stages
+[lip-0053#ccu-processing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#cross-chain-command-processing-stages
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
 [lip-0055#block-processing-stages]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-processing-stages
 [lip-0055#failing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#failing-and-invalid-transactions

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -194,7 +194,7 @@ By default, the first topic is set to:
 * the constant `EVENT_TOPIC_BEFORE_TRANSACTIONS`, for events emitted during the 'before transactions execution' stage,
 * the constant `EVENT_TOPIC_AFTER_TRANSACTIONS`, for events emitted during the 'after transactions execution' stage,
 * the constant `EVENT_TOPIC_TRANSACTION_EXECUTION` concatenated with the transaction ID, for events emitted during the transaction processing stages,
-* the constant `EVENT_TOPIC_CCM_EXECUTION` concatenated with the cross-chain message ID, for events emitted during the cross-chain message processing stages.
+* the constant `EVENT_TOPIC_CCM_EXECUTION` concatenated with the cross-chain message ID, for events emitted during the cross-chain message processing stages. This is indicated by setting `eventsDefaultTopic = ccmID` during the processing of [mainchain][lip-0053#mc-execution] and [sidechain][lip-0053#sc-execution] cross-chain updates.
 
 An event emitted during transaction processing cannot have any of these default values in the `topics` array.
 
@@ -264,6 +264,8 @@ This LIP, and in general the new block header proposed in [LIP 0055][lip-0055], 
 [lip-0049]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md
 [lip-0053]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md
 [lip-0053#ccu-processing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#cross-chain-command-processing-stages
+[lip-0053#mc-execution]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#execution
+[lip-0053#sc-execution]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#execution-1
 [lip-0055]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md
 [lip-0055#block-processing-stages]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#block-processing-stages
 [lip-0055#failing]: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0055.md#failing-and-invalid-transactions

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-events-and-add-events-root
 Status: Draft
 Type: Standards Track
 Created: 2022-05-03
-Updated: 2023-06-12
+Updated: 2023-10-23
 Requires: 0039, 0055
 ```
 

--- a/proposals/lip-0065.md
+++ b/proposals/lip-0065.md
@@ -108,6 +108,8 @@ To summarize, we chose sparse Merkle trees because:
 | `EVENT_TOPIC_FINALIZE_GENESIS_STATE` | bytes | `0x01` | Default topic for events emitted during genesis state finalization. |
 | `EVENT_TOPIC_BEFORE_TRANSACTIONS` | bytes | `0x02` | Default topic for events emitted _before_ transactions execution. |
 | `EVENT_TOPIC_AFTER_TRANSACTIONS` | bytes | `0x03` | Default topic for events emitted _after_ transactions execution. |
+| `EVENT_TOPIC_TRANSACTION_EXECUTION` | bytes | `0x04` | Default topic for events emitted during transaction processing. |
+| `EVENT_TOPIC_CCM_EXECUTION` | bytes | `0x05` | Default topic for events emitted during cross-chain message processing. |
 | `EVENT_NAME_DEFAULT` | string | `commandExecutionResult` | Name of default event emitted at the end of transaction execution. |
 | `EVENT_INDEX_LENGTH_BITS` | integer | `30` | Length in bits of the index used to calculate events tree leaf keys. |
 | `MAX_EVENTS_PER_BLOCK` | integer | `2^EVENT_INDEX_LENGTH_BITS` | Max number of events emitted per block. |
@@ -187,12 +189,12 @@ The event `topics` is an array of unique byte values whose length ranges between
 
 By default, the first topic is set to:
 
-* the transaction ID, for events emitted during the transaction processing stages,
-* the cross-chain message ID, for events emitted during the cross-chain message processing stages,
 * the constant `EVENT_TOPIC_INIT_GENESIS_STATE`, for events emitted during the 'genesis state initialization' stage,
 * the constant `EVENT_TOPIC_FINALIZE_GENESIS_STATE`, for events emitted during the 'genesis state finalization' stage,
 * the constant `EVENT_TOPIC_BEFORE_TRANSACTIONS`, for events emitted during the 'before transactions execution' stage,
-* or the constant `EVENT_TOPIC_AFTER_TRANSACTIONS`, for events emitted during the 'after transactions execution' stage.
+* the constant `EVENT_TOPIC_AFTER_TRANSACTIONS`, for events emitted during the 'after transactions execution' stage,
+* the constant `EVENT_TOPIC_TRANSACTION_EXECUTION` concatenated with the transaction ID, for events emitted during the transaction processing stages,
+* the constant `EVENT_TOPIC_CCM_EXECUTION` concatenated with the cross-chain message ID, for events emitted during the cross-chain message processing stages.
 
 An event emitted during transaction processing cannot have any of these default values in the `topics` array.
 


### PR DESCRIPTION
Add new tags for the default topic emitted during transaction execution and CCM execution. This tag can be used to easily identify whether the default topic is a transaction or a CCM ID.