### PR TITLE
Emit persistent event in `verifyPartnerChainOutboxRoot`

### DIFF
--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -173,6 +173,7 @@ In this section, we specify the substores that are part of the Interoperability 
 | `EVENT_NAME_TERMINATED_OUTBOX_CREATED` | string | "terminatedOutboxCreated"| Name of the terminated outbox created event. |
 | `EVENT_NAME_INVALID_SMT_VERIFICATION` | string | "invalidSMTVerification"| Name of the invalid sparse Merkle tree verification event. |
 | `EVENT_NAME_INVALID_RMT_VERIFICATION` | string | "invalidRMTVerification"| Name of the invalid regular Merkle tree verification event. |
+| `EVENT_NAME_INVALID_OUTBOX_ROOT_VERIFICATION` | string | "invalidOutboxRootVerification"| Name of the invalid outbox root verification event. |
 | **CCM Processed Event Results** | | | |
 | `CCM_PROCESSED_RESULT_APPLIED` | uint32 | 0 | Value of `result` of CCM Processed Event if CCM is applied. |
 | `CCM_PROCESSED_RESULT_FORWARDED` | uint32 | 1 | Value of `result` of CCM Processed Event if CCM is forwarded. |

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -1318,6 +1318,7 @@ invalidOutboxRootVerificationSchema = {
         }
     }
 }
+```
 
 ### Protocol Logic for Other Modules
 

--- a/proposals/lip-0045.md
+++ b/proposals/lip-0045.md
@@ -7,7 +7,7 @@ Discussions-To: https://research.lisk.com/t/introduce-interoperability-module/29
 Status: Draft
 Type: Standards Track
 Created: 2021-05-21
-Updated: 2023-09-13
+Updated: 2023-10-23
 Requires: 0043, 0049, 0053, 0054
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -322,11 +322,23 @@ def verifyPartnerChainOutboxRoot(ccu: CCU) -> None:
 
         certificate = decode(certificateSchema, ccu.params.certificate)
         if smtVerifyInclusionProof([outboxKey], proof, certificate.stateRoot) == False:
+            emitPersistentEvent(
+                module = MODULE_NAME_INTEROPERABILITY,
+                name = EVENT_NAME_INVALID_SMT_VERIFICATION,
+                data = {},
+                topic = []
+            )
             raise Exception("Invalid inclusion proof for inbox update.")
 
     # Verification for empty certificates.
     else:
         if newInboxRoot != channel(partnerchainID).partnerChainOutboxRoot:
+            emitPersistentEvent(
+                module = MODULE_NAME_INTEROPERABILITY,
+                name = EVENT_NAME_INVALID_OUTBOX_ROOT,
+                data = {"inboxRoot": newInboxRoot, "partnerChainOutboxRoot": channel(partnerchainID).partnerChainOutboxRoot},
+                topic = [ccu.params.sendingChainID]
+            )
             raise Exception("Inbox root does not match partner chain outbox root.")
 ```
 

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -335,7 +335,7 @@ def verifyPartnerChainOutboxRoot(ccu: CCU) -> None:
         if newInboxRoot != channel(partnerchainID).partnerChainOutboxRoot:
             emitPersistentEvent(
                 module = MODULE_NAME_INTEROPERABILITY,
-                name = EVENT_NAME_INVALID_OUTBOX_ROOT,
+                name = EVENT_NAME_INVALID_OUTBOX_ROOT_VERIFICATION,
                 data = {"inboxRoot": newInboxRoot, "partnerChainOutboxRoot": channel(partnerchainID).partnerChainOutboxRoot},
                 topic = [ccu.params.sendingChainID]
             )
@@ -748,7 +748,7 @@ def execute(trs: Transaction) -> None:
         # If the account already exists, nothing is done.
         relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
         messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
-        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)    
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
 
     try:
         beforeCrossChainMessagesExecution(ccu)

--- a/proposals/lip-0053.md
+++ b/proposals/lip-0053.md
@@ -449,21 +449,6 @@ Here, we make use of the [`emitCCMEvent` function][lip-0045#emitccmevent] define
 
 ```python
 def beforeCrossChainMessagesExecution(ccu: CCU) -> None:
-    # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
-    verifyCertificateSignature(ccu)
-
-    if ccu.params.inboxUpdate is not empty:
-        # This check is expensive. Therefore, it is done in the execute step instead of the verify
-        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
-        # costly CCU verifications without paying fees.
-        verifyPartnerChainOutboxRoot(ccu)
-        # Initialize the relayer account for the message fee token.
-        # This is necessary to ensure that the relayer can receive the CCM fees
-        # If the account already exists, nothing is done.
-        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
-        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
-        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
-
     # Process cross-chain messages in inbox update.
     crossChainMessages = ccu.params.inboxUpdate.crossChainMessages
 
@@ -668,6 +653,21 @@ def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
 
+    # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
+    verifyCertificateSignature(ccu)
+
+    if ccu.params.inboxUpdate is not empty:
+        # This check is expensive. Therefore, it is done in the execute step instead of the verify
+        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+        # costly CCU verifications without paying fees.
+        verifyPartnerChainOutboxRoot(ccu)
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)
+
     try:
         beforeCrossChainMessagesExecution(ccu)
     except:
@@ -734,6 +734,21 @@ _Figure 2: A schematic of the steps of a sidechain CCU execution. Some details a
 def execute(trs: Transaction) -> None:
     ccu = trs
     ccu.params = decode(crossChainUpdateTransactionParams, trs.params)
+
+    # Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
+    verifyCertificateSignature(ccu)
+
+    if ccu.params.inboxUpdate is not empty:
+        # This check is expensive. Therefore, it is done in the execute step instead of the verify
+        # step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+        # costly CCU verifications without paying fees.
+        verifyPartnerChainOutboxRoot(ccu)
+        # Initialize the relayer account for the message fee token.
+        # This is necessary to ensure that the relayer can receive the CCM fees
+        # If the account already exists, nothing is done.
+        relayerAddress = sha256(ccu.senderPublicKey)[:ADDRESS_LENGTH]
+        messageFeeTokenID = getMessageFeeTokenID(ccu.params.sendingChainID)
+        Token.initializeUserAccount(relayerAddress, messageFeeTokenID)    
 
     try:
         beforeCrossChainMessagesExecution(ccu)


### PR DESCRIPTION
- We emit events during `verifyPartnerChainOutboxRoot` in case the verification fails. 
- We extract the verification parts of `beforeCrossChainMessagesExecution` (`verifyCertificateSignature` and `verifyPartnerChainOutboxRoot`) so that result in a failed transaction.